### PR TITLE
feat(format): add seed fixtures + end-to-end markdown→schema test

### DIFF
--- a/packages/format/src/fixtures/index.test.ts
+++ b/packages/format/src/fixtures/index.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseFrontmatter } from "../frontmatter";
+import { PracticeSchema } from "../schema";
+import { validatePack, validatePractice } from "../validate";
+import { layeredDesignMarkdown, layeredDesignPractice, reactPack } from "./index";
+
+describe("fixtures are self-validating", () => {
+  test("reactPack passes validatePack with no issues", () => {
+    const r = validatePack(reactPack());
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.warnings).toEqual([]);
+    expect(r.infos).toEqual([]);
+  });
+
+  test("layeredDesignPractice passes validatePractice", () => {
+    expect(validatePractice(layeredDesignPractice)).toEqual([]);
+  });
+});
+
+describe("end-to-end: markdown → frontmatter → schema", () => {
+  test("parsed markdown data satisfies PracticeSchema", () => {
+    const { data } = parseFrontmatter(layeredDesignMarkdown);
+    const r = PracticeSchema.safeParse(data);
+    expect(r.success).toBe(true);
+  });
+
+  test("parsed markdown data matches the practice object on shared fields", () => {
+    const { data } = parseFrontmatter(layeredDesignMarkdown);
+    // Anti-patterns ship in a separate structured file in real packs, so the
+    // markdown carries only the frontmatter fields — compare those.
+    expect(data.id).toBe(layeredDesignPractice.id);
+    expect(data.title).toBe(layeredDesignPractice.title);
+    expect(data.stage).toBe(layeredDesignPractice.stage);
+    expect(data.tech_stack).toEqual(layeredDesignPractice.tech_stack);
+    expect(data.applies_when).toBe(layeredDesignPractice.applies_when);
+    expect(data.severity).toBe(layeredDesignPractice.severity);
+  });
+});

--- a/packages/format/src/fixtures/index.ts
+++ b/packages/format/src/fixtures/index.ts
@@ -1,0 +1,2 @@
+export * from "./layered-design";
+export * from "./react-pack";

--- a/packages/format/src/fixtures/layered-design.ts
+++ b/packages/format/src/fixtures/layered-design.ts
@@ -1,0 +1,61 @@
+import type { Practice } from "../schema";
+
+/**
+ * Seed Practice — `react.api.layered-design`, README-aligned.
+ *
+ * Frontmatter mirrors the README sample; `title` and `severity` (omitted in
+ * README) are filled to satisfy PracticeSchema. The three README anti-patterns
+ * are structured into `{ id, name, description, severity }`.
+ */
+export const layeredDesignPractice: Practice = {
+  id: "react.api.layered-design",
+  title: "Layered API Design",
+  stage: "api-layer",
+  tech_stack: ["react", "typescript"],
+  applies_when: "building an API layer in a React SPA",
+  severity: "warn",
+  body: "Concrete guidance: http client, base API, modules, DTO boundary.",
+  anti_patterns: [
+    {
+      id: "api.direct-axios-in-component",
+      name: "Direct axios in component",
+      description:
+        "Call axios inside components. Wrap it in the API layer; components call via hooks.",
+      severity: "warn",
+    },
+    {
+      id: "api.local-storage-in-api-class",
+      name: "Local storage in API class",
+      description: "Persist tokens inside the API class. Keep persistence in a dedicated module.",
+      severity: "warn",
+    },
+    {
+      id: "api.dto-used-as-ui-model",
+      name: "DTO used as UI model",
+      description: "Reuse DTOs as UI state. Map DTOs to UI models at the boundary.",
+      severity: "warn",
+    },
+  ],
+};
+
+/**
+ * The same Practice authored as a markdown file with YAML frontmatter —
+ * what a pack author actually writes. `parseFrontmatter(layeredDesignMarkdown)`
+ * yields `.data` that feeds `PracticeSchema.safeParse` and matches the fields
+ * above. Anti-patterns are NOT in the markdown (they ship in a separate
+ * structured file in real packs); the end-to-end test checks frontmatter
+ * fields only.
+ */
+export const layeredDesignMarkdown = `---
+id: react.api.layered-design
+title: Layered API Design
+stage: api-layer
+tech_stack: [react, typescript]
+applies_when: building an API layer in a React SPA
+severity: warn
+---
+
+# Layered API Design
+
+Concrete guidance: http client, base API, modules, DTO boundary.
+`;

--- a/packages/format/src/fixtures/react-pack.ts
+++ b/packages/format/src/fixtures/react-pack.ts
@@ -1,0 +1,52 @@
+import type { PackInput } from "../validate";
+
+import { layeredDesignPractice } from "./layered-design";
+
+/**
+ * Seed pack — a complete valid PackInput for happy-path testing.
+ *
+ * Factory function (not a constant): tests mutate the returned object, so
+ * each call must produce a fresh copy. Three practices (≥3 to avoid the
+ * small-pack info) + one decision whose branch recommends an existing
+ * practice. Practice[0] is the layered-design seed; [1]/[2] are minimal
+ * valid siblings with distinct ids and titles (the duplicate-id and
+ * similar-practice tests mutate them to collide).
+ */
+export function reactPack(): PackInput {
+  return {
+    pack: { name: "react-fullstack", version: "0.1.0" },
+    practices: [
+      {
+        ...layeredDesignPractice,
+        anti_patterns: layeredDesignPractice.anti_patterns?.map((a) => ({ ...a })),
+      },
+      {
+        id: "react.state.redux",
+        title: "Redux for heavy state",
+        stage: "state",
+        tech_stack: ["react"],
+        applies_when: "managing heavy client-side state at scale",
+        severity: "warn",
+        body: "Use redux when state is large.",
+      },
+      {
+        id: "react.auth.guard",
+        title: "Route guard for auth",
+        stage: "auth",
+        tech_stack: ["react"],
+        applies_when: "protecting routes that require authentication",
+        severity: "warn",
+        body: "Wrap protected routes.",
+      },
+    ],
+    decisions: [
+      {
+        id: "state.client-vs-server",
+        question: "How much client state?",
+        branches: [
+          { when: "heavy client state", recommend: ["react.state.redux"], reason: "Redux scales" },
+        ],
+      },
+    ],
+  };
+}

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -4,7 +4,7 @@
  * zod schemas for pack.yaml, Practice frontmatter, Decision Nodes, and
  * anti-patterns; validatePack / validatePractice for the authoring CI tool
  * (format checks, reference integrity, cycle detection, graded reporting);
- * parseFrontmatter thin wrapper over gray-matter.
+ * parseFrontmatter thin wrapper over gray-matter; seed fixtures.
  */
 
 export const PACKAGE_NAME = "@lorelum/format";
@@ -12,3 +12,4 @@ export const PACKAGE_NAME = "@lorelum/format";
 export * from "./schema";
 export * from "./validate";
 export * from "./frontmatter";
+export * from "./fixtures";

--- a/packages/format/src/validate/validate.test.ts
+++ b/packages/format/src/validate/validate.test.ts
@@ -1,56 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import type { PackInput } from "./validate";
+import { reactPack } from "../fixtures";
 import { validatePack, validatePractice } from "./validate";
-
-/** A happy-path pack: 3 practices + 1 decision with a valid next edge. */
-function validPack(): PackInput {
-  return {
-    pack: { name: "react-fullstack", version: "0.1.0" },
-    practices: [
-      {
-        id: "react.api.layered-design",
-        title: "Layered API Design",
-        stage: "api-layer",
-        tech_stack: ["react", "typescript"],
-        applies_when: "building an API layer in a React SPA",
-        severity: "warn",
-        body: "Concrete guidance.",
-      },
-      {
-        id: "react.state.redux",
-        title: "Redux for heavy state",
-        stage: "state",
-        tech_stack: ["react"],
-        applies_when: "managing heavy client-side state at scale",
-        severity: "warn",
-        body: "Use redux when state is large.",
-      },
-      {
-        id: "react.auth.guard",
-        title: "Route guard for auth",
-        stage: "auth",
-        tech_stack: ["react"],
-        applies_when: "protecting routes that require authentication",
-        severity: "warn",
-        body: "Wrap protected routes.",
-      },
-    ],
-    decisions: [
-      {
-        id: "state.client-vs-server",
-        question: "How much client state?",
-        branches: [
-          {
-            when: "heavy client state",
-            recommend: ["react.state.redux"],
-            reason: "Redux scales",
-          },
-        ],
-      },
-    ],
-  };
-}
 
 function findCode(
   report: { errors: { code: string }[]; warnings: { code: string }[]; infos: { code: string }[] },
@@ -62,7 +13,7 @@ function findCode(
 
 describe("validatePack — happy path", () => {
   test("valid pack returns valid:true with empty buckets", () => {
-    const r = validatePack(validPack());
+    const r = validatePack(reactPack());
     expect(r.valid).toBe(true);
     expect(r.errors).toEqual([]);
     expect(r.warnings).toEqual([]);
@@ -72,7 +23,7 @@ describe("validatePack — happy path", () => {
 
 describe("validatePack — format errors", () => {
   test("pack missing name", () => {
-    const input = validPack();
+    const input = reactPack();
     // @ts-expect-error: intentionally removing a required field
     delete input.pack.name;
     const r = validatePack(input);
@@ -81,21 +32,21 @@ describe("validatePack — format errors", () => {
   });
 
   test("practice with non-dotted id", () => {
-    const input = validPack();
+    const input = reactPack();
     input.practices[0]!.id = "notdotted";
     const r = validatePack(input);
     expect(findCode(r, "errors", "format")).toBe(true);
   });
 
   test("pack with non-semver version", () => {
-    const input = validPack();
+    const input = reactPack();
     input.pack.version = "1.2";
     const r = validatePack(input);
     expect(findCode(r, "errors", "format")).toBe(true);
   });
 
   test("decision branch missing recommend", () => {
-    const input = validPack();
+    const input = reactPack();
     // @ts-expect-error: intentionally removing a required field
     delete input.decisions[0]!.branches[0]!.recommend;
     const r = validatePack(input);
@@ -103,7 +54,7 @@ describe("validatePack — format errors", () => {
   });
 
   test("format errors short-circuit semantic checks (no duplicate-id noise)", () => {
-    const input = validPack();
+    const input = reactPack();
     input.pack.version = "not-semver"; // format error
     // also add a duplicate id that would normally be flagged:
     input.practices[1]!.id = input.practices[0]!.id;
@@ -115,28 +66,28 @@ describe("validatePack — format errors", () => {
 
 describe("validatePack — reference integrity errors", () => {
   test("duplicate practice id", () => {
-    const input = validPack();
+    const input = reactPack();
     input.practices[1]!.id = input.practices[0]!.id;
     const r = validatePack(input);
     expect(findCode(r, "errors", "duplicate-id")).toBe(true);
   });
 
   test("branch.recommend dangles (points to no practice)", () => {
-    const input = validPack();
+    const input = reactPack();
     input.decisions[0]!.branches[0]!.recommend = ["does.not.exist"];
     const r = validatePack(input);
     expect(findCode(r, "errors", "dangling-ref")).toBe(true);
   });
 
   test("branch.next dangles (points to no decision)", () => {
-    const input = validPack();
+    const input = reactPack();
     input.decisions[0]!.branches[0]!.next = "no.such.decision";
     const r = validatePack(input);
     expect(findCode(r, "errors", "dangling-ref")).toBe(true);
   });
 
   test("decision cycle via next edges", () => {
-    const input = validPack();
+    const input = reactPack();
     // Three decisions in a cycle: choice-a → choice-b → choice-c → choice-a.
     input.decisions = [
       {
@@ -168,28 +119,28 @@ describe("validatePack — reference integrity errors", () => {
 
 describe("validatePack — warnings", () => {
   test("non-empty depends_on → depends-on-ignored", () => {
-    const input = validPack();
+    const input = reactPack();
     input.pack.depends_on = ["core"];
     const r = validatePack(input);
     expect(findCode(r, "warnings", "depends-on-ignored")).toBe(true);
   });
 
   test("practice without severity → missing-severity", () => {
-    const input = validPack();
+    const input = reactPack();
     delete input.practices[0]!.severity;
     const r = validatePack(input);
     expect(findCode(r, "warnings", "missing-severity")).toBe(true);
   });
 
   test("applies_when shorter than 10 chars → applies-when-too-short", () => {
-    const input = validPack();
+    const input = reactPack();
     input.practices[0]!.applies_when = "short";
     const r = validatePack(input);
     expect(findCode(r, "warnings", "applies-when-too-short")).toBe(true);
   });
 
   test("empty body → empty-guidance", () => {
-    const input = validPack();
+    const input = reactPack();
     input.practices[0]!.body = "   ";
     const r = validatePack(input);
     expect(findCode(r, "warnings", "empty-guidance")).toBe(true);
@@ -198,14 +149,14 @@ describe("validatePack — warnings", () => {
 
 describe("validatePack — infos", () => {
   test("two practices with identical titles → similar-practice", () => {
-    const input = validPack();
+    const input = reactPack();
     input.practices[1]!.title = input.practices[0]!.title;
     const r = validatePack(input);
     expect(findCode(r, "infos", "similar-practice")).toBe(true);
   });
 
   test("fewer than 3 practices → small-pack", () => {
-    const input = validPack();
+    const input = reactPack();
     input.practices = input.practices.slice(0, 1)!;
     const r = validatePack(input);
     expect(findCode(r, "infos", "small-pack")).toBe(true);
@@ -214,7 +165,7 @@ describe("validatePack — infos", () => {
 
 describe("validatePractice", () => {
   test("valid practice returns empty list", () => {
-    const issues = validatePractice(validPack().practices[0]);
+    const issues = validatePractice(reactPack().practices[0]);
     expect(issues).toEqual([]);
   });
 


### PR DESCRIPTION
PR 5 of 5 — **final PR**. Closes the \`@lorelum/format\` v1 scope.

## What
Two happy-path fixtures + an end-to-end test proving the full pipeline works: `.md` → \`parseFrontmatter\` → \`PracticeSchema.safeParse\` → \`validate\`.

## Files

### \`fixtures/layered-design.ts\` — README-aligned seed Practice
- \`layeredDesignPractice\`: a complete valid \`Practice\`. Frontmatter mirrors the README sample; \`title\`/\`severity\` (omitted in README) filled to satisfy the schema. The 3 README anti-pattern bullets are structured into \`{ id, name, description, severity }\`.
- \`layeredDesignMarkdown\`: the same Practice as a markdown file with YAML frontmatter — what a pack author actually writes. Anti-patterns are deliberately NOT in the markdown (in real packs they ship in a separate structured file).
- **Two forms, same source** so the e2e test can assert \`parse(markdown).data == practice fields\`.

### \`fixtures/react-pack.ts\` — replaces PR10's inline \`validPack()\`
- \`reactPack()\` **factory function** (not a constant — tests mutate the return value, a shared constant would leak state across tests).
- 3 practices (≥3 to avoid the small-pack info) + 1 decision. \`practice[0]\` is the layered-design seed; \`[1]\`/\`[2]\` are minimal siblings with distinct ids/titles (the duplicate-id and similar-practice tests mutate them to collide).
- Deep-copies the layered-design anti-patterns so callers can mutate safely.

### \`fixtures/index.test.ts\` — self-validation + e2e
- \`validatePack(reactPack())\` → \`valid: true\`, empty buckets (guards against fixture drift breaking downstream tests).
- \`validatePractice(layeredDesignPractice)\` → \`[]\`.
- **End-to-end**: \`parseFrontmatter(layeredDesignMarkdown)\` → \`PracticeSchema.safeParse(data)\` succeeds, and parsed fields match the practice object.

### \`validate.test.ts\` — swap data source
- Inline \`validPack()\` deleted; \`import { reactPack } from "../fixtures"\` instead.
- **All 18 tests preserved unchanged** — same 11 mutation sites, same assertions. Only the data source moved. Net −68 lines.

## Validation
- \`bun run typecheck\` — 5 packages, 0 errors ✅
- \`bun run lint\` — 0/0 ✅
- \`bun test\` — 100 pass, 0 fail (+4 fixtures tests) ✅
- \`oxfmt --check packages/format/\` — clean ✅

## v1 scope complete 🎉

After this merges, \`@lorelum/format\` delivers:
| Module | PR | Exports |
|---|---|---|
| schema | #9 | \`PackSchema\`, \`PracticeSchema\`, \`DecisionNodeSchema\`, \`AntiPatternSchema\` + inferred types |
| validate | #10 | \`validatePack\`, \`validatePractice\`, \`ValidationReport\` |
| frontmatter | #11 | \`parseFrontmatter\` (gray-matter thin wrapper) |
| fixtures | #12 (this) | \`layeredDesignPractice\`, \`layeredDesignMarkdown\`, \`reactPack\` |

- Every spec §4.2 rule tested (except the documented v1 gap: Practice→Practice body references, awaiting reference-syntax definition).
- No \`cli\` dependency; validate is a pure function.
- Docs synced: \`AGENTS.md\` (File organization), ADR 0003 (\`branches[].next\` + v1 gap), Feishu finalized spec + implementation-plan tracker.

The package is ready for the downstream tasks (engine \`CanonicalTextBuilder\`, CLI \`lore validate/query/get/decide/check\`) to consume.