### PR TITLE
docs(format): align contract baseline (AGENTS.md + ADR 0003 + deps)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,16 @@ TypeScript is the language; Bun runs it. These rules apply from day one.
 - **No silent failures.** A function that can fail should signal it explicitly (typed error, Result, or similar) — not return `null` and hope.
 - **Naming:** consistent with the chosen language's prevailing conventions. Whatever they are, apply them uniformly.
 
+### File organization
+
+Keep the tree navigable and each file independently understandable. These are principles, not a line-count budget — judge by whether a file can be understood on its own.
+
+- **One responsibility per file.** A file owns one schema entity, one piece of closely-related logic, or one group of constants. If you are editing a file and the change is unrelated to its existing contents, that work probably belongs in a sibling file.
+- **Group by function into subdirectories.** Don't accumulate files at the `src/` root. A package like `format` separates `schema/`, `validate/`, `frontmatter/`, `fixtures/` so each concern has a home. Cross-cutting helpers live in a `common.ts` within the relevant directory.
+- **`index.ts` is a barrel, nothing more.** It re-exports the directory's public API. Business logic does not live in `index.ts` — put it in a named file and re-export it.
+- **File name matches what it exports.** `practice.ts` exports the Practice schema and `Practice` type; `cycle.ts` exports cycle detection. A reader should predict the file's contents from its name.
+- **Co-locate tests.** `*.test.ts` sits next to the source it covers, mirroring the same split — `schema/practice.test.ts` tests `schema/practice.ts`.
+
 ## Testing
 
 - New code ships with tests. No exceptions for the format/parser and retrieval layers.

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@lorelum/shared": "workspace:*",
+        "gray-matter": "4.0.3",
         "zod": "4.4.3",
       },
     },
@@ -53,6 +54,9 @@
       "name": "@lorelum/shared",
       "version": "0.0.0",
     },
+  },
+  "overrides": {
+    "js-yaml": "3.14.2",
   },
   "packages": {
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
@@ -155,6 +159,8 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
@@ -195,6 +201,8 @@
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
@@ -204,6 +212,8 @@
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -223,6 +233,8 @@
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
+    "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
@@ -239,15 +251,21 @@
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
+    "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
+
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
+    "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -297,6 +315,8 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
@@ -315,7 +335,11 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 

--- a/docs/adr/0003-practice-pack-format.md
+++ b/docs/adr/0003-practice-pack-format.md
@@ -18,7 +18,7 @@ Three layers (full table lives in the internal "定稿：格式规范 v1" doc; s
 
 - **pack.yaml**: `name`, `version` (semver) required; `description`, `author`, `license`, `applies_to`, `depends_on` optional. `depends_on` is reserved-but-ignored (see point 5).
 - **Practice frontmatter**: `id` (dotted, e.g. `react.api.layered-design`), `title`, `stage`, `tech_stack[]`, `applies_when` required; `severity` optional.
-- **Decision Node** (`decisions.yaml`): `id`, `question`, `branches[]` with `when` / `recommend[]` / `reason`.
+- **Decision Node** (`decisions.yaml`): `id`, `question`, `branches[]` with `when` / `recommend[]` / `reason`. Each branch optionally carries `next` (a Decision Node id) to chain to the next decision — `recommend` strictly references Practice ids, `next` strictly references Decision ids. Cycle detection (point 3) runs over the `next` edges.
 - **Anti-patterns** are first-class: `{ id, name, description, severity }`, with a reserved `check` field whose format is **not defined in v1** (see point 6).
 
 `profile` (embedding model config) is deliberately **not** in pack.yaml — pack owns content, profile owns index config, different lifecycles.
@@ -39,7 +39,7 @@ Consequence for dangling references: references consumed at runtime (Decision No
 
 ### 3 & 5. Circular dependencies + pack-to-pack dependencies (decided together, as they are coupled)
 
-- **Decision Node ↔ Decision Node cycles = error.** Detected by DFS topological sort on the explicit `recommend` references. A decision graph you can never finish walking makes `lore decide` recurse forever.
+- **Decision Node ↔ Decision Node cycles = error.** Detected by DFS topological sort on the `branches[].next` edges (each `next` references another Decision id). A decision graph you can never finish walking makes `lore decide` recurse forever.
 - **Pack-to-pack dependencies: not supported in v1.** `depends_on` is retained as a field but ignored; a non-empty value emits a warning ("v1 ignores pack-to-pack deps"). Rationale: YAGNI (one pack exists today), it would force a mini-npm (resolution, semver ranges, id-conflict handling, cycle detection) that inflates the storage engine's complexity, and the reuse need will be clearer at P3+ when more packs exist.
 
 ### 4. error/warning/info boundary
@@ -70,6 +70,7 @@ So `lore check` (v1) is positioned as **retrieve the relevant anti-patterns and 
 - **`lore check` is not an auto-linter in v1.** It surfaces relevant anti-patterns for the AI to judge. Teams expecting "run check, get a fail/pass verdict" will be surprised until the check engine lands later.
 - **The error/warning reframe is non-obvious.** Contributors familiar with tsc/eslint will initially reach for the conventional semantics. This ADR (and the doc it points to) must be the place they read to correct that.
 - **`check` reserved field.** If a future machine-check engine defines `check`'s shape, old packs that never set it are unaffected; packs that *did* set an experimental value would need migration — unlikely, since v1 says the format is undefined.
+- **v1 gap — Practice→Practice body references are not yet validated.** §2.3 classifies "Practice→Practice body reference = error", but the *syntax* of in-body references is not yet defined (no `[[practice:<id>]]` or equivalent). v1 `lore validate` therefore checks only structural references — Decision→Practice (`recommend`), Decision→Decision (`next`), anti-pattern→Practice (structural ownership). In-body reference validation lands once the reference syntax is settled. Packs today carry no in-body references, so this is an accepted gap, not a regression.
 
 **Follow-ups:**
 

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",
     "typescript": "5.7.2"
+  },
+  "overrides": {
+    "js-yaml": "3.14.2"
   }
 }

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@lorelum/shared": "workspace:*",
+    "gray-matter": "4.0.3",
     "zod": "4.4.3"
   }
 }


### PR DESCRIPTION
## What

Establishes the **contract baseline** before the four code PRs that implement `@lorelum/format` (Practice/pack zod schema + validate). This PR carries **no code** — only the spec/ADR/dependency alignment that the code PRs will build against.

This is PR 1 of 5 (modular rollout, reviewed one PR at a time). Full plan tracked in the Feishu implementation-plan doc linked below.

## Changes

### `AGENTS.md` — File organization principles
New `### File organization` subsection under Code style:
- One responsibility per file
- Group by function into subdirectories (`schema/`, `validate/`, …), don't pile up at `src/` root
- `index.ts` is a barrel only — no business logic
- File name matches its primary export
- Co-locate `*.test.ts` next to source

Principles, **no hard line cap** (per maintainer decision).

### `docs/adr/0003` — Decision Node edges + v1 gap
This ADR was Accepted but no code landed yet — per maintainer direction, it's amended in place rather than superseded (still effectively pre-finalization):

- **§1.4**: add optional `branches[].next` (Decision→Decision edge). `recommend` now strictly references Practice ids. Rationale: §3 required Decision-Node cycle detection but §1.4 only defined `recommend` (a Practice-id list); adding `next` gives the cycle detector a dedicated edge field instead of overloading `recommend`.
- **§3**: cycle detection now runs over the `next` edges (DFS topological sort), not `recommend`.
- **Consequences**: recorded v1 gap — Practice→Practice body references (§2.3 = error) are **not** validated in v1 because the in-body reference syntax isn't defined yet. v1 validates structural references only (Decision→Practice via `recommend`, Decision→Decision via `next`, anti-pattern→Practice by ownership).

### Dependencies
- `packages/format/package.json`: add `gray-matter@4.0.3` (frontmatter parser; ADR 0002 toolchain pick).
- Root `package.json`: `overrides: { "js-yaml": "3.14.2" }` — forces gray-matter's transitive `js-yaml@^3.13.1` to the CVE-2025-64718 fix (ADR 0002 mitigation). Verified: only `js-yaml@3.14.2` resolves after install.

## Feishu synced (not in git)
- 《P0 格式规范定稿》doc `B5x8dQ3E2oYmZyxBYJfcAUpXnUb`: §1.4 next row, §3 rewrite, v1 gap callout.
- New implementation-plan doc `BVoQdTeAHobcawxOOVQcl6Tfn2e` (sibling under parent node CNKaw) — the 5-PR tracking table for this rollout.

## Validation
Three gates green:
- `bun run typecheck` — 5 packages, 0 errors
- `bun run lint` — 0 warnings, 0 errors
- `bun test` — 5 pass, 0 fail (existing smoke tests unaffected by dep change)

## Notes for review
- **No linked issue.** This is the contract-baseline PR for the format task; the task came in as a spec, not a tracked issue. Subsequent code PRs will reference this PR as their contract source. If you'd prefer an issue to track, happy to open one retroactively.
- `.zcode/` (editor-local dir) is untracked and **deliberately not ignored here** — ignoring it is a separate repo-hygiene concern out of scope for this PR. Flag if you want it bundled in.

## Up next
PR 2: `feat(format): zod schema 全套（按实体拆）` — fills `packages/format/src/schema/` (pack/practice/decision/anti-pattern/common) + per-entity tests.