### PR TITLE
feat(format): add parseFrontmatter thin wrapper over gray-matter

### DIFF
--- a/packages/format/src/frontmatter/index.ts
+++ b/packages/format/src/frontmatter/index.ts
@@ -1,0 +1,1 @@
+export * from "./parse";

--- a/packages/format/src/frontmatter/parse.test.ts
+++ b/packages/format/src/frontmatter/parse.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { PracticeSchema } from "../schema";
+import { parseFrontmatter } from "./parse";
+
+describe("parseFrontmatter", () => {
+  test("parses frontmatter and body", () => {
+    const md = `---
+id: react.api.layered-design
+title: Layered API Design
+tech_stack: [react, typescript]
+---
+
+# Layered API Design
+
+Concrete guidance here.`;
+    const r = parseFrontmatter(md);
+    expect(r.data.id).toBe("react.api.layered-design");
+    expect(r.data.tech_stack).toEqual(["react", "typescript"]);
+    expect(r.content.trim()).toBe("# Layered API Design\n\nConcrete guidance here.");
+  });
+
+  test("markdown without frontmatter → empty data, full content", () => {
+    const md = "# Just a title\n\nNo frontmatter here.";
+    const r = parseFrontmatter(md);
+    expect(r.data).toEqual({});
+    expect(r.content).toBe(md);
+  });
+
+  test("empty frontmatter block → empty data", () => {
+    const md = `---
+---
+
+Body after the empty block.`;
+    const r = parseFrontmatter(md);
+    expect(r.data).toEqual({});
+    expect(r.content.trim()).toBe("Body after the empty block.");
+  });
+
+  test("malformed YAML propagates as a thrown error (not swallowed)", () => {
+    const md = `---
+key: : invalid
+---
+body`;
+    expect(() => parseFrontmatter(md)).toThrow();
+  });
+
+  test("end-to-end: parsed data feeds PracticeSchema.safeParse", () => {
+    const md = `---
+id: react.api.layered-design
+title: Layered API Design
+stage: api-layer
+tech_stack: [react, typescript]
+applies_when: building an API layer in a React SPA
+severity: warn
+---
+
+Guidance body.`;
+    const { data } = parseFrontmatter(md);
+    const r = PracticeSchema.safeParse(data);
+    expect(r.success).toBe(true);
+  });
+});

--- a/packages/format/src/frontmatter/parse.ts
+++ b/packages/format/src/frontmatter/parse.ts
@@ -1,0 +1,27 @@
+import matter from "gray-matter";
+
+/**
+ * Result of parsing a markdown file with YAML frontmatter. Mirrors the two
+ * fields consumers need from gray-matter; `.excerpt`/`.orig`/`.matter` are
+ * intentionally not surfaced (exposing them leaks the parser choice).
+ */
+export interface ParsedFrontmatter {
+  /** Parsed YAML frontmatter. Empty object when the file has no frontmatter. */
+  data: Record<string, unknown>;
+  /** Markdown body after the frontmatter (delimiters stripped). */
+  content: string;
+}
+
+/**
+ * Parse a markdown string with `---` YAML frontmatter.
+ *
+ * Thin wrapper over gray-matter — this is the single swap point if we move
+ * to `front-matter` (same API shape), per ADR 0002.
+ *
+ * Malformed YAML propagates the underlying `YAMLException` — this wrapper
+ * does not catch it. Callers (CLI/MCP) translate it into user-facing output.
+ */
+export function parseFrontmatter(markdown: string): ParsedFrontmatter {
+  const result = matter(markdown);
+  return { data: result.data, content: result.content };
+}

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -3,10 +3,12 @@
  *
  * zod schemas for pack.yaml, Practice frontmatter, Decision Nodes, and
  * anti-patterns; validatePack / validatePractice for the authoring CI tool
- * (format checks, reference integrity, cycle detection, graded reporting).
+ * (format checks, reference integrity, cycle detection, graded reporting);
+ * parseFrontmatter thin wrapper over gray-matter.
  */
 
 export const PACKAGE_NAME = "@lorelum/format";
 
 export * from "./schema";
 export * from "./validate";
+export * from "./frontmatter";


### PR DESCRIPTION
PR 4 of 5 — the thin frontmatter parser. Smallest PR in the rollout; sets up the markdown→schema pipeline that PR5's fixtures will exercise end-to-end.

## What
`packages/format/src/frontmatter/parse.ts` (~20 lines) — a single function `parseFrontmatter(markdown)` wrapping gray-matter. This is the **single swap point** ADR 0002 mandates: if we ever move to `front-matter` (same API shape), only this one file changes.

## Decisions (per maintainer sign-off)
- **Re-throws `YAMLException` — no try/catch.** Parsing IS a fallible operation (unlike validate, which is an assessment), so the error propagates. Callers (CLI/MCP) translate it into user output. Consistent with AGENTS.md's "throw specific errors, let the CLI/MCP boundary translate".
- **Returns `{ data, content }` verbatim — no renamed restructure.** data narrowed from gray-matter's `{[k]: any}` to `Record<string, unknown>` (kill `any` at the boundary; consumers narrow via zod).
- **Default import**: `import matter from "gray-matter"` — it's `export = matter` (CJS), named import would be wrong.

## Not exposed
gray-matter's `.excerpt` / `.orig` / `.matter` — surfacing them leaks the parser choice and isn't needed yet. No `options` param either — only the default `---` delimiter is needed (YAGNI).

## Bug found while writing tests
An **unclosed** `---` block (`---\n\nbody`) is parsed as bare YAML — `data` becomes the body string. Only a **closed** empty block (`---\n---\nbody`) yields `data: {}`. The test fixture originally used the unclosed form and failed; fixed to the closed form. Worth knowing for pack authors: always close your frontmatter.

## Tests (5)
- frontmatter + body parsed correctly
- no frontmatter → empty data, full content
- closed empty block → empty data
- malformed YAML throws (not swallowed)
- **end-to-end**: parsed `.data` feeds `PracticeSchema.safeParse` directly — confirms the .md → parseFrontmatter → PracticeSchema pipeline works (this is what PR5's fixtures will build on).

## Validation
- `bun run typecheck` — 5 packages, 0 errors ✅
- `bun run lint` — 0/0 ✅
- `bun test` — 96 pass, 0 fail (5 new) ✅
- `oxfmt --check packages/format/` — clean ✅

## Up next
PR5 (final): seed fixtures (`layered-design` practice, `react-pack` happy-path) + replace the inline `validPack()` fixture in validate.test.ts with the real ones. Closes the format package's v1 scope.