### PR TITLE
docs(readme): reposition on AGENTS.md silent-failure; add end-to-end example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,27 +18,35 @@
 
 ## The problem
 
-You've felt this:
+You wrote an `AGENTS.md` (or `CLAUDE.md`, `.cursorrules`). Then this happens:
 
-- Your team wrote a `.cursorrules` / `AGENTS.md` / Skills file. It worked for the first 10 minutes of a session. By message 20, the agent has forgotten the rules from message 1.
-- Every developer's AI assistant outputs **different** architecture, naming, error handling, API layering — even though "the standard" is written down somewhere.
-- Onboarding new AI tools feels like starting from scratch every time: rewrite the conventions, re-explain the stack, re-state the anti-patterns.
+- **Your rules silently stop being followed.** Frontier models comply with only ~68% of a 500-rule ruleset — *every rule you add makes every other rule less likely to be followed.*<sup>[\[1\]](#fn-1)</sup> You don't get a warning; the agent just drifts.
+- **Compaction eats your rules.** A long session triggers context compaction → your early `AGENTS.md` is gone from the window. The community workaround is to re-paste `@AGENTS.md` and dump *all* the rules back in.
+- **You only find out when it's already wrong.** There is no signal that the agent has drifted — until you review the code yourself and spot the violation.
 
-You're not alone. This is the **knowledge layer gap** in AI coding.
+This is the **knowledge layer gap**: your rules exist, but they don't reliably reach the agent *at the moment it needs them*.
 
 ## Why it happens
 
+This is how your `AGENTS.md` actually reaches the agent today:
+
 ```
-                       ┌─────────────────────────────────┐
-                       │  full ruleset dumped at start   │
-                       │  (10k tokens of conventions)    │
-                       └──────────────┬──────────────────┘
-                                      ▼
-   message 1 ── message 5 ── message 10 ── message 20 ── message 30
-   [rules recalled]   [partial]        [attention decay]   [forgotten]
+  ┌────────────────────────────────────────────────────────────┐
+  │  AGENTS.md — dumped into context once, at session start    │
+  └────────────────────────────────────────────────────────────┘
+        │
+        ├─▶ Few rules followed      ~68% compliance at 500 rules
+        │                            (the more you write, the less
+        │                             each one matters)
+        │
+        ├─▶ Compaction discards     long sessions summarize the
+        │   your rules               context window — rules fall out
+        │
+        └─▶ Drift is invisible      no signal, until you review the
+                                     code and find the violation
 ```
 
-The conventional approach ("paste all the rules into context") fights two **physical limits**: attention decay across long sessions, and context-window capacity. Even a 1M-token window doesn't recall early instructions reliably after long sessions. Throwing more context at the problem doesn't fix it.
+The conventional approach ("paste all the rules into context") fights physical limits: attention decay across long sessions, context-window capacity, and the fact that *more rules lower per-rule compliance*.<sup>[\[2\]](#fn-2)</sup> Even a 1M-token window doesn't recall early instructions reliably after compaction. **More rules ≠ more control.** Throwing more context at the problem doesn't fix it.
 
 ## How Lorelum solves it
 
@@ -53,7 +61,7 @@ Lorelum turns team engineering experience into **discrete, retrievable, trigger-
    └─────────────┘            └────────────────────┘             └──────────────┘
 ```
 
-**Need-to-know, not all-at-once.** When the agent starts implementing auth, Lorelum hands it the auth Practice — not the routing, testing, and deployment Practices too.
+**Lorelum doesn't replace your `AGENTS.md` — it keeps it alive.** Every time the agent needs a piece of it, Lorelum re-injects that exact slice. When the agent starts implementing auth, Lorelum hands it the auth Practice — not the routing, testing, and deployment Practices too.
 
 ### What a Practice looks like
 
@@ -76,6 +84,61 @@ applies_when: building an API layer in a React SPA
 ```
 
 A **Knowledge Pack** bundles many Practices + a decision graph (`decisions.yaml`) + templates + anti-patterns, scoped to a stack or team standard.
+
+## An end-to-end example
+
+Same task, same agent — once without Lorelum, once with.
+
+### The setup
+
+A long session. Your `AGENTS.md` says *"layer the API; never call axios from a component."* But that was 40 messages ago, and the context was just compacted. The agent is now asked to build a login page.
+
+### Without Lorelum — the agent drifts
+
+```tsx
+// LoginPage.tsx — what the agent wrote
+function LoginPage() {
+  const [email, setEmail] = useState("");
+  async function handleLogin() {
+    const res = await axios.post("/api/login", { email });  // ❌ axios in component
+    localStorage.setItem("token", res.data.token);           // ❌ token in localStorage
+  }
+}
+```
+
+It called `axios` inside the component and stuffed the token into `localStorage`. Your rules said not to. The agent never knew it broke them.
+
+### With Lorelum — triggered, not dumped
+
+When the agent touches `src/features/auth/`, Lorelum retrieves the one Practice that applies — `react.api.layered-design` — and injects only that slice:
+
+```markdown
+## Anti-patterns to avoid
+- api.direct-axios-in-component   (call axios inside components)
+- api.local-storage-in-api-class  (persist tokens inside API class)
+- api.dto-used-as-ui-model        (reuse DTOs as UI state)
+```
+
+The agent rewrites its own output — *fresh, from the relevant slice, not the whole ruleset*:
+
+```tsx
+// LoginPage.tsx — corrected by the agent after injection
+function LoginPage() {
+  const { login } = useAuthApi();   // ✅ through the layered API client
+  async function handleLogin() {
+    await login({ email });          // ✅ token handled inside the API layer
+  }
+}
+```
+
+### The loop closes
+
+```bash
+lore check src/features/auth/LoginPage.tsx   # confirms no violation
+lore learn "single-flight refresh token in the HTTP client"
+```
+
+That fix is now a Practice your whole team retrieves next time — without anyone re-pasting an `AGENTS.md`.
 
 ## 5-minute tour
 
@@ -102,10 +165,11 @@ Or wire it into your AI tool via MCP — Lorelum ships an MCP server that any MC
 
 ## How it's different
 
-| | `.cursorrules` / `AGENTS.md` | Skills / Slash commands | **Lorelum** |
+| | `AGENTS.md` / `.cursorrules` | Skills / Slash commands | **Lorelum** |
 |---|---|---|---|
 | **Delivery** | Static, all-at-once | Manual trigger | **Retrieved on demand** |
 | **Decays over session** | Yes | No (one-shot) | No (fresh each query) |
+| **Re-injection after compaction** | Manual: re-paste all rules | Manual | ✅ Automatic, task-scoped |
 | **Scales to 100s of rules** | ❌ | Tedious | ✅ built for it |
 | **Captures team decisions** | No | No | ✅ `decisions.yaml` |
 | **Tool-agnostic** | Tool-specific | Tool-specific | ✅ MCP / CLI / Skill |
@@ -174,6 +238,13 @@ Lorelum is **open-core**:
 The boundary: **if it lets a developer run the full workflow offline on a personal laptop, it's open source.** The paid tiers buy managed ops, collaboration, and compliance — never gated features.
 
 See [LICENSE](./LICENSE) for the Apache 2.0 terms applicable to this repository.
+
+## Notes
+
+<ol>
+<li id="fn-1">~68% compliance from <em>IFScale</em> (<a href="https://arxiv.org/abs/2507.11538">Jaroslawicz et al., 2025</a>, NeurIPS 2025): even the best frontier model followed only ~68% of 500 simultaneous keyword-inclusion instructions, with accuracy degrading as instruction density grew. The <a href="https://paddo.dev/blog/your-agents-md-is-a-liability/">"Your AGENTS.md is a Liability"</a> post discusses what this means for large rules files specifically.</li>
+<li id="fn-2">Position-dependent recall from <em>Lost in the Middle</em> (<a href="https://arxiv.org/abs/2307.03172">Liu et al., TACL 2024</a>): models recall information at the start and end of a long context better than in the middle — a U-shaped curve that holds even within the stated context window.</li>
+</ol>
 
 ## Acknowledgements
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,27 +18,34 @@
 
 ## 你遇到过这些问题吗？
 
-如果你用 AI 编码工具开发过项目，下面这些大概率都遇到过：
+你写了 `AGENTS.md`（或 `CLAUDE.md`、`.cursorrules`）。然后这些事就发生了：
 
-- 团队写了 `.cursorrules` / `AGENTS.md` / Skills。会话前 10 分钟规则还记得，聊到第 20 条消息时，第 1 条的规范已经被 AI 忘了。
-- 每个开发者的 AI 输出**都不一样**——架构分层、命名、错误处理、API 设计——明明"团队标准"白纸黑字写在某处。
-- 每换一个 AI 工具就像从零开始：重新交代技术栈、重新讲架构约定、重新说明反模式。
+- **规则被静默忽略。** 前沿模型对 500 条规则的合规率只有约 68%——*你每多写一条规则，其它规则被遵守的概率都在下降。*<sup>[\[1\]](#fn-1)</sup> 没有任何提示，Agent 就这么悄悄偏离了。
+- **压缩（compaction）吞掉了规则。** 长会话触发上下文压缩 → 你会话开头写的 `AGENTS.md` 已经不在窗口里了。社区公认的唯一解法是重新 `@AGENTS.md`，把**全部**规则再灌一遍。
+- **等发现时已经晚了。** Agent 是否已经偏离，你得不到任何信号——直到自己 review 代码时才发现违规。
 
-你不是一个人。这是 AI 编码的**知识层缺位**。
+这是 AI 编码的**知识层缺位**：你的规则存在，却没能在 Agent **需要的那一刻**抵达它。
 
 ## 为什么会这样
 
+你的 `AGENTS.md` 今天是这样抵达 Agent 的：
+
 ```
-                       ┌─────────────────────────────────┐
-                       │   会话开始时一次性灌入全部规范   │
-                       │      （10k tokens 的约定）       │
-                       └──────────────┬──────────────────┘
-                                      ▼
-   第 1 条 ── 第 5 条 ── 第 10 条 ── 第 20 条 ── 第 30 条
-    [记得]      [部分遗忘]            [注意力衰减]      [全忘了]
+  ┌─────────────────────────────────────────────────────────────┐
+  │  AGENTS.md —— 会话开始时一次性灌进上下文                     │
+  └─────────────────────────────────────────────────────────────┘
+        │
+        ├─▶ 规则多数不被遵守      500 条规则下合规率约 68%
+        │                          （写得越多，每条越没用）
+        │
+        ├─▶ 压缩把规则丢掉        长会话触发上下文压缩，
+        │                          规则被挤出窗口
+        │
+        └─▶ 偏离静默发生          没有任何信号，直到你 review
+                                    代码才发现违规
 ```
 
-常见做法（"把规则全量塞进上下文"）对抗的是两个**物理限制**：长会话中的注意力衰减，和上下文窗口容量。即使 1M token 的窗口，长会话后早期指令的召回率也不可靠。靠堆上下文解决不了根本问题。
+常见做法（"把规则全量塞进上下文"）对抗的是物理限制：长会话中的注意力衰减、上下文窗口容量，以及"**规则越多，每条合规率越低**"这个事实。<sup>[\[2\]](#fn-2)</sup> 即便 1M token 的窗口，压缩之后早期指令的召回率也不可靠。**规则越多 ≠ 控制力越强。** 靠堆上下文解决不了根本问题。
 
 ## Lorelum 怎么解决
 
@@ -53,7 +60,7 @@ Lorelum 把团队工程经验切成**离散、可检索、带触发条件的 *Pr
    └─────────────┘
 ```
 
-**按需给，不是一次给全。** 当 AI 开始实现认证模块时，Lorelum 只给它 auth 相关的 Practice，而不是把路由、测试、部署的规范也一起塞进来。
+**Lorelum 不替代你的 `AGENTS.md`，而是让它保持鲜活。** 每次 Agent 需要其中的一块时，Lorelum 都把那一片精准切片重新注入。当 AI 开始实现认证模块时，Lorelum 只给它 auth 相关的 Practice，而不是把路由、测试、部署的规范也一起塞进来。
 
 ### Practice 长什么样
 
@@ -76,6 +83,61 @@ applies_when: 在 React SPA 中构建 API 层
 ```
 
 一个 **Knowledge Pack（知识包）** 把多条 Practice + 决策图谱（`decisions.yaml`）+ 模板 + 反模式打包，绑定到某个技术栈或团队标准。
+
+## 端到端示例
+
+同一个任务、同一个 Agent——一次没有 Lorelum，一次有。
+
+### 场景
+
+一个很长的会话。你的 `AGENTS.md` 写着*"API 要分层；绝不要在组件里直接调 axios"*。但那是 40 条消息之前的事了，上下文刚刚被压缩过。此时 Agent 被要求写一个登录页。
+
+### 没有 Lorelum —— Agent 偏离了
+
+```tsx
+// LoginPage.tsx —— Agent 写出来的
+function LoginPage() {
+  const [email, setEmail] = useState("");
+  async function handleLogin() {
+    const res = await axios.post("/api/login", { email });  // ❌ 组件里直接调 axios
+    localStorage.setItem("token", res.data.token);           // ❌ token 存进 localStorage
+  }
+}
+```
+
+它在组件里直接调了 `axios`，还把 token 塞进了 `localStorage`。你的规则明明禁止这么做。Agent 自己并不知道违规了。
+
+### 有 Lorelum —— 触发式注入，不是全量灌
+
+当 Agent 触碰 `src/features/auth/` 时，Lorelum 只检索出唯一相关的那条 Practice——`react.api.layered-design`——并只注入这一片切片：
+
+```markdown
+## 要避免的反模式
+- api.direct-axios-in-component   （在组件里直接调 axios）
+- api.local-storage-in-api-class  （在 API 类里持久化 token）
+- api.dto-used-as-ui-model        （DTO 直接当 UI 模型用）
+```
+
+Agent 随即重写了自己的输出——*常新的、来自相关切片的，而非整套规则*：
+
+```tsx
+// LoginPage.tsx —— 注入后 Agent 自我修正
+function LoginPage() {
+  const { login } = useAuthApi();   // ✅ 走分层 API client
+  async function handleLogin() {
+    await login({ email });          // ✅ token 在 API 层内部处理
+  }
+}
+```
+
+### 闭环
+
+```bash
+lore check src/features/auth/LoginPage.tsx   # 确认无违规
+lore learn "HTTP client 里的 single-flight refresh token"
+```
+
+这次修复从此成为全团队下次都能检索到的 Practice——不需要任何人重新粘贴 `AGENTS.md`。
 
 ## 5 分钟了解
 
@@ -102,10 +164,11 @@ lore learn "HTTP client 里的 single-flight refresh token"
 
 ## 和现有方案有什么不同
 
-| | `.cursorrules` / `AGENTS.md` | Skills / 斜杠命令 | **Lorelum** |
+| | `AGENTS.md` / `.cursorrules` | Skills / 斜杠命令 | **Lorelum** |
 |---|---|---|---|
 | **供给方式** | 静态、全量灌入 | 手动触发 | **按需检索** |
 | **长会话衰减** | 会 | 不会（一次性） | 不会（每次查询都新鲜） |
+| **压缩后重注入** | 手动：重新粘贴全部规则 | 手动 | ✅ 自动、按任务切片 |
 | **支持上百条规则** | ❌ | 繁琐 | ✅ 为此而生 |
 | **承载团队决策** | 否 | 否 | ✅ `decisions.yaml` |
 | **工具中立** | 绑定单一工具 | 绑定单一工具 | ✅ MCP / CLI / Skill |
@@ -174,6 +237,13 @@ Lorelum 采用 **open-core** 模式：
 边界一句话：**能让开发者离线跑通完整流程的部分，永远开源。** 付费买的是托管运维、团队协作、企业合规，不是被阉割的功能。
 
 本仓库适用 Apache 2.0，全文见 [LICENSE](./LICENSE)。
+
+## 注释
+
+<ol>
+<li id="fn-1">约 68% 的合规率来自 <em>IFScale</em> 基准测试（<a href="https://arxiv.org/abs/2507.11538">Jaroslawicz et al., 2025</a>，NeurIPS 2025）：即便最好的前沿模型，在 500 条同时下发的关键词类指令中也只遵循了约 68%，且准确率随指令密度增加而持续下降。<a href="https://paddo.dev/blog/your-agents-md-is-a-liability/">《Your AGENTS.md is a Liability》</a>一文专门讨论了这对大型规则文件意味着什么。</li>
+<li id="fn-2">召回率与位置相关，见 <em>Lost in the Middle</em>（<a href="https://arxiv.org/abs/2307.03172">Liu et al., TACL 2024</a>）：模型对长上下文开头和结尾的信息召回更好，中间位置明显变差——呈 U 型曲线，且在标称上下文窗口内依然成立。</li>
+</ol>
 
 ## 致谢
 


### PR DESCRIPTION
## Summary

Repositions the README's persuasive center of gravity from **attention decay** (a physiological, unsolvable model limit) to **AGENTS.md silent failure** (a tool-addressable gap), and adds the end-to-end example the README was missing.

The community conversation has moved from `.cursorrules` to `AGENTS.md` / `CLAUDE.md` (2025–2026), but the README was still arguing against the previous generation. This brings it onto the current wave.

## What changed

### Narrative reposition (The problem, Why it happens)
- **First pain point** shifted from "attention decay" → "**AGENTS.md silent failure**": rules silently ignored, compaction discards them, drift is invisible until code review.
- **Comparison anchor** moved from `.cursorrules` to `AGENTS.md` throughout.
- ASCII diagram upgraded from a single-axis "message 1→30 decay" to a **three-mode failure model** (compliance drop / compaction discard / invisible drift).
- Closing line: *More rules ≠ more control.*

### End-to-end example (new section)
- A before/after React auth case in a long-session, post-compaction context: agent drifts (axios-in-component, token in localStorage) → Lorelum injects the one relevant Practice (`react.api.layered-design`) on touch → agent self-corrects → `lore check` + `lore learn` closes the loop.
- Reuses the anti-patterns already in the README — no extra design cost.

### Supporting updates
- **Key line**: "Lorelum doesn't replace your `AGENTS.md` — it keeps it alive."
- **Comparison table**: new row *Re-injection after compaction* (manual full re-paste → automatic, task-scoped).

### Citations upgraded to authoritative sources
| Before | After |
|---|---|
| Single paddo.dev blog post | **IFScale** (arXiv 2507.11538, NeurIPS 2025) — primary source for the ~68% compliance figure |
| — | **Lost in the Middle** (Liu et al., TACL 2024) — position-dependent recall |
| — | paddo.dev demoted to secondary community-discussion reference |

The 68% figure originates from the IFScale paper; the blog was paraphrasing it — this corrects the sourcing.

## Sync
Both `README.md` (English) and `README.zh-CN.md` (Chinese) updated with identical structure throughout.

## Checklist
- [x] Conventional Commits title
- [x] Does not modify LICENSE, package.json license field, or CI publish steps
- [x] Does not run any publish command
- [x] Documentation-only change — no code, no tests, no ADR

## Related discussion
No tracking issue exists yet. Opening this PR to anchor the README repositioning discussion — happy to file a retroactive issue if maintainers prefer the issue-driven flow.