### PR TITLE
docs(adr): establish ADR practice and record toolchain decision

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,45 @@
+# ADR NNNN: <title>
+
+- **Date:** YYYY-MM-DD
+- **Status:** Proposed
+
+<!--
+Copy this file to a new NNNN-*.md to start an ADR.
+- NNNN: next free number (zero-padded, 4 digits)
+- Title: short, kebab-case in filename; readable prose in the H1
+- Date: the day the ADR is proposed
+- Status: Proposed → Accepted → (Deprecated | Superseded by NNNN)
+-->
+
+## Context
+
+What is the problem we're solving? What are the constraints, forces, and alternatives in view at the time of the decision? State the situation *as it is now* — future readers need to understand the world the decision was made in, not the world it led to.
+
+Include:
+
+- The requirement or force driving the decision.
+- Relevant constraints (license, performance, compatibility, team, timeline).
+- The alternatives seriously considered (briefly — they'll be revisited in Decision).
+
+## Decision
+
+What we decided. Be specific and unambiguous — a reader should be able to point at code and say "this is here because of this ADR."
+
+Cover:
+
+- The chosen option, stated plainly.
+- **Why this over the alternatives** — the actual reasoning, not a post-hoc justification.
+- Any sub-decisions bundled in (if small) or deferred to child ADRs (if large).
+
+## Consequences
+
+What follows from the decision. Be honest about both sides.
+
+- **Positive:** what we gain.
+- **Negative / accepted risk:** what we give up or expose ourselves to, and how we mitigate.
+- **Follow-ups:** work or decisions this forces later (e.g. "P4 will revisit X when Y happens").
+
+## References (optional)
+
+- Related ADRs: `Supersedes NNNN` / `Superseded by NNNN` / `Related: NNNN`.
+- Links to issues, Discussions, or external write-ups that informed the decision.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,40 @@
+# ADR 0001: Record Architecture Decisions
+
+- **Date:** 2026-07-08
+- **Status:** Accepted
+
+## Context
+
+Lorelum is an open-core project whose product surface — the Practice/pack format, the retrieval model, the CLI — will become public contracts that packs, users, and contributors depend on. The codebase is about to enter active development, and many of the choices that shape it (runtime, language, data format, storage strategy) are hard to reverse after code lands.
+
+Today, decisions are made in team discussion and live in people's heads or scattered across chat. That has two failure modes:
+
+1. **"Why is it like this?"** — a newcomer (human or AI agent) hits a non-obvious design choice and has no record of the alternatives considered or the constraints that drove it.
+2. **Re-litigation** — without a durable record, settled questions get reopened every few months when someone re-discovers the trade-off.
+
+We need a lightweight, in-repo mechanism to capture *why* a decision was made at the time, not just *what* was decided.
+
+## Decision
+
+We will keep Architecture Decision Records (ADRs) in `docs/adr/`, one decision per file, numbered `NNNN-short-title.md`.
+
+We adopt the Nygard format: each ADR has **Status**, **Context**, **Decision**, **Consequences**. See [`0000-template.md`](./0000-template.md) and [`README.md`](./README.md) for the full convention.
+
+ADRs go through the normal PR workflow. They are **immutable history** — to change a decision, write a new ADR that supersedes the old one rather than editing the conclusion in place.
+
+## Consequences
+
+**Positive:**
+
+- Every hard-to-reverse decision has a durable rationale attached. Future contributors (and AI agents reading [`AGENTS.md`](../../AGENTS.md)) can trace *why* instead of guessing.
+- Settled decisions stay settled — reopening a question means writing a new ADR that references the old one, which forces the challenger to engage with the original reasoning.
+- The `Accepted`/`Superseded` lifecycle gives a clear picture of which decisions are still in force.
+
+**Negative:**
+
+- A small ongoing cost: every architecturally significant decision needs a written record. We accept this — it's the point.
+- ADRs can drift from reality if a decision is changed in code but no superseding ADR is written. We mitigate by treating "no ADR for a change" as a review smell.
+
+**Neutral:**
+
+- ADRs are English prose, not machine-readable. They're for humans (and agents), not tooling.

--- a/docs/adr/0002-bun-typescript-toolchain.md
+++ b/docs/adr/0002-bun-typescript-toolchain.md
@@ -1,0 +1,71 @@
+# ADR 0002: Bun + TypeScript toolchain
+
+- **Date:** 2026-07-08
+- **Status:** Accepted
+
+## Context
+
+Lorelum ships a CLI (`lore`), a local MCP server, a Practice/pack parser, and a retrieval engine. Before writing code, we needed to pick a runtime, language, and package manager. This is the single most expensive decision to reverse later — once packages, build steps, and contributors depend on a stack, changing it means a full rewrite.
+
+The constraints that shaped the choice:
+
+1. **CLI first.** The primary user-facing surface is a command-line tool. Fast cold start, fast install, and single-binary distribution materially affect user experience.
+2. **MCP is a core surface.** Lorelum's value is delivered to AI agents via an MCP server. The official `@modelcontextprotocol/sdk` is a Node/TypeScript library, so a JS-runtime stack avoids a foreign-function bridge.
+3. **Type safety is non-negotiable for the format layer.** The Practice/pack schema is a public contract. We want runtime validation and static types derived from the same source.
+4. **AI toolchain alignment.** Most AI coding agents and their ecosystems (Cursor, Claude Code, Codex, MCP SDK, embedding SDKs) are TypeScript-first. Working in the same language reduces friction across the board.
+5. **Open-core friendly.** The engine is Apache-2.0; we must be able to inspect the dependency tree for license conflicts.
+
+## Decision
+
+**Runtime & package manager: Bun.**
+**Language: TypeScript** (`strict: true`), run directly by Bun without a separate compile step.
+**Monorepo: Bun workspaces** (`packages/cli`, `engine`, `format`, `mcp`, `shared`).
+
+For the adjacent tooling (chosen at the same time and documented here for completeness):
+
+| Concern | Choice |
+|---|---|
+| Tests | `bun:test` |
+| Lint | `oxlint` |
+| Format | `oxfmt` (beta; see consequences) |
+| Schema validation | `zod` (export JSON Schema for pack authors) |
+| Embedding | thin OpenAI-compatible client (covers Voyage/Jina/Ollama via `baseURL`) |
+| Local vector store (P2) | `bun:sqlite` + in-memory brute-force cosine search |
+| MCP | `@modelcontextprotocol/sdk` |
+
+### Why Bun over Node + pnpm
+
+- **All-in-one binary.** `bun install / run / test / build` live in one executable; contributors install one thing.
+- **Single-binary distribution.** `bun build --compile` produces a standalone CLI binary — users don't need to install Bun to use `lore`.
+- **TypeScript native.** `.ts` runs directly; no `tsc` prerequisite in the dev loop.
+- **Speed.** Install and cold start are dramatically faster than Node, which matters for a CLI users invoke often.
+- **Node compatibility** covers the npm ecosystem, including the MCP SDK.
+
+Node + pnpm remains the **fallback** if Bun incompatibilities block us. Today Bun is mature (stable since 2023) and the MCP SDK runs cleanly under it.
+
+### Why TypeScript over Go / Rust / Python
+
+- Go: weak MCP SDK support, AI toolchain is not Go-native.
+- Rust: best performance, but slow iteration and a thin CLI ecosystem — overkill for a knowledge-retrieval CLI.
+- Python: distribution pain (packaging, version management) and weak static typing.
+
+TypeScript is the common language of the AI tooling ecosystem Lorelum integrates with.
+
+## Consequences
+
+**Positive:**
+
+- One toolchain to learn, one to install. Contributors get `bun install` → `bun test` in seconds.
+- MCP server, CLI, and parser share types end-to-end — no serialization cliff between layers.
+- `bun build --compile` gives us a distributable binary without a separate packaging step.
+
+**Negative / accepted risk:**
+
+- **`oxfmt` is still in beta** (as of mid-2026). It passes 100% of Prettier's JS/TS conformance tests, but stable is not 1.0 yet. Mitigation: **pin the version in CI**; treat formatter upgrades as PR-reviewed changes, not automatic.
+- **Embedding providers lock the index dimension.** Different providers use different vector dimensions (OpenAI 1536, Voyage 1024, Jina 768). Switching the default provider invalidates stored embeddings and forces a full re-embed. Mitigation: P2 standardizes on one default (`text-embedding-3-small`); multi-provider support is a later concern.
+- **Native Node addons** (e.g. `better-sqlite3`) are a Bun compatibility risk. We deliberately avoid them in P2 by using Bun's built-in `bun:sqlite`. If a future phase needs a native vector extension, re-validate Bun compatibility before committing.
+
+**Follow-ups:**
+
+- The vector store choice (brute-force in P2) is intentionally minimal. P4 will revisit once we hit the roadmap's "million Practices < 100ms" target — see the corresponding section in the internal roadmap.
+- Lint/format version pinning and the CI workflow land with the P2 code scaffold.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,55 @@
+# Architecture Decision Records
+
+This directory holds Lorelum's Architecture Decision Records (ADRs) — short documents that capture **why** an architecturally significant choice was made, not just *what* was decided.
+
+## Why ADRs
+
+Code tells you *how* the system works today. ADRs tell you *why* it works that way — the context, the alternatives considered, and the trade-offs accepted. When someone (human or AI agent) asks "why is X like this?", the answer lives here.
+
+## When to write an ADR
+
+Write an ADR for decisions that are:
+
+- **Hard to reverse** — changing it later is expensive (tech stack, data format, public API).
+- **Cross-cutting** — affects multiple packages or modules.
+- **Public contract** — packs, users, or contributors depend on it (Practice format, retrieval model, CLI surface).
+
+Trivial decisions (naming a helper, picking a minor util) don't need ADRs. If in doubt, write one — a short ADR is cheap insurance against re-litigating the same question later.
+
+## Directory layout
+
+```
+docs/adr/
+├── README.md                                  # this file (convention + index)
+├── 0001-record-architecture-decisions.md      # meta-ADR: we use ADRs
+├── 0002-bun-typescript-toolchain.md           # the first real decision
+├── 0003-...                                   # subsequent decisions
+└── 0000-template.md                           # copy this to start a new ADR
+```
+
+- Files are **zero-padded 4-digit numbers** + kebab-case title: `NNNN-short-title.md`.
+- Numbers are **monotonic** — never renumber, never reuse. Superseded ADRs keep their number.
+- One decision per file. If a decision has sub-decisions, link to child ADRs rather than cramming them in.
+
+## ADR lifecycle
+
+Every ADR has a **Status** field at the top:
+
+| Status | Meaning |
+|---|---|
+| `Proposed` | Open for discussion (usually via a PR). Not yet the source of truth. |
+| `Accepted` | The decision is active and in effect. |
+| `Deprecated` | No longer relevant; nothing replaces it directly. |
+| `Superseded by NNNN` | Replaced by a later ADR. The old one stays for history. |
+
+ADRs are **immutable history**. To change a decision, write a new ADR that supersedes the old one — don't edit an Accepted ADR to flip its conclusion. The reasoning at the time matters as much as the outcome.
+
+## How to add an ADR
+
+1. Copy [`0000-template.md`](./0000-template.md).
+2. Pick the next free number.
+3. Fill in Context, Decision, Consequences.
+4. Open a PR — ADRs go through the same review as code. Link any relevant issue/Discussion.
+5. Merge → status becomes `Accepted`.
+
+> ADRs follow the same [Conventional Commits](../../CONTRIBUTING.md#commit-conventions) and [issue-driven workflow](../../CONTRIBUTING.md#development-workflow) as the rest of the repo. Use the `spec` scope: `spec(adr): accept 0003 vector-storage strategy`.


### PR DESCRIPTION
## Summary

Introduce Architecture Decision Records to Lorelum: establish the `docs/adr/` convention, and record the first two decisions — the meta-ADR adopting the practice (0001) and the toolchain choice already landed via PR #3 (0002).

This is a companion to PR #3. PR #3 propagates the stack choice into the contributor-facing files (AGENTS/CONTRIBUTING/.gitignore); this PR captures *why* the choice was made, in a format that scales to future decisions.

## Linked issue

None — same precedent as PR #2 and PR #3 (decision landing, not issue-driven).

## Type of change

- [x] 📚 Docs only

## What's in this PR

| File | Purpose |
|---|---|
| `docs/adr/README.md` | Convention: when to write an ADR, directory layout, lifecycle (Proposed → Accepted → Superseded), how to add one |
| `docs/adr/0000-template.md` | Nygard-format template (Status / Context / Decision / Consequences) to copy for new ADRs |
| `docs/adr/0001-record-architecture-decisions.md` | Meta-ADR: we adopt the ADR practice itself |
| `docs/adr/0002-bun-typescript-toolchain.md` | The first real decision: Bun + TypeScript + oxc + bun:test, with rationale and accepted risks |

### ADR 0002 covers

- Runtime/package manager: **Bun** (over Node + pnpm, which stays as fallback)
- Language: **TypeScript** (`strict`)
- Adjacent tooling chosen at the same time: `bun:test`, `oxlint`, `oxfmt`, `zod` (+ JSON Schema export), OpenAI-compatible embedding client, `bun:sqlite` for P2 vector storage, `@modelcontextprotocol/sdk`
- **Accepted risks called out explicitly:** oxfmt beta status (pin version), embedding dimension lock to provider, native Node addon avoidance via `bun:sqlite`

## How was this tested?

Docs-only. Verified markdown renders, internal links resolve, and the four files are internally consistent (0001 references the template; 0002 cross-links to AGENTS.md; README links to both).

## Checklist

- [x] Linked the issue (n/a — decision landing, PR #2/#3 precedent)
- [x] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed first — n/a, this *documents* decisions already made
- [x] Added/updated tests — n/a, docs
- [x] Lint, type-check, and tests all pass locally — n/a, docs
- [x] Updated relevant documentation — *this PR is the documentation*
- [x] No secrets, credentials, or private info in the diff

## AI assistance

- [x] Parts of this PR were generated or assisted by an AI tool
- [x] I have reviewed every line of the AI-generated code and take full responsibility for it

## Notes for reviewers

- **Scope discipline:** this PR only creates the ADR scaffolding and records the toolchain decision. It deliberately does **not** add ADRs for other decisions (License architecture, CLA model, knowledge-pack format) — those land in their own PRs when they're next revisited, using the template established here.
- **Public vs internal:** ADR 0002 is the *public* version of an internal decision. Internal-only context (e.g. which prior project validated the Bun + MCP SDK combination) is intentionally omitted; the ADR states the compatibility conclusion without the private provenance. The rationale stands on its own.
- **Convention source:** the `docs/adr/` + `NNNN-kebab-title.md` + Nygard format is the dominant convention across open-source projects (popularized by [adr-tools](https://github.com/npryce/adr-tools) and the [ADR GitHub org](https://github.com/architecture-decision-record/architecture-decision-record)). Nothing exotic.
- **Follow-up (not in this PR):** once P2 lands and the Practice format solidifies, expect an ADR for the format schema and another for the retrieval model. Those belong with the code, not here.