### PR TITLE
docs(cla): fix dead link to removed .cla/cla.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ That signature covers **all** Lorelum repositories. You only sign once, ever.
 
 **Why we require a CLA.** Lorelum is open-core: the core engine is open source (Apache 2.0), but we also ship closed-source SaaS and enterprise tiers. The CLA grants us the right to sublicense your contribution into both open and closed releases. You **keep your copyright** — this is the standard license-style model used by Apache, Google, and HashiCorp.
 
-- Read the full text: [`.cla/cla.md`](./.cla/cla.md)
+- Read the full text: [CLA (Gist)](https://gist.github.com/TatsukiMeng/407a0f07f61da9b71557d7fd0754a0ec)
 - We use [cla-assistant.io](https://cla-assistant.io/) — a free, open-source GitHub App.
 
 A PR cannot be merged until the CLA check passes. This protects the entire Lorelum codebase from IP contamination (a single unsigned contribution would break the licensing foundation).


### PR DESCRIPTION
## Summary

Fix a dead internal link in CONTRIBUTING.md. The CLA section still pointed to `./.cla/cla.md`, but that file was deleted in d776268 (the CLA text now lives in a gist that cla-assistant.io reads). This updates the link to point to the gist.

## Linked issue

None — spotted while setting up the CLA flow.

## Type of change

- [x] 📚 Docs only

## Checklist

- [x] Linked the issue (n/a — link-fix)
- [x] Docs only — no code, no design discussion needed
- [x] No secrets in the diff

## Why this matters

Visitors clicking "Read the full text" in the CLA section were hitting a 404. The gist is the canonical source cla-assistant.io is configured to read.

<!-- This is the first PR on the repo — also a chance to verify the CLA assistant bot fires. -->