### PR TITLE
feat(format): add validatePack / validatePractice (refs + cycle + graded report)

### DIFF
--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -1,11 +1,12 @@
 /**
- * @lorelum/format — Practice & Knowledge Pack schema (the public contract).
+ * @lorelum/format — Practice & Knowledge Pack schema + validation.
  *
  * zod schemas for pack.yaml, Practice frontmatter, Decision Nodes, and
- * anti-patterns. Validation (reference integrity, cycle detection,
- * severity-graded reports) lands in a follow-up.
+ * anti-patterns; validatePack / validatePractice for the authoring CI tool
+ * (format checks, reference integrity, cycle detection, graded reporting).
  */
 
 export const PACKAGE_NAME = "@lorelum/format";
 
 export * from "./schema";
+export * from "./validate";

--- a/packages/format/src/validate/cycle.test.ts
+++ b/packages/format/src/validate/cycle.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import { detectCycles } from "./cycle";
+
+function graph(entries: [string, string[]][]): Map<string, string[]> {
+  return new Map(entries);
+}
+
+describe("detectCycles", () => {
+  test("empty graph has no cycles", () => {
+    expect(detectCycles(graph([]))).toEqual([]);
+  });
+
+  test("acyclic chain A→B→C→D", () => {
+    expect(
+      detectCycles(
+        graph([
+          ["A", ["B"]],
+          ["B", ["C"]],
+          ["C", ["D"]],
+          ["D", []],
+        ]),
+      ),
+    ).toEqual([]);
+  });
+
+  test("self-loop A→A is a cycle", () => {
+    const cycles = detectCycles(graph([["A", ["A"]]]));
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0]).toEqual(["A", "A"]);
+  });
+
+  test("two-node cycle A→B→A", () => {
+    const cycles = detectCycles(
+      graph([
+        ["A", ["B"]],
+        ["B", ["A"]],
+      ]),
+    );
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0]?.[0]).toBe("A");
+    expect(cycles[0]?.[1]).toBe("B");
+  });
+
+  test("three-node cycle A→B→C→A", () => {
+    const cycles = detectCycles(
+      graph([
+        ["A", ["B"]],
+        ["B", ["C"]],
+        ["C", ["A"]],
+      ]),
+    );
+    expect(cycles).toHaveLength(1);
+    // members are A, B, C in traversal order, closing back to A
+    expect(new Set(cycles[0])).toEqual(new Set(["A", "B", "C", "A"]));
+  });
+
+  test("two independent cycles are both reported", () => {
+    const cycles = detectCycles(
+      graph([
+        ["A", ["B"]],
+        ["B", ["A"]],
+        ["C", ["D"]],
+        ["D", ["C"]],
+      ]),
+    );
+    expect(cycles).toHaveLength(2);
+  });
+
+  test("node with no outgoing edges (leaf) is fine", () => {
+    expect(
+      detectCycles(
+        graph([
+          ["A", ["B"]],
+          ["B", []],
+        ]),
+      ),
+    ).toEqual([]);
+  });
+
+  test("node not present as a key but referenced (dangling edge) is treated as a leaf", () => {
+    // A→B where B has no entry; B is discovered as white leaf, no cycle.
+    expect(detectCycles(graph([["A", ["B"]]]))).toEqual([]);
+  });
+});

--- a/packages/format/src/validate/cycle.ts
+++ b/packages/format/src/validate/cycle.ts
@@ -1,0 +1,63 @@
+/**
+ * Cycle detection over a directed graph — three-colour DFS.
+ *
+ * Lives in its own file because it is a pure graph algorithm with no
+ * dependency on the Practice/Decision schemas; validate.ts builds the edge
+ * map and converts the returned cycles into validation issues.
+ *
+ * Three-colour DFS is chosen over Kahn's algorithm because the moment we
+ * step onto a grey node, the current recursion stack *is* the cycle, so we
+ * get the cycle members for free. Kahn only tells you "cycles exist", not
+ * which nodes are on them.
+ */
+
+// Three-colour DFS. A node absent from `color` is implicitly WHITE (unvisited);
+// only GRAY (on the current recursion stack) and BLACK (fully explored) are set.
+const GRAY = 1;
+const BLACK = 2;
+
+/**
+ * @param edges Adjacency map: node id → ids it points to. Missing keys are
+ *   treated as leaves (no outgoing edges).
+ * @returns One array per detected cycle, each listing the node ids on it
+ *   in traversal order (e.g. ["A","B","C"] means A→B→C→A). Empty when the
+ *   graph is acyclic.
+ */
+export function detectCycles(edges: Map<string, string[]>): string[][] {
+  const color = new Map<string, number>();
+  const path: string[] = [];
+  const cycles: string[][] = [];
+
+  function visit(node: string): void {
+    color.set(node, GRAY);
+    path.push(node);
+
+    const targets = edges.get(node);
+    if (targets) {
+      for (const target of targets) {
+        const targetColor = color.get(target);
+        if (targetColor === GRAY) {
+          // Stepped onto a node already on the current path → cycle.
+          // Slice from where it first appeared on the stack.
+          const start = path.indexOf(target);
+          cycles.push([...path.slice(start), target]);
+        } else if (targetColor === undefined) {
+          visit(target);
+        }
+        // BLACK → fully explored, skip.
+      }
+    }
+
+    path.pop();
+    color.set(node, BLACK);
+  }
+
+  // Start DFS from every node so disconnected components are covered.
+  for (const start of edges.keys()) {
+    if (color.get(start) === undefined) {
+      visit(start);
+    }
+  }
+
+  return cycles;
+}

--- a/packages/format/src/validate/index.ts
+++ b/packages/format/src/validate/index.ts
@@ -1,0 +1,3 @@
+export * from "./report";
+export * from "./cycle";
+export * from "./validate";

--- a/packages/format/src/validate/report.test.ts
+++ b/packages/format/src/validate/report.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildReport, issue } from "./report";
+
+describe("buildReport", () => {
+  test("empty issue list → valid report with empty buckets", () => {
+    const r = buildReport([]);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.warnings).toEqual([]);
+    expect(r.infos).toEqual([]);
+  });
+
+  test("buckets issues by level", () => {
+    const r = buildReport([
+      issue("error", "format", "name", "bad"),
+      issue("warning", "missing-severity", "practices[0].severity", "x"),
+      issue("info", "small-pack", "practices", "y"),
+      issue("error", "dangling-ref", "decisions[0]", "z"),
+    ]);
+    expect(r.valid).toBe(false);
+    expect(r.errors).toHaveLength(2);
+    expect(r.warnings).toHaveLength(1);
+    expect(r.infos).toHaveLength(1);
+  });
+
+  test("warnings and infos do not affect validity", () => {
+    const r = buildReport([
+      issue("warning", "missing-severity", "x", "y"),
+      issue("info", "small-pack", "x", "y"),
+    ]);
+    expect(r.valid).toBe(true);
+  });
+});

--- a/packages/format/src/validate/report.ts
+++ b/packages/format/src/validate/report.ts
@@ -1,0 +1,44 @@
+/**
+ * Validation report shape — consumed by validate.ts and (later) by the CLI
+ * `lore validate` command and MCP server to format output. Pure types plus a
+ * small constructor; no validation logic lives here.
+ */
+
+export type ValidationLevel = "error" | "warning" | "info";
+
+export interface ValidationIssue {
+  /** Severity bucket. */
+  level: ValidationLevel;
+  /** Machine-readable code, e.g. "format" / "dangling-ref" / "cycle". */
+  code: string;
+  /** Dot path to the offending location, e.g. "practices[1].applies_when". */
+  path: string;
+  /** Human-readable explanation. */
+  message: string;
+}
+
+export interface ValidationReport {
+  /** True iff errors is empty — warnings/infos never affect validity. */
+  valid: boolean;
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+  infos: ValidationIssue[];
+}
+
+/** Convenience constructor: pack a level+code+path+message into an issue. */
+export function issue(
+  level: ValidationLevel,
+  code: string,
+  path: string,
+  message: string,
+): ValidationIssue {
+  return { level, code, path, message };
+}
+
+/** Bucket a flat issue list into a report. valid is derived from errors.length. */
+export function buildReport(allIssues: ValidationIssue[]): ValidationReport {
+  const errors = allIssues.filter((i) => i.level === "error");
+  const warnings = allIssues.filter((i) => i.level === "warning");
+  const infos = allIssues.filter((i) => i.level === "info");
+  return { valid: errors.length === 0, errors, warnings, infos };
+}

--- a/packages/format/src/validate/validate.test.ts
+++ b/packages/format/src/validate/validate.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PackInput } from "./validate";
+import { validatePack, validatePractice } from "./validate";
+
+/** A happy-path pack: 3 practices + 1 decision with a valid next edge. */
+function validPack(): PackInput {
+  return {
+    pack: { name: "react-fullstack", version: "0.1.0" },
+    practices: [
+      {
+        id: "react.api.layered-design",
+        title: "Layered API Design",
+        stage: "api-layer",
+        tech_stack: ["react", "typescript"],
+        applies_when: "building an API layer in a React SPA",
+        severity: "warn",
+        body: "Concrete guidance.",
+      },
+      {
+        id: "react.state.redux",
+        title: "Redux for heavy state",
+        stage: "state",
+        tech_stack: ["react"],
+        applies_when: "managing heavy client-side state at scale",
+        severity: "warn",
+        body: "Use redux when state is large.",
+      },
+      {
+        id: "react.auth.guard",
+        title: "Route guard for auth",
+        stage: "auth",
+        tech_stack: ["react"],
+        applies_when: "protecting routes that require authentication",
+        severity: "warn",
+        body: "Wrap protected routes.",
+      },
+    ],
+    decisions: [
+      {
+        id: "state.client-vs-server",
+        question: "How much client state?",
+        branches: [
+          {
+            when: "heavy client state",
+            recommend: ["react.state.redux"],
+            reason: "Redux scales",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function findCode(
+  report: { errors: { code: string }[]; warnings: { code: string }[]; infos: { code: string }[] },
+  level: "errors" | "warnings" | "infos",
+  code: string,
+): boolean {
+  return report[level].some((i) => i.code === code);
+}
+
+describe("validatePack — happy path", () => {
+  test("valid pack returns valid:true with empty buckets", () => {
+    const r = validatePack(validPack());
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.warnings).toEqual([]);
+    expect(r.infos).toEqual([]);
+  });
+});
+
+describe("validatePack — format errors", () => {
+  test("pack missing name", () => {
+    const input = validPack();
+    // @ts-expect-error: intentionally removing a required field
+    delete input.pack.name;
+    const r = validatePack(input);
+    expect(r.valid).toBe(false);
+    expect(findCode(r, "errors", "format")).toBe(true);
+  });
+
+  test("practice with non-dotted id", () => {
+    const input = validPack();
+    input.practices[0]!.id = "notdotted";
+    const r = validatePack(input);
+    expect(findCode(r, "errors", "format")).toBe(true);
+  });
+
+  test("pack with non-semver version", () => {
+    const input = validPack();
+    input.pack.version = "1.2";
+    const r = validatePack(input);
+    expect(findCode(r, "errors", "format")).toBe(true);
+  });
+
+  test("decision branch missing recommend", () => {
+    const input = validPack();
+    // @ts-expect-error: intentionally removing a required field
+    delete input.decisions[0]!.branches[0]!.recommend;
+    const r = validatePack(input);
+    expect(findCode(r, "errors", "format")).toBe(true);
+  });
+
+  test("format errors short-circuit semantic checks (no duplicate-id noise)", () => {
+    const input = validPack();
+    input.pack.version = "not-semver"; // format error
+    // also add a duplicate id that would normally be flagged:
+    input.practices[1]!.id = input.practices[0]!.id;
+    const r = validatePack(input);
+    expect(findCode(r, "errors", "format")).toBe(true);
+    expect(findCode(r, "errors", "duplicate-id")).toBe(false);
+  });
+});
+
+describe("validatePack — reference integrity errors", () => {
+  test("duplicate practice id", () => {
+    const input = validPack();
+    input.practices[1]!.id = input.practices[0]!.id;
+    const r = validatePack(input);
+    expect(findCode(r, "errors", "duplicate-id")).toBe(true);
+  });
+
+  test("branch.recommend dangles (points to no practice)", () => {
+    const input = validPack();
+    input.decisions[0]!.branches[0]!.recommend = ["does.not.exist"];
+    const r = validatePack(input);
+    expect(findCode(r, "errors", "dangling-ref")).toBe(true);
+  });
+
+  test("branch.next dangles (points to no decision)", () => {
+    const input = validPack();
+    input.decisions[0]!.branches[0]!.next = "no.such.decision";
+    const r = validatePack(input);
+    expect(findCode(r, "errors", "dangling-ref")).toBe(true);
+  });
+
+  test("decision cycle via next edges", () => {
+    const input = validPack();
+    // Three decisions in a cycle: choice-a → choice-b → choice-c → choice-a.
+    input.decisions = [
+      {
+        id: "state.choice-a",
+        question: "q",
+        branches: [
+          { when: "w", recommend: ["react.state.redux"], reason: "r", next: "state.choice-b" },
+        ],
+      },
+      {
+        id: "state.choice-b",
+        question: "q",
+        branches: [
+          { when: "w", recommend: ["react.state.redux"], reason: "r", next: "state.choice-c" },
+        ],
+      },
+      {
+        id: "state.choice-c",
+        question: "q",
+        branches: [
+          { when: "w", recommend: ["react.state.redux"], reason: "r", next: "state.choice-a" },
+        ],
+      },
+    ];
+    const r = validatePack(input);
+    expect(findCode(r, "errors", "cycle")).toBe(true);
+  });
+});
+
+describe("validatePack — warnings", () => {
+  test("non-empty depends_on → depends-on-ignored", () => {
+    const input = validPack();
+    input.pack.depends_on = ["core"];
+    const r = validatePack(input);
+    expect(findCode(r, "warnings", "depends-on-ignored")).toBe(true);
+  });
+
+  test("practice without severity → missing-severity", () => {
+    const input = validPack();
+    delete input.practices[0]!.severity;
+    const r = validatePack(input);
+    expect(findCode(r, "warnings", "missing-severity")).toBe(true);
+  });
+
+  test("applies_when shorter than 10 chars → applies-when-too-short", () => {
+    const input = validPack();
+    input.practices[0]!.applies_when = "short";
+    const r = validatePack(input);
+    expect(findCode(r, "warnings", "applies-when-too-short")).toBe(true);
+  });
+
+  test("empty body → empty-guidance", () => {
+    const input = validPack();
+    input.practices[0]!.body = "   ";
+    const r = validatePack(input);
+    expect(findCode(r, "warnings", "empty-guidance")).toBe(true);
+  });
+});
+
+describe("validatePack — infos", () => {
+  test("two practices with identical titles → similar-practice", () => {
+    const input = validPack();
+    input.practices[1]!.title = input.practices[0]!.title;
+    const r = validatePack(input);
+    expect(findCode(r, "infos", "similar-practice")).toBe(true);
+  });
+
+  test("fewer than 3 practices → small-pack", () => {
+    const input = validPack();
+    input.practices = input.practices.slice(0, 1)!;
+    const r = validatePack(input);
+    expect(findCode(r, "infos", "small-pack")).toBe(true);
+  });
+});
+
+describe("validatePractice", () => {
+  test("valid practice returns empty list", () => {
+    const issues = validatePractice(validPack().practices[0]);
+    expect(issues).toEqual([]);
+  });
+
+  test("invalid practice returns format errors", () => {
+    const issues = validatePractice({ id: "bad", title: "x" });
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues.every((i) => i.code === "format")).toBe(true);
+  });
+});

--- a/packages/format/src/validate/validate.ts
+++ b/packages/format/src/validate/validate.ts
@@ -1,0 +1,223 @@
+/**
+ * validatePack / validatePractice — the validation entry points.
+ *
+ * Pipeline: format check (zod safeParse) → reference integrity → cycle
+ * detection → warning/info rules → buildReport. Each stage pushes issues
+ * into a single flat list; buildReport buckets them by level at the end.
+ *
+ * Reference and cycle checks only run when format passes — otherwise the
+ * data is too broken for semantic checks to produce meaningful signals
+ * (e.g. a missing `id` field can't be checked for duplicates).
+ */
+
+import type { DecisionNode, Pack, Practice } from "../schema";
+import { DecisionNodeSchema, PackSchema, PracticeSchema } from "../schema";
+import { detectCycles } from "./cycle";
+import { buildReport, issue, type ValidationIssue, type ValidationReport } from "./report";
+
+/** The three sources validate needs: pack.yaml metadata + scanned practices + decisions.yaml. */
+export interface PackInput {
+  pack: Pack;
+  practices: Practice[];
+  decisions: DecisionNode[];
+}
+
+/** Turn a zod path array (["branches",0,"recommend"]) into a readable dot path. */
+function toDotPath(path: PropertyKey[]): string {
+  if (path.length === 0) return "(root)";
+  let out = String(path[0]);
+  for (let i = 1; i < path.length; i++) {
+    const seg = path[i];
+    if (seg !== undefined) out += typeof seg === "number" ? `[${seg}]` : `.${String(seg)}`;
+  }
+  return out;
+}
+
+/** Convert every zod issue from a failed safeParse into a "format" error issue. */
+function zodIssuesToFormatErrors(
+  result: { success: false; error: { issues: { path: PropertyKey[]; message: string }[] } },
+  basePath: string,
+): ValidationIssue[] {
+  return result.error.issues.map((zi) =>
+    issue(
+      "error",
+      "format",
+      basePath ? `${basePath}.${toDotPath(zi.path)}` : toDotPath(zi.path),
+      zi.message,
+    ),
+  );
+}
+
+/**
+ * Validate a full pack. Returns a report bucketed by error/warning/info.
+ * Pure: no filesystem, no network, no side effects.
+ */
+export function validatePack(input: PackInput): ValidationReport {
+  const issues: ValidationIssue[] = [];
+
+  // Stage 1 — format check.
+  const packParsed = PackSchema.safeParse(input.pack);
+  if (!packParsed.success) {
+    issues.push(...zodIssuesToFormatErrors(packParsed, "pack"));
+  }
+  input.practices.forEach((p, i) => {
+    const r = PracticeSchema.safeParse(p);
+    if (!r.success) issues.push(...zodIssuesToFormatErrors(r, `practices[${i}]`));
+  });
+  input.decisions.forEach((d, i) => {
+    const r = DecisionNodeSchema.safeParse(d);
+    if (!r.success) issues.push(...zodIssuesToFormatErrors(r, `decisions[${i}]`));
+  });
+
+  // If anything failed format, stop here — semantic checks would only noise.
+  const hasFormatErrors = issues.some((i) => i.level === "error");
+  if (hasFormatErrors) {
+    return buildReport(issues);
+  }
+
+  // Stage 2 — reference integrity.
+  const practiceIds = new Set<string>();
+  const decisionIds = new Set<string>();
+  input.practices.forEach((p, i) => {
+    if (practiceIds.has(p.id)) {
+      issues.push(
+        issue("error", "duplicate-id", `practices[${i}].id`, `duplicate practice id "${p.id}"`),
+      );
+    } else {
+      practiceIds.add(p.id);
+    }
+  });
+  input.decisions.forEach((d, i) => {
+    if (decisionIds.has(d.id)) {
+      issues.push(
+        issue("error", "duplicate-id", `decisions[${i}].id`, `duplicate decision id "${d.id}"`),
+      );
+    } else {
+      decisionIds.add(d.id);
+    }
+    d.branches.forEach((b, bi) => {
+      b.recommend.forEach((rid) => {
+        if (!practiceIds.has(rid)) {
+          issues.push(
+            issue(
+              "error",
+              "dangling-ref",
+              `decisions[${i}].branches[${bi}].recommend`,
+              `recommend "${rid}" matches no practice`,
+            ),
+          );
+        }
+      });
+      if (b.next !== undefined && !decisionIds.has(b.next)) {
+        issues.push(
+          issue(
+            "error",
+            "dangling-ref",
+            `decisions[${i}].branches[${bi}].next`,
+            `next "${b.next}" matches no decision`,
+          ),
+        );
+      }
+    });
+  });
+  // TODO(v2): Practice→Practice body references (spec §2.3) are not validated
+  //   until the in-body reference syntax is defined (ADR 0003 v1 gap).
+
+  // Stage 3 — cycle detection over the `next` edges.
+  const edges = new Map<string, string[]>();
+  for (const d of input.decisions) {
+    const nexts = d.branches.map((b) => b.next).filter((n): n is string => n !== undefined);
+    if (nexts.length > 0) edges.set(d.id, nexts);
+  }
+  for (const cycle of detectCycles(edges)) {
+    issues.push(issue("error", "cycle", "decisions", `cycle detected: ${cycle.join(" → ")}`));
+  }
+
+  // Stage 4 — warnings (quality risks).
+  if (input.pack.depends_on !== undefined && input.pack.depends_on.length > 0) {
+    issues.push(
+      issue(
+        "warning",
+        "depends-on-ignored",
+        "pack.depends_on",
+        "v1 ignores pack-to-pack deps; this field will be ignored",
+      ),
+    );
+  }
+  input.practices.forEach((p, i) => {
+    if (p.severity === undefined) {
+      issues.push(
+        issue(
+          "warning",
+          "missing-severity",
+          `practices[${i}].severity`,
+          "severity not set; lore check ordering may degrade",
+        ),
+      );
+    }
+    if (p.applies_when.length < 10) {
+      issues.push(
+        issue(
+          "warning",
+          "applies-when-too-short",
+          `practices[${i}].applies_when`,
+          "applies_when shorter than 10 chars; recall may degrade",
+        ),
+      );
+    }
+    if (p.body === undefined || p.body.trim() === "") {
+      issues.push(
+        issue(
+          "warning",
+          "empty-guidance",
+          `practices[${i}].body`,
+          "guidance body is empty; nothing to inject",
+        ),
+      );
+    }
+  });
+
+  // Stage 5 — infos (advisory).
+  const titles = new Map<string, number>();
+  input.practices.forEach((p, i) => {
+    const prev = titles.get(p.title);
+    if (prev !== undefined) {
+      issues.push(
+        issue(
+          "info",
+          "similar-practice",
+          `practices[${i}].title`,
+          `title identical to practices[${prev}] — possible duplicate`,
+        ),
+      );
+    } else {
+      titles.set(p.title, i);
+    }
+  });
+  if (input.practices.length < 3) {
+    issues.push(
+      issue(
+        "info",
+        "small-pack",
+        "practices",
+        `pack has ${input.practices.length} practice(s); fewer than 3`,
+      ),
+    );
+  }
+
+  return buildReport(issues);
+}
+
+/**
+ * Validate a single Practice object. Runs only the format check (no pack
+ * context, so no reference or cycle checks). Returns the issue list — empty
+ * when valid.
+ */
+export function validatePractice(practice: unknown): ValidationIssue[] {
+  const r = PracticeSchema.safeParse(practice);
+  if (r.success) return [];
+  return r.error.issues.map((zi) => issue("error", "format", toDotPath(zi.path), zi.message));
+}
+
+// Re-export report types so consumers can `import { ValidationReport } from "@lorelum/format"`.
+export type { ValidationIssue, ValidationLevel, ValidationReport } from "./report";


### PR DESCRIPTION
PR 3 of 5 — the authoring-CI validation layer. Builds on the zod schemas from #9. Pure functions, no filesystem/network.

## What
Fills `packages/format/src/validate/` — three files, each with a single responsibility:

| File | Role | Why its own file |
|---|---|---|
| `report.ts` | Types (`ValidationIssue` / `ValidationReport`) + `buildReport` | Pure types consumed by future CLI/MCP too — keep them free of validate logic |
| `cycle.ts` | Three-colour DFS cycle detection | A pure graph algorithm; testing it standalone (8 cases) is far easier than triggering cycles end-to-end |
| `validate.ts` | `validatePack` + `validatePractice` orchestration | The one place issue-collection logic lives |

## The pipeline (in `validatePack`)
```
1. format (zod safeParse)   →  errors[format]
2. if any format error → STOP (semantic checks would only noise)
3. reference integrity      →  errors[duplicate-id / dangling-ref]
4. cycle (detectCycles)     →  errors[cycle]
5. warnings                 →  warnings[depends-on-ignored / missing-severity / applies-when-too-short / empty-guidance]
6. infos                    →  infos[similar-practice / small-pack]
```

## Design decisions worth flagging in review

- **`validatePack({ pack, practices, decisions })` — not `(Pack)`.** `PackSchema` (PR9) is §1.1 metadata only; the spec separates pack.yaml, practice files, and decisions.yaml. validate assembles the three sources rather than inventing fields on the schema.
- **`validatePractice(unknown)` — not `(Practice)`.** It runs its own `safeParse`; the whole point is to tell you whether the input *is* a valid Practice.
- **Format failures short-circuit.** If `id` is the wrong type, checking it for duplicates is meaningless. Broken-format inputs return after stage 1 — semantic and warning/info stages don't run. (Tested: `format errors short-circuit semantic checks`.)
- **No Result/Either wrapper.** validate is an assessment, not a fallible operation — there's no failure branch to encode, so Result would create dead `if (isErr)` paths.
- **severity-omitted is detectable** because PR9 deliberately did *not* give `severity` a schema default. The spec's `warn` default is injected by consumers; the raw input staying `undefined` is exactly what `missing-severity` checks for.
- **zod issues collapse to code `"format"`.** Authors don't care about zod's internal `invalid_type` vs `invalid_format` split — `path` + `message` already locate the problem.

## A discovery worth noting
The plan called for `z.toDotPath(path)` (zod 4's helper). It's declared in the core `.d.ts` but **not exported from the default entry** (`import { z } from "zod"`). A local 5-line `toDotPath` replaces it — same result, no dependency on an internal API.

## v1 gap (carried from ADR 0003)
- **Practice→Practice body references (§2.3 = error) are NOT validated.** The in-body reference syntax isn't defined yet. TODO in `validate.ts`, ADR 0003 records it. Packs carry no body references today, so this is an accepted gap, not a regression.
- **Anti-pattern→Practice** is structural ownership in v1 (anti-patterns live *inside* `Practice.anti_patterns`), so no dangling check is possible or needed.

## Tests (29 new)
- `cycle.test.ts` (8): empty graph, acyclic chain, self-loop, 2-cycle, 3-cycle, two independent cycles, leaf, dangling edge.
- `report.test.ts` (3): empty buckets, bucketing by level, warnings/infos don't affect validity.
- `validate.test.ts` (18): every spec rule positive+negative, happy path, short-circuit, `validatePractice`. Inline `validPack()` fixture factory (replaced by seed fixtures in PR5).

## Validation
- `bun run typecheck` — 5 packages, 0 errors ✅
- `bun run lint` — 0 warnings, 0 errors ✅
- `bun test` — 91 pass, 0 fail (29 new) ✅
- `oxfmt --check packages/format/` — clean ✅

## Up next
PR4: `feat(format): frontmatter wrapper` — thin gray-matter parse function, single-file swap point per ADR 0002.