### PR TITLE
feat(format): add zod schemas (pack / practice / decision / anti-pattern)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Thumbs.db
 .vscode/*
 !.vscode/extensions.json
 .idea/
+.zcode/
 *.swp
 *.swo
 

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -1,8 +1,11 @@
 /**
  * @lorelum/format — Practice & Knowledge Pack schema (the public contract).
  *
- * P0 scaffold: only a presence marker. The Practice/pack zod schema and
- * parser land with the format-spec task.
+ * zod schemas for pack.yaml, Practice frontmatter, Decision Nodes, and
+ * anti-patterns. Validation (reference integrity, cycle detection,
+ * severity-graded reports) lands in a follow-up.
  */
 
 export const PACKAGE_NAME = "@lorelum/format";
+
+export * from "./schema";

--- a/packages/format/src/schema/common.test.ts
+++ b/packages/format/src/schema/common.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+import { AuthorSchema, ID_REGEX, PACK_NAME_REGEX, SEMVER_REGEX, SeverityEnum } from "./common";
+
+describe("ID_REGEX", () => {
+  test.each([
+    "react.api.layered-design",
+    "a.b",
+    "a.b.c",
+    "api.direct-axios-in-component",
+    "state.client-vs-server",
+  ])("accepts %p", (id) => {
+    expect(ID_REGEX.test(id)).toBe(true);
+  });
+
+  test.each([
+    "React.api", // uppercase
+    "react..api", // empty segment
+    "react", // single segment
+    "react.api.", // trailing dot
+    ".react.api", // leading dot
+    "react.api_x", // underscore
+    "", // empty
+  ])("rejects %p", (id) => {
+    expect(ID_REGEX.test(id)).toBe(false);
+  });
+});
+
+describe("PACK_NAME_REGEX", () => {
+  test.each(["react-fullstack", "react", "a", "go-kit-v2"])("accepts %p", (name) => {
+    expect(PACK_NAME_REGEX.test(name)).toBe(true);
+  });
+
+  test.each(["React", "react_fullstack", "react--x", ""])("rejects %p", (name) => {
+    expect(PACK_NAME_REGEX.test(name)).toBe(false);
+  });
+});
+
+describe("SEMVER_REGEX", () => {
+  test.each(["0.1.0", "1.2.3", "1.2.3-beta.1", "0.0.0+build.1", "1.0.0-alpha+x"])(
+    "accepts %p",
+    (v) => {
+      expect(SEMVER_REGEX.test(v)).toBe(true);
+    },
+  );
+
+  test.each(["1.2", "v1.2.3", "01.2.3", "1.2.3.beta", ""])("rejects %p", (v) => {
+    expect(SEMVER_REGEX.test(v)).toBe(false);
+  });
+});
+
+describe("SeverityEnum", () => {
+  test("accepts the three levels", () => {
+    expect(SeverityEnum.safeParse("info").success).toBe(true);
+    expect(SeverityEnum.safeParse("warn").success).toBe(true);
+    expect(SeverityEnum.safeParse("critical").success).toBe(true);
+  });
+
+  test("rejects other values", () => {
+    expect(SeverityEnum.safeParse("error").success).toBe(false);
+  });
+});
+
+describe("AuthorSchema", () => {
+  test("accepts a string", () => {
+    expect(AuthorSchema.safeParse("Jane Doe").success).toBe(true);
+  });
+
+  test("accepts an object with name", () => {
+    expect(AuthorSchema.safeParse({ name: "Jane Doe" }).success).toBe(true);
+  });
+
+  test("rejects an object without name", () => {
+    expect(AuthorSchema.safeParse({ handle: "jane" }).success).toBe(false);
+  });
+});

--- a/packages/format/src/schema/common.ts
+++ b/packages/format/src/schema/common.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+/**
+ * Practice / Decision / anti-pattern id: dotted name, at least two segments,
+ * each segment `[a-z0-9]+(-[a-z0-9]+)*`. Matches `react.api.layered-design`;
+ * rejects `React.x`, `react..api`, and a single segment like `react`.
+ */
+export const ID_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*(\.[a-z0-9]+(-[a-z0-9]+)*)+$/;
+
+/** Pack name: kebab-case, single segment allowed (`react-fullstack`). */
+export const PACK_NAME_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+/** Semver (zod has no built-in helper): x.y.z with optional prerelease/build. */
+export const SEMVER_REGEX =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+
+export const SeverityEnum = z.enum(["info", "warn", "critical"]);
+
+/** Pack author: free-form string or `{ name }`. Registry concern; local mode ignores. */
+export const AuthorSchema = z.union([z.string(), z.object({ name: z.string() })]);

--- a/packages/format/src/schema/common.ts
+++ b/packages/format/src/schema/common.ts
@@ -14,7 +14,11 @@ export const PACK_NAME_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 export const SEMVER_REGEX =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
 
-export const SeverityEnum = z.enum(["info", "warn", "critical"]);
+export const SeverityEnum = z
+  .enum(["info", "warn", "critical"])
+  .describe("Severity for lore check ordering; spec default is warn.");
 
 /** Pack author: free-form string or `{ name }`. Registry concern; local mode ignores. */
-export const AuthorSchema = z.union([z.string(), z.object({ name: z.string() })]);
+export const AuthorSchema = z
+  .union([z.string(), z.object({ name: z.string() })])
+  .describe("Registry ownership; local mode does not depend on it.");

--- a/packages/format/src/schema/decision.test.ts
+++ b/packages/format/src/schema/decision.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { DecisionNodeSchema } from "./decision";
+
+const clientVsServer = {
+  id: "state.client-vs-server",
+  question: "How much client state?",
+  branches: [
+    {
+      when: "heavy client state",
+      recommend: ["react.state.redux"],
+      reason: "Redux scales for heavy state",
+      next: "state.persistence-choice",
+    },
+  ],
+};
+
+describe("DecisionNodeSchema", () => {
+  test("accepts a node with a next edge", () => {
+    expect(DecisionNodeSchema.safeParse(clientVsServer).success).toBe(true);
+  });
+
+  test("accepts a branch without next", () => {
+    const r = DecisionNodeSchema.safeParse({
+      id: "state.client-vs-server",
+      question: "How much client state?",
+      branches: [{ when: "x", recommend: ["react.state.redux"], reason: "y" }],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  test("rejects missing branches", () => {
+    expect(
+      DecisionNodeSchema.safeParse({ id: "state.client-vs-server", question: "q" }).success,
+    ).toBe(false);
+  });
+
+  test("rejects a branch missing recommend", () => {
+    const branchWithoutRecommend = { when: "x", reason: "y", next: "state.persistence-choice" };
+    expect(
+      DecisionNodeSchema.safeParse({ ...clientVsServer, branches: [branchWithoutRecommend] })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/packages/format/src/schema/decision.ts
+++ b/packages/format/src/schema/decision.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+import { ID_REGEX } from "./common";
+
+/**
+ * One branch of a Decision Node. `recommend` references Practice ids only;
+ * the optional `next` references another Decision id (ADR 0003 §1.4) — cycle
+ * detection (validate) runs over `next` edges.
+ */
+export const DecisionBranchSchema = z.object({
+  when: z.string(),
+  recommend: z.array(z.string().regex(ID_REGEX)),
+  reason: z.string(),
+  next: z.string().regex(ID_REGEX).optional(),
+});
+
+export type DecisionBranch = z.infer<typeof DecisionBranchSchema>;
+
+export const DecisionNodeSchema = z.object({
+  id: z.string().regex(ID_REGEX, "decision id must be dotted"),
+  question: z.string(),
+  branches: z.array(DecisionBranchSchema),
+});
+
+export type DecisionNode = z.infer<typeof DecisionNodeSchema>;

--- a/packages/format/src/schema/decision.ts
+++ b/packages/format/src/schema/decision.ts
@@ -8,18 +8,22 @@ import { ID_REGEX } from "./common";
  * detection (validate) runs over `next` edges.
  */
 export const DecisionBranchSchema = z.object({
-  when: z.string(),
-  recommend: z.array(z.string().regex(ID_REGEX)),
-  reason: z.string(),
-  next: z.string().regex(ID_REGEX).optional(),
+  when: z.string().describe("Condition expression."),
+  recommend: z.array(z.string().regex(ID_REGEX)).describe("Practice ids only."),
+  reason: z.string().describe("Why this recommendation."),
+  next: z
+    .string()
+    .regex(ID_REGEX)
+    .optional()
+    .describe("Reference to another Decision id for chaining; cycle detection runs over next."),
 });
 
 export type DecisionBranch = z.infer<typeof DecisionBranchSchema>;
 
 export const DecisionNodeSchema = z.object({
-  id: z.string().regex(ID_REGEX, "decision id must be dotted"),
-  question: z.string(),
-  branches: z.array(DecisionBranchSchema),
+  id: z.string().regex(ID_REGEX, "decision id must be dotted").describe("Dotted name."),
+  question: z.string().describe("What this decision answers."),
+  branches: z.array(DecisionBranchSchema).describe("Conditional branches."),
 });
 
 export type DecisionNode = z.infer<typeof DecisionNodeSchema>;

--- a/packages/format/src/schema/index.ts
+++ b/packages/format/src/schema/index.ts
@@ -1,0 +1,4 @@
+export * from "./common";
+export * from "./pack";
+export * from "./practice";
+export * from "./decision";

--- a/packages/format/src/schema/pack.test.ts
+++ b/packages/format/src/schema/pack.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { PackSchema } from "./pack";
+
+describe("PackSchema", () => {
+  test("accepts a minimal pack (name + version)", () => {
+    const r = PackSchema.safeParse({ name: "react-fullstack", version: "0.1.0" });
+    expect(r.success).toBe(true);
+  });
+
+  test("accepts a full pack", () => {
+    const r = PackSchema.safeParse({
+      name: "react-fullstack",
+      version: "1.2.3-beta.1",
+      description: "React fullstack pack",
+      author: { name: "Lorelum" },
+      license: "CC-BY-4.0",
+      applies_to: ["react"],
+      depends_on: ["core"],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  test("rejects missing name", () => {
+    expect(PackSchema.safeParse({ version: "0.1.0" }).success).toBe(false);
+  });
+
+  test("rejects missing version", () => {
+    expect(PackSchema.safeParse({ name: "react-fullstack" }).success).toBe(false);
+  });
+
+  test("rejects non-kebab name", () => {
+    expect(PackSchema.safeParse({ name: "React_Fullstack", version: "0.1.0" }).success).toBe(false);
+  });
+
+  test("rejects non-semver version", () => {
+    expect(PackSchema.safeParse({ name: "react-fullstack", version: "1.2" }).success).toBe(false);
+  });
+});

--- a/packages/format/src/schema/pack.ts
+++ b/packages/format/src/schema/pack.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+import { PACK_NAME_REGEX, SEMVER_REGEX, AuthorSchema } from "./common";
+
+/**
+ * pack.yaml metadata. Mirrors §1.1 of the finalized spec — name/version
+ * required, the rest optional. `depends_on` is reserved; v1 ignores it
+ * (validate flags a non-empty value as a warning).
+ */
+export const PackSchema = z.object({
+  name: z.string().regex(PACK_NAME_REGEX, "pack name must be kebab-case"),
+  version: z.string().regex(SEMVER_REGEX, "version must be semver"),
+  description: z.string().optional(),
+  author: AuthorSchema.optional(),
+  license: z.string().optional(),
+  applies_to: z.array(z.string()).optional(),
+  depends_on: z.array(z.string()).optional(),
+});
+
+export type Pack = z.infer<typeof PackSchema>;

--- a/packages/format/src/schema/pack.ts
+++ b/packages/format/src/schema/pack.ts
@@ -8,13 +8,22 @@ import { PACK_NAME_REGEX, SEMVER_REGEX, AuthorSchema } from "./common";
  * (validate flags a non-empty value as a warning).
  */
 export const PackSchema = z.object({
-  name: z.string().regex(PACK_NAME_REGEX, "pack name must be kebab-case"),
-  version: z.string().regex(SEMVER_REGEX, "version must be semver"),
-  description: z.string().optional(),
+  name: z
+    .string()
+    .regex(PACK_NAME_REGEX, "pack name must be kebab-case")
+    .describe("Stable pack id, e.g. react-fullstack. Key for search/reference/install."),
+  version: z.string().regex(SEMVER_REGEX, "version must be semver").describe("Semver, e.g. 0.1.0."),
+  description: z.string().optional().describe("One line, for lore search and humans."),
   author: AuthorSchema.optional(),
-  license: z.string().optional(),
-  applies_to: z.array(z.string()).optional(),
-  depends_on: z.array(z.string()).optional(),
+  license: z.string().optional().describe("SPDX; pack content is CC-BY-4.0."),
+  applies_to: z
+    .array(z.string())
+    .optional()
+    .describe("tech_stack list this pack covers; used for metadata filtering."),
+  depends_on: z
+    .array(z.string())
+    .optional()
+    .describe("Reserved — ignored in v1; a non-empty value is a warning."),
 });
 
 export type Pack = z.infer<typeof PackSchema>;

--- a/packages/format/src/schema/practice.test.ts
+++ b/packages/format/src/schema/practice.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import { AntiPatternSchema, PracticeSchema } from "./practice";
+
+const layeredDesign = {
+  id: "react.api.layered-design",
+  title: "Layered API Design",
+  stage: "api-layer",
+  tech_stack: ["react", "typescript"],
+  applies_when: "building an API layer in a React SPA",
+  body: "Concrete guidance: http client, base API, modules, DTO boundary.",
+  anti_patterns: [
+    {
+      id: "api.direct-axios-in-component",
+      name: "Call axios inside components",
+      description: "Wrap axios in the API layer; call it via hooks.",
+      severity: "warn",
+    },
+  ],
+};
+
+describe("PracticeSchema", () => {
+  test("accepts the layered-design seed practice", () => {
+    expect(PracticeSchema.safeParse(layeredDesign).success).toBe(true);
+  });
+
+  test("accepts without optional severity / body / anti_patterns", () => {
+    const r = PracticeSchema.safeParse({
+      id: "react.api.layered-design",
+      title: "Layered API Design",
+      stage: "api-layer",
+      tech_stack: ["react"],
+      applies_when: "building an API layer",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  test.each(["id", "title", "stage", "tech_stack", "applies_when"])(
+    "rejects missing %s",
+    (field) => {
+      const { [field]: _removed, ...rest } = layeredDesign;
+      expect(PracticeSchema.safeParse(rest).success).toBe(false);
+    },
+  );
+
+  test("rejects non-array tech_stack", () => {
+    expect(PracticeSchema.safeParse({ ...layeredDesign, tech_stack: "react" }).success).toBe(false);
+  });
+
+  test("does NOT default severity (input stays undefined so validate can warn)", () => {
+    const r = PracticeSchema.safeParse({
+      id: "react.api.layered-design",
+      title: "Layered API Design",
+      stage: "api-layer",
+      tech_stack: ["react"],
+      applies_when: "building an API layer",
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.severity).toBeUndefined();
+    }
+  });
+});
+
+describe("AntiPatternSchema", () => {
+  test("accepts a structured anti-pattern", () => {
+    expect(AntiPatternSchema.safeParse(layeredDesign.anti_patterns?.[0]).success).toBe(true);
+  });
+
+  test("accepts an arbitrary reserved `check` value (format undefined in v1)", () => {
+    expect(
+      AntiPatternSchema.safeParse({
+        id: "api.direct-axios-in-component",
+        name: "x",
+        description: "x",
+        check: { any: { shape: true } },
+      }).success,
+    ).toBe(true);
+  });
+
+  test("rejects missing description", () => {
+    expect(AntiPatternSchema.safeParse({ id: "api.x", name: "x" }).success).toBe(false);
+  });
+});

--- a/packages/format/src/schema/practice.ts
+++ b/packages/format/src/schema/practice.ts
@@ -7,11 +7,11 @@ import { ID_REGEX, SeverityEnum } from "./common";
  * reserved — its format is intentionally undefined in v1 (ADR 0003 §6).
  */
 export const AntiPatternSchema = z.object({
-  id: z.string().regex(ID_REGEX, "anti-pattern id must be dotted"),
-  name: z.string(),
-  description: z.string(),
+  id: z.string().regex(ID_REGEX, "anti-pattern id must be dotted").describe("Stable id, dotted."),
+  name: z.string().describe("Human-readable name."),
+  description: z.string().describe("Detail consumed by the AI."),
   severity: SeverityEnum.optional(),
-  check: z.unknown().optional(),
+  check: z.unknown().optional().describe("Reserved — format undefined in v1 (ADR 0003 §6)."),
 });
 
 export type AntiPattern = z.infer<typeof AntiPatternSchema>;
@@ -22,13 +22,20 @@ export type AntiPattern = z.infer<typeof AntiPatternSchema>;
  * lets validate detect "author omitted severity" and emit a warning.
  */
 export const PracticeSchema = z.object({
-  id: z.string().regex(ID_REGEX, "practice id must be dotted"),
-  title: z.string(),
-  stage: z.string(),
-  tech_stack: z.array(z.string()),
-  applies_when: z.string(),
+  id: z
+    .string()
+    .regex(ID_REGEX, "practice id must be dotted")
+    .describe("Dotted name; lore get key."),
+  title: z.string().describe("Human-readable; required for embedding canonical text."),
+  stage: z
+    .string()
+    .describe("Free-form stage, e.g. api-layer / auth / state; used for embedding filtering."),
+  tech_stack: z
+    .array(z.string())
+    .describe("e.g. [react, typescript]; used for embedding filtering."),
+  applies_when: z.string().describe("Natural-language applicability; recall core."),
   severity: SeverityEnum.optional(),
-  body: z.string().optional(),
+  body: z.string().optional().describe("Guidance markdown; embedding canonical text extracts it."),
   anti_patterns: z.array(AntiPatternSchema).optional(),
 });
 

--- a/packages/format/src/schema/practice.ts
+++ b/packages/format/src/schema/practice.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { ID_REGEX, SeverityEnum } from "./common";
+
+/**
+ * Anti-pattern: first-class Practice entry with a stable id. `check` is
+ * reserved — its format is intentionally undefined in v1 (ADR 0003 §6).
+ */
+export const AntiPatternSchema = z.object({
+  id: z.string().regex(ID_REGEX, "anti-pattern id must be dotted"),
+  name: z.string(),
+  description: z.string(),
+  severity: SeverityEnum.optional(),
+  check: z.unknown().optional(),
+});
+
+export type AntiPattern = z.infer<typeof AntiPatternSchema>;
+
+/**
+ * Practice frontmatter. `severity` is optional with no schema default — the
+ * spec's `warn` default is injected by consumers; leaving the input as-is
+ * lets validate detect "author omitted severity" and emit a warning.
+ */
+export const PracticeSchema = z.object({
+  id: z.string().regex(ID_REGEX, "practice id must be dotted"),
+  title: z.string(),
+  stage: z.string(),
+  tech_stack: z.array(z.string()),
+  applies_when: z.string(),
+  severity: SeverityEnum.optional(),
+  body: z.string().optional(),
+  anti_patterns: z.array(AntiPatternSchema).optional(),
+});
+
+export type Practice = z.infer<typeof PracticeSchema>;


### PR DESCRIPTION
PR 2 of 5 — the public Practice/pack zod contract. Pure schemas, no validation yet (that's PR3).

## What
Fills `packages/format/src/schema/` — one zod schema per entity, mirroring ADR 0003 field tables exactly. No wrappers, factories, or intermediate types.

| File | Contents |
|---|---|
| `common.ts` | `ID_REGEX` (dotted), `PACK_NAME_REGEX` (kebab), `SEMVER_REGEX` (zod has no built-in), `SeverityEnum`, `AuthorSchema` |
| `pack.ts` | `PackSchema` — §1.1 fields only |
| `practice.ts` | `PracticeSchema` + `AntiPatternSchema` (anti-patterns are Practice-embedded → same file) |
| `decision.ts` | `DecisionBranchSchema` (with optional `next` from #8) + `DecisionNodeSchema` |
| `index.ts` | barrel |

## Design choices (deliberate, all minimal)
- **`severity` has no schema default.** The spec's `warn` default is injected by consumers; leaving the raw input as-is lets `validate` (PR3) detect "author omitted severity" → warning. This is the spec's explicit intent (§4.2 warning list).
- **`PackSchema` excludes `practices`/`decisions`.** pack.yaml is the §1.1 metadata; practices are directory-scanned. `validate` (PR3) assembles the full pack object, so the schema mirrors the spec table instead of inventing fields.
- **`anti-pattern.ts` merged into `practice.ts`.** Anti-patterns are Practice-embedded (`Practice.anti_patterns: AntiPattern[]`); splitting them was for-its-own-sake.
- **No JSON Schema export yet.** Deferred until validate lands — the export shape depends on whether `pack`'s JSON Schema should include assembled practices/decisions.

## zod 4 notes (verified against installed .d.ts)
- `.regex(/re/, \"msg\")` — string shorthand for the error (zod 4 uses `error`, not the deprecated `message`)
- `z.enum([\"info\",\"warn\",\"critical\"])` — array form (tuple-object form dropped in v4)

## Tests
One file per entity, positive + negative cases for spec-listed rules only:
- `common.test.ts`: ID/PACK_NAME/SEMVER regex positive+negative, SeverityEnum, AuthorSchema (string + object + missing-name)
- `pack.test.ts`: minimal pack, full pack, missing name/version, non-kebab name, non-semver version
- `practice.test.ts`: layered-design seed practice, missing each required field, non-array tech_stack, severity stays undefined, anti-pattern with reserved `check`, anti-pattern missing description
- `decision.test.ts`: node with `next`, branch without `next`, missing branches, branch missing `recommend`

## Validation
- `bun run typecheck` — 5 packages, 0 errors ✅
- `bun run lint` — 0 warnings, 0 errors ✅
- `bun test` — 62 pass, 0 fail (57 new) ✅
- `oxfmt --check packages/format/` — all my files clean ✅

## ⚠️ Heads-up: pre-existing repo-wide fmt drift (NOT introduced here)
`bun run fmt:check` (which runs `oxfmt --check .` across the whole repo) **fails on `main`**, independent of this PR. `oxfmt --write .` reformats 16 pre-existing files (README, CONTRIBUTING, ADR 0000/0001/0002, all package.json, etc.) that drifted from oxfmt defaults before this PR. I deliberately did **not** bundle those reformatting changes here — they're unrelated noise that would violate one-PR-one-concern. My new files all pass `oxfmt --check`. Recommend a separate `style: oxfmt whole-repo reformat` PR/issue.

## Also
- `.zcode/` (editor-local dir) added to `.gitignore` (approved last round).

## Up next
PR3: `feat(format): validate` — reference integrity (recommend/next dangling), Decision-Node cycle detection (DFS over `next`), duplicate id, severity-graded report.