### PR TITLE
feat(engine): implement LocalStore lifecycle

### DIFF
--- a/docs/adr/0004-local-practice-store.md
+++ b/docs/adr/0004-local-practice-store.md
@@ -1,0 +1,147 @@
+# ADR 0004: Local Practice store
+
+- **Date:** 2026-07-26
+- **Status:** Proposed
+- **Related:** ADR 0003 (Practice & Pack format and validation semantics)
+
+## Context
+
+`@lorelum/engine` needs a persistent LocalStore for installed knowledge Packs and
+their Practices. The store is the boundary between the public Pack format and
+local retrieval: it must admit only valid Pack content, retain enough durable
+information to recover from a damaged derived index, merge identical Practices
+from multiple Packs deterministically, and remove a Pack without deleting
+content still supplied by another Pack.
+
+This is an architectural decision rather than an implementation detail. The
+storage root, persisted recovery sources, identity and conflict rules, and
+revision consistency become user-visible behavior once Packs are installed.
+
+The finalized LocalStore design establishes the following constraints:
+
+- `@lorelum/engine` consumes `Practice`, `Pack`, and `validatePack` from
+  `@lorelum/format`. A Pack with validation errors is not installed; warnings
+  and informational findings retain the lifecycle semantics from ADR 0003.
+- v1 is a user-local store. It must not discover or use a project-local
+  `.lorelum/` directory.
+- LocalStore uses Bun's built-in `bun:sqlite` driver. It adds no runtime npm
+  dependency.
+- A SQLite database alone is not an adequate recovery source.
+- A Practice's stable `id`, not its title, is its cross-Pack identity.
+
+The alternatives considered were a project-local `.lorelum/` root, a JSON-only
+query index, SQLite as the only persisted source, and install-order precedence
+for conflicting Practices.
+
+## Decision
+
+### Local root and durable state
+
+v1 stores LocalStore data under `~/.lorelum/`. The engine receives a
+`StorageRoot` abstraction so tests, CI, and future storage modes can provide an
+alternate root without changing LocalStore behavior. Project-local storage is
+out of scope for v1.
+
+The durable recovery sources are:
+
+- `installed-packs.json`, the active-Pack manifest with a monotonically
+  increasing `generation`;
+- immutable unpacked Pack artifacts under
+  `packs/<storage-key>/<artifact-digest>/`; and
+- an operation journal used to recover interrupted mutations.
+
+SQLite is derived state rather than the sole source of truth. It stores the
+active Pack, Practice, source, and revision data owned by LocalStore.
+
+The manifest and artifact layout must be versioned. A damaged or missing
+SQLite database is rebuilt from the active manifest and its referenced local
+artifacts. Historical artifacts that are no longer active are not scanned to
+restore an uninstalled Pack.
+
+### Installation, merge, and removal semantics
+
+Before an install or upgrade is admitted, the engine validates the Pack through
+`validatePack` and persists an immutable artifact for the admitted content.
+Only one active version of a Pack may exist for each `pack.yaml.name`.
+
+For every active Practice:
+
+- `practice.id` is the identity key. `title` is descriptive content and never
+  selects or overrides a Practice.
+- The engine computes a canonical `contentDigest`.
+- The same Practice id with the same canonical `contentDigest` produces one
+  Effective Practice with multiple Practice Sources.
+- The same Practice id with a different `contentDigest` rejects the
+  install/upgrade with `PracticeConflictError`. v1 has no source precedence,
+  partial merge, or automatic conflict resolution.
+
+Uninstall removes the specified Pack's source contribution. An Effective
+Practice remains available while at least one active source remains; it is
+removed only after its final source is removed. LocalStore does not reconstruct
+or merge partially overlapping Practice content: only byte-for-byte equivalent
+canonical content, represented by the same digest, is deduplicated.
+
+### Mutation and recovery
+
+Install, upgrade, and uninstall are coordinated mutations over immutable
+artifacts, the active manifest generation, the operation journal, SQLite
+transactions, and an `effectiveRevision` representing the resulting Effective
+Practice set.
+
+On startup and before serving reads, LocalStore recovers an interrupted
+operation using the journal and reconciles derived SQLite state from the active
+manifest and artifacts when necessary. Reindex rebuilds only from the current
+active manifest and referenced artifacts.
+
+### Scope boundary
+
+This ADR defines LocalStore's persistence, identity, source, revision, and
+recovery contracts. It selects Bun's built-in SQLite driver, but does not
+prescribe SQL table layouts or specify embedding/vector algorithms. A later
+vector-index decision may consume LocalStore's effective Practices and
+`effectiveRevision`, but is not part of this ADR.
+
+## Consequences
+
+**Positive:**
+
+- Local installations are deterministic and recoverable without depending on a
+  derived database.
+- Cross-Pack duplicate content is stored and retrieved as one Effective
+  Practice while preserving every contributing source for correct uninstall.
+- Conflicting guidance cannot silently change retrieval based on installation
+  order.
+- `effectiveRevision` prevents a query from observing half-applied Pack
+  mutations or a stale vector index.
+
+**Negative / accepted risk:**
+
+- Immutable artifacts duplicate Pack content on disk, and journals plus
+  recovery add operational complexity.
+- v1 gives all projects for one user the same installed-Pack view. Project
+  isolation requires a separate future decision.
+- Pack-to-Pack dependencies remain unsupported in v1, consistent with ADR 0003.
+
+**Compatibility and migration:**
+
+- v1 introduces the first LocalStore layout, so there is no existing persisted
+  layout to migrate.
+- The manifest, artifact metadata, SQLite schema, and journal formats require
+  explicit versioning and forward migration handling before they are persisted.
+- A future project-local store, alternate conflict semantics, or change to the
+  recovery source requires a new ADR rather than an incompatible reinterpretation
+  of this layout.
+
+**Follow-ups:**
+
+- Write the engine implementation plan, including file ownership, public API,
+  typed errors, and the specification's Section 9 acceptance tests.
+- Implement LocalStore in `@lorelum/engine` with filesystem-isolated tests;
+- Link the implementation PR to the required issue or Discussion before code
+  changes are proposed.
+
+## References
+
+- Finalized LocalStore design: https://jcnv104g7m1c.feishu.cn/wiki/UgRGwhGsii1a05kzV9Ics30DnNb
+- ADR 0003: Practice & Pack format and validation semantics.
+- Issue: https://github.com/lorelum/lorelum/issues/15

--- a/docs/adr/0007-local-practice-store.md
+++ b/docs/adr/0007-local-practice-store.md
@@ -1,4 +1,4 @@
-# ADR 0004: Local Practice store
+# ADR 0007: Local Practice store
 
 - **Date:** 2026-07-26
 - **Status:** Proposed

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,7 +24,7 @@ docs/adr/
 ├── 0001-record-architecture-decisions.md      # meta-ADR: we use ADRs
 ├── 0002-bun-typescript-toolchain.md           # the first real decision
 ├── 0003-practice-pack-format.md               # Practice/pack format & validation semantics
-├── 0004-...                                   # subsequent decisions
+├── 0007-local-practice-store.md                # LocalStore persistence decision
 └── 0000-template.md                           # copy this to start a new ADR
 ```
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,8 +1,3 @@
-/**
- * @lorelum/engine — Practice retrieval (embed + metadata + graph).
- *
- * P0 scaffold: only a presence marker. Retrieval, ranking, and the local
- * vector store land with the engine tasks.
- */
-
 export const PACKAGE_NAME = "@lorelum/engine";
+
+export * from "./local-store";

--- a/packages/engine/src/local-store/artifact-store.ts
+++ b/packages/engine/src/local-store/artifact-store.ts
@@ -1,0 +1,114 @@
+import { access, mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+
+import { normalizeSnapshotPath } from "./canonicalize";
+import { InvalidPreparedPackError } from "./errors";
+import type { SnapshotFile, StorageRoot } from "./types";
+
+export interface StagedArtifact {
+  readonly directory: string;
+}
+
+export function artifactPath(
+  root: StorageRoot,
+  storageKey: string,
+  artifactDigest: string,
+): string {
+  return join(root.path, "packs", storageKey, artifactDigest);
+}
+
+export async function stageArtifact(
+  root: StorageRoot,
+  operationId: string,
+  files: readonly SnapshotFile[],
+): Promise<StagedArtifact> {
+  const directory = join(root.path, "staging", operationId);
+  const seen = new Set<string>();
+  await mkdir(directory, { recursive: true });
+
+  try {
+    const writes: Promise<void>[] = [];
+    for (const file of files) {
+      const path = normalizeSnapshotPath(file.relativePath);
+      if (seen.has(path)) {
+        throw new InvalidPreparedPackError(`Duplicate snapshot path "${path}"`);
+      }
+      seen.add(path);
+
+      const destination = safeDescendant(directory, path);
+      writes.push(
+        mkdir(join(destination, ".."), { recursive: true }).then(() =>
+          writeFile(destination, file.bytes),
+        ),
+      );
+    }
+
+    const results = await Promise.allSettled(writes);
+    const failure = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failure !== undefined) throw failure.reason;
+  } catch (error: unknown) {
+    await discardStagedArtifact(root, { directory });
+    throw error;
+  }
+
+  return { directory };
+}
+
+export async function promoteArtifact(
+  root: StorageRoot,
+  staged: StagedArtifact,
+  storageKey: string,
+  artifactDigest: string,
+): Promise<void> {
+  const destination = artifactPath(root, storageKey, artifactDigest);
+  await mkdir(join(destination, ".."), { recursive: true });
+
+  try {
+    await access(destination);
+    await discardStagedArtifact(root, staged);
+  } catch (error: unknown) {
+    if (!isNodeError(error, "ENOENT")) throw error;
+    await rename(staged.directory, destination);
+  }
+}
+
+export async function discardStagedArtifact(
+  root: StorageRoot,
+  staged: StagedArtifact,
+): Promise<void> {
+  const stagingRoot = resolve(root.path, "staging");
+  const target = resolve(staged.directory);
+  if (relative(stagingRoot, target).startsWith("..")) {
+    throw new InvalidPreparedPackError(
+      "Refusing to remove a staging directory outside StorageRoot",
+    );
+  }
+  await rm(target, { recursive: true, force: true });
+}
+
+export async function removeArtifact(
+  root: StorageRoot,
+  storageKey: string,
+  artifactDigest: string,
+): Promise<void> {
+  const packsRoot = resolve(root.path, "packs");
+  const target = resolve(artifactPath(root, storageKey, artifactDigest));
+  if (relative(packsRoot, target).startsWith("..")) {
+    throw new InvalidPreparedPackError("Refusing to remove an artifact outside StorageRoot");
+  }
+  await rm(target, { recursive: true, force: true });
+}
+
+function safeDescendant(root: string, relativePath: string): string {
+  const destination = resolve(root, ...relativePath.split("/"));
+  if (relative(resolve(root), destination).startsWith("..")) {
+    throw new InvalidPreparedPackError(`Unsafe snapshot path "${relativePath}"`);
+  }
+  return destination;
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === code;
+}

--- a/packages/engine/src/local-store/canonicalize.test.ts
+++ b/packages/engine/src/local-store/canonicalize.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { canonicalContent, contentDigest, normalizeSnapshotPath } from "./canonicalize";
+import { InvalidPreparedPackError } from "./errors";
+
+const practice = {
+  id: "react.api.layered-design",
+  title: "Layered API Design",
+  stage: "api-layer",
+  tech_stack: ["react", "typescript"],
+  applies_when: "building an API layer in a React SPA",
+  body: "Use a client\r\nwith clear module boundaries.\r",
+};
+
+describe("LocalStore canonical content", () => {
+  test("normalizes line endings and expands the Practice severity default", () => {
+    expect(canonicalContent(practice)).toBe(
+      JSON.stringify({
+        id: "react.api.layered-design",
+        title: "Layered API Design",
+        stage: "api-layer",
+        tech_stack: ["react", "typescript"],
+        applies_when: "building an API layer in a React SPA",
+        severity: "warn",
+        body: "Use a client\nwith clear module boundaries.\n",
+        anti_patterns: [],
+      }),
+    );
+  });
+
+  test("treats omitted severity and explicit warn as the same Practice content", () => {
+    expect(contentDigest(practice)).toBe(contentDigest({ ...practice, severity: "warn" }));
+  });
+
+  test("retains array order as part of canonical Practice content", () => {
+    expect(contentDigest(practice)).not.toBe(
+      contentDigest({ ...practice, tech_stack: ["typescript", "react"] }),
+    );
+  });
+
+  test("rejects Windows drive paths as snapshot-relative paths", () => {
+    expect(() => normalizeSnapshotPath("C:\\outside.md")).toThrow(InvalidPreparedPackError);
+  });
+});

--- a/packages/engine/src/local-store/canonicalize.ts
+++ b/packages/engine/src/local-store/canonicalize.ts
@@ -1,0 +1,98 @@
+import { createHash } from "node:crypto";
+import { posix } from "node:path";
+
+import type { Practice } from "@lorelum/format";
+
+import { InvalidPreparedPackError } from "./errors";
+import type { SnapshotFile } from "./types";
+
+const DEFAULT_SEVERITY = "warn";
+
+function normalizeText(value: string): string {
+  return value.replace(/\r\n?/g, "\n");
+}
+
+function hashParts(parts: readonly Uint8Array[]): string {
+  const hash = createHash("sha256");
+  for (const part of parts) {
+    hash.update(part);
+  }
+  return hash.digest("hex");
+}
+
+function encodedPart(value: string | Uint8Array): Uint8Array {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
+  return new TextEncoder().encode(`${bytes.byteLength}:`);
+}
+
+export function normalizeSnapshotPath(relativePath: string): string {
+  const normalizedInput = relativePath.replace(/\\/g, "/");
+  const normalized = posix.normalize(normalizedInput);
+
+  if (
+    normalizedInput.includes("\0") ||
+    /^[a-z]:/i.test(normalizedInput) ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.startsWith("/") ||
+    normalizedInput.startsWith("/")
+  ) {
+    throw new InvalidPreparedPackError(`Unsafe snapshot path "${relativePath}"`);
+  }
+
+  return normalized;
+}
+
+export function artifactDigest(files: readonly SnapshotFile[]): string {
+  const normalized = files
+    .map((file) => ({ ...file, relativePath: normalizeSnapshotPath(file.relativePath) }))
+    .sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+  const seen = new Set<string>();
+  const parts: Uint8Array[] = [];
+
+  for (const file of normalized) {
+    if (seen.has(file.relativePath)) {
+      throw new InvalidPreparedPackError(`Duplicate snapshot path "${file.relativePath}"`);
+    }
+    seen.add(file.relativePath);
+    parts.push(encodedPart(file.relativePath), new TextEncoder().encode(file.relativePath));
+    parts.push(encodedPart(file.bytes), file.bytes);
+  }
+
+  return hashParts(parts);
+}
+
+export function storageKey(packName: string): string {
+  let output = "";
+  for (const character of packName) {
+    output += /[a-z0-9-]/.test(character)
+      ? character
+      : `_${character.codePointAt(0)?.toString(16) ?? ""}_`;
+  }
+  return output;
+}
+
+export function canonicalContent(practice: Practice): string {
+  const antiPatterns = (practice.anti_patterns ?? []).map((antiPattern) => ({
+    id: normalizeText(antiPattern.id),
+    name: normalizeText(antiPattern.name),
+    description: normalizeText(antiPattern.description),
+    severity: antiPattern.severity ?? null,
+  }));
+
+  return JSON.stringify({
+    id: normalizeText(practice.id),
+    title: normalizeText(practice.title),
+    stage: normalizeText(practice.stage),
+    tech_stack: practice.tech_stack.map(normalizeText),
+    applies_when: normalizeText(practice.applies_when),
+    severity: practice.severity ?? DEFAULT_SEVERITY,
+    body: normalizeText(practice.body ?? ""),
+    anti_patterns: antiPatterns,
+  });
+}
+
+export function contentDigest(practice: Practice): string {
+  return hashParts([new TextEncoder().encode(canonicalContent(practice))]);
+}

--- a/packages/engine/src/local-store/database.ts
+++ b/packages/engine/src/local-store/database.ts
@@ -1,0 +1,22 @@
+import { Database } from "bun:sqlite";
+import { join } from "node:path";
+
+import type { StorageRoot } from "./types";
+import { migrateDatabase } from "./migrations";
+
+export class StoreDatabase {
+  readonly connection: Database;
+
+  constructor(root: StorageRoot) {
+    this.connection = new Database(join(root.path, "store.sqlite"), { strict: true });
+    migrateDatabase(this.connection);
+  }
+
+  transaction<T>(operation: () => T): T {
+    return this.connection.transaction(operation).immediate();
+  }
+
+  close(): void {
+    this.connection.close();
+  }
+}

--- a/packages/engine/src/local-store/errors.ts
+++ b/packages/engine/src/local-store/errors.ts
@@ -1,0 +1,51 @@
+import type { ValidationReport } from "@lorelum/format";
+
+export class LocalStoreError extends Error {
+  override readonly name: string = "LocalStoreError";
+}
+
+export class PackValidationError extends LocalStoreError {
+  override readonly name: string = "PackValidationError";
+
+  constructor(readonly report: ValidationReport) {
+    super("Pack validation failed");
+  }
+}
+
+export class InvalidPreparedPackError extends LocalStoreError {
+  override readonly name: string = "InvalidPreparedPackError";
+}
+
+export class PackUpgradeRequiredError extends LocalStoreError {
+  override readonly name: string = "PackUpgradeRequiredError";
+
+  constructor(readonly packName: string) {
+    super(`Pack "${packName}" is already installed with different content; use upgrade`);
+  }
+}
+
+export class PackNotInstalledError extends LocalStoreError {
+  override readonly name: string = "PackNotInstalledError";
+
+  constructor(readonly packName: string) {
+    super(`Pack "${packName}" is not installed`);
+  }
+}
+
+export class PracticeConflictError extends LocalStoreError {
+  override readonly name: string = "PracticeConflictError";
+
+  constructor(
+    readonly practiceId: string,
+    readonly candidatePackName: string,
+    readonly activePackName: string,
+  ) {
+    super(
+      `Practice "${practiceId}" from "${candidatePackName}" conflicts with active pack "${activePackName}"`,
+    );
+  }
+}
+
+export class StoreInvariantError extends LocalStoreError {
+  override readonly name: string = "StoreInvariantError";
+}

--- a/packages/engine/src/local-store/errors.ts
+++ b/packages/engine/src/local-store/errors.ts
@@ -49,3 +49,11 @@ export class PracticeConflictError extends LocalStoreError {
 export class StoreInvariantError extends LocalStoreError {
   override readonly name: string = "StoreInvariantError";
 }
+
+export class StoreBusyError extends LocalStoreError {
+  override readonly name: string = "StoreBusyError";
+
+  constructor(readonly lockPath: string) {
+    super(`LocalStore is busy with another mutation at "${lockPath}"`);
+  }
+}

--- a/packages/engine/src/local-store/index.ts
+++ b/packages/engine/src/local-store/index.ts
@@ -1,0 +1,3 @@
+export * from "./errors";
+export * from "./local-store";
+export * from "./types";

--- a/packages/engine/src/local-store/local-store.test.ts
+++ b/packages/engine/src/local-store/local-store.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import type { PackInput, Practice } from "@lorelum/format";
+import {
+  PackSchema,
+  PracticeSchema,
+  parseFrontmatter,
+  type PackInput,
+  type Practice,
+} from "@lorelum/format";
 
 import {
   InvalidPreparedPackError,
@@ -15,6 +21,7 @@ import {
   defaultStorageRoot,
   storageRoot,
   type PreparedPack,
+  type SnapshotCodec,
 } from "./index";
 
 function practice(id: string, overrides: Partial<Practice> = {}): Practice {
@@ -35,11 +42,11 @@ function preparedPack(name: string, version: string, practices: readonly Practic
   const files = [
     {
       relativePath: "pack.yaml",
-      bytes: new TextEncoder().encode(`name: ${name}\nversion: ${version}\n`),
+      bytes: new TextEncoder().encode(JSON.stringify(input.pack)),
     },
     ...practices.map((item) => ({
       relativePath: `practices/${item.id}.md`,
-      bytes: new TextEncoder().encode(`# ${item.title}\n${item.body ?? ""}\n`),
+      bytes: practiceMarkdown(item),
     })),
   ];
   return {
@@ -49,11 +56,55 @@ function preparedPack(name: string, version: string, practices: readonly Practic
   };
 }
 
+function practiceMarkdown(item: Practice): Uint8Array {
+  const { body, ...frontmatter } = item;
+  return new TextEncoder().encode(`---\n${JSON.stringify(frontmatter)}\n---\n${body ?? ""}`);
+}
+
+function testSnapshotCodec(): SnapshotCodec {
+  return {
+    async decode(artifactDirectory) {
+      const pack = PackSchema.parse(
+        JSON.parse(await readFile(join(artifactDirectory, "pack.yaml"), "utf8")) as unknown,
+      );
+      const practiceDirectory = join(artifactDirectory, "practices");
+      const entries = await readdir(practiceDirectory, { withFileTypes: true });
+      const decodedPractices = await Promise.all(
+        entries
+          .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+          .map(async (entry) => {
+            const relativePath = `practices/${entry.name}`;
+            const markdown = await readFile(join(practiceDirectory, entry.name), "utf8");
+            const parsed = parseFrontmatter(markdown);
+            const decodedPractice = PracticeSchema.parse({ ...parsed.data, body: parsed.content });
+            return { decodedPractice, relativePath };
+          }),
+      );
+      const practices = decodedPractices.map(({ decodedPractice }) => decodedPractice);
+      const practiceSourcePaths = new Map(
+        decodedPractices.map(({ decodedPractice, relativePath }) => [
+          decodedPractice.id,
+          relativePath,
+        ]),
+      );
+
+      return {
+        input: { pack, practices, decisions: [] },
+        files: [],
+        practiceSourcePaths,
+      };
+    },
+  };
+}
+
 async function withStore(
   operation: (store: LocalStore, rootPath: string) => Promise<void>,
 ): Promise<void> {
   const rootPath = await mkdtemp(join(tmpdir(), "lorelum-local-store-"));
-  const store = await LocalStore.open({ root: storageRoot(rootPath) });
+  const store = await LocalStore.open({
+    root: storageRoot(rootPath),
+    snapshotCodec: testSnapshotCodec(),
+  });
   try {
     await operation(store, rootPath);
   } finally {
@@ -94,7 +145,10 @@ describe("LocalStore lifecycle", () => {
       await stat(join(rootPath, "packs", entry.storageKey, entry.artifactDigest, "pack.yaml"));
 
       store.close();
-      const restarted = await LocalStore.open({ root: storageRoot(rootPath) });
+      const restarted = await LocalStore.open({
+        root: storageRoot(rootPath),
+        snapshotCodec: testSnapshotCodec(),
+      });
       try {
         expect(restarted.state()).toEqual({ installedPacksGeneration: 1, effectiveRevision: 1 });
         expect(restarted.effectivePractices()).toHaveLength(1);
@@ -288,5 +342,69 @@ describe("LocalStore lifecycle", () => {
 
       await expect(store.install(invalid)).rejects.toBeInstanceOf(InvalidPreparedPackError);
     });
+  });
+
+  test("rejects a snapshot whose decoded Pack or Practice differs from validated input", async () => {
+    await withStore(async (store) => {
+      const expected = preparedPack("react-base", "1.0.0", [practice("react.api.layered-design")]);
+      const mismatched: PreparedPack = {
+        ...expected,
+        files: [
+          {
+            relativePath: "pack.yaml",
+            bytes: new TextEncoder().encode(
+              JSON.stringify({ name: "different-pack", version: "9.9.9" }),
+            ),
+          },
+          {
+            relativePath: "practices/react.api.layered-design.md",
+            bytes: practiceMarkdown(
+              practice("react.api.layered-design", { body: "Different guidance." }),
+            ),
+          },
+        ],
+      };
+
+      await expect(store.install(mismatched)).rejects.toBeInstanceOf(InvalidPreparedPackError);
+      expect(store.installedPacks()).toEqual([]);
+      expect(store.effectivePractices()).toEqual([]);
+    });
+  });
+
+  test("serializes concurrent mutations from multiple LocalStore instances", async () => {
+    const rootPath = await mkdtemp(join(tmpdir(), "lorelum-local-store-"));
+    const root = storageRoot(rootPath);
+    const first = await LocalStore.open({ root, snapshotCodec: testSnapshotCodec() });
+    const second = await LocalStore.open({ root, snapshotCodec: testSnapshotCodec() });
+
+    try {
+      const base = preparedPack("react-base", "1.0.0", [practice("react.api.base")]);
+      const baseUpgrade = preparedPack("react-base", "1.1.0", [
+        practice("react.api.base", { body: "Updated base guidance." }),
+      ]);
+      const team = preparedPack("react-team", "1.0.0", [practice("react.api.team")]);
+
+      await first.install(base);
+      await Promise.all([first.upgrade(baseUpgrade), second.install(team)]);
+      await Promise.all([first.uninstall("react-base"), second.uninstall("react-team")]);
+
+      const manifest = JSON.parse(
+        await readFile(join(rootPath, "installed-packs.json"), "utf8"),
+      ) as { schemaVersion: number; generation: number; packs: { name: string }[] };
+      expect(manifest).toEqual({ generation: 5, packs: [], schemaVersion: 1 });
+
+      const restarted = await LocalStore.open({ root, snapshotCodec: testSnapshotCodec() });
+      try {
+        expect(restarted.installedPacks()).toEqual([]);
+        expect(restarted.effectivePractices()).toEqual([]);
+        expect(restarted.state()).toEqual({ installedPacksGeneration: 5, effectiveRevision: 5 });
+      } finally {
+        restarted.close();
+      }
+    } finally {
+      first.close();
+      second.close();
+      await rm(rootPath, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/engine/src/local-store/local-store.test.ts
+++ b/packages/engine/src/local-store/local-store.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import type { PackInput, Practice } from "@lorelum/format";
+
+import {
+  InvalidPreparedPackError,
+  LocalStore,
+  PackUpgradeRequiredError,
+  PackValidationError,
+  PracticeConflictError,
+  defaultStorageRoot,
+  storageRoot,
+  type PreparedPack,
+} from "./index";
+
+function practice(id: string, overrides: Partial<Practice> = {}): Practice {
+  return {
+    id,
+    title: `Title for ${id}`,
+    stage: "api-layer",
+    tech_stack: ["typescript"],
+    applies_when: "building a TypeScript API integration",
+    severity: "warn",
+    body: `Guidance for ${id}.`,
+    ...overrides,
+  };
+}
+
+function preparedPack(name: string, version: string, practices: readonly Practice[]): PreparedPack {
+  const input: PackInput = { pack: { name, version }, practices: [...practices], decisions: [] };
+  const files = [
+    {
+      relativePath: "pack.yaml",
+      bytes: new TextEncoder().encode(`name: ${name}\nversion: ${version}\n`),
+    },
+    ...practices.map((item) => ({
+      relativePath: `practices/${item.id}.md`,
+      bytes: new TextEncoder().encode(`# ${item.title}\n${item.body ?? ""}\n`),
+    })),
+  ];
+  return {
+    input,
+    files,
+    practiceSourcePaths: new Map(practices.map((item) => [item.id, `practices/${item.id}.md`])),
+  };
+}
+
+async function withStore(
+  operation: (store: LocalStore, rootPath: string) => Promise<void>,
+): Promise<void> {
+  const rootPath = await mkdtemp(join(tmpdir(), "lorelum-local-store-"));
+  const store = await LocalStore.open({ root: storageRoot(rootPath) });
+  try {
+    await operation(store, rootPath);
+  } finally {
+    store.close();
+    await rm(rootPath, { recursive: true, force: true });
+  }
+}
+
+describe("LocalStore lifecycle", () => {
+  test("uses the user-level default root and accepts an injected StorageRoot", async () => {
+    expect(defaultStorageRoot().path).toBe(join(homedir(), ".lorelum"));
+
+    await withStore(async (store, rootPath) => {
+      expect(store.root).toEqual(storageRoot(rootPath));
+    });
+  });
+
+  test("installs immutable artifacts and reads persisted state after restart", async () => {
+    await withStore(async (store, rootPath) => {
+      const input = preparedPack("react-fullstack", "1.0.0", [
+        practice("react.api.layered-design"),
+      ]);
+      const installed = await store.install(input);
+
+      expect(installed.kind).toBe("installed");
+      expect(installed.effectiveRevision).toBe(1);
+      expect(store.effectivePractice("react.api.layered-design")?.sourcePackNames).toEqual([
+        "react-fullstack",
+      ]);
+
+      const manifest = JSON.parse(
+        await readFile(join(rootPath, "installed-packs.json"), "utf8"),
+      ) as { packs: { storageKey: string; artifactDigest: string }[] };
+      const entry = manifest.packs[0];
+      expect(entry).toBeDefined();
+      if (entry === undefined) throw new Error("expected installed pack manifest entry");
+      await stat(join(rootPath, "store.sqlite"));
+      await stat(join(rootPath, "packs", entry.storageKey, entry.artifactDigest, "pack.yaml"));
+
+      store.close();
+      const restarted = await LocalStore.open({ root: storageRoot(rootPath) });
+      try {
+        expect(restarted.state()).toEqual({ installedPacksGeneration: 1, effectiveRevision: 1 });
+        expect(restarted.effectivePractices()).toHaveLength(1);
+      } finally {
+        restarted.close();
+      }
+    });
+  });
+
+  test("treats an identical install as idempotent and requires upgrade for changed artifacts", async () => {
+    await withStore(async (store) => {
+      const initial = preparedPack("react-fullstack", "1.0.0", [
+        practice("react.api.layered-design"),
+      ]);
+      await store.install(initial);
+
+      const unchanged = await store.install(initial);
+      expect(unchanged.kind).toBe("unchanged");
+      expect(unchanged.effectiveRevision).toBe(1);
+
+      await expect(
+        store.install(
+          preparedPack("react-fullstack", "1.1.0", [practice("react.api.layered-design")]),
+        ),
+      ).rejects.toBeInstanceOf(PackUpgradeRequiredError);
+    });
+  });
+
+  test("upgrade replaces all sources from the old Pack version", async () => {
+    await withStore(async (store) => {
+      await store.install(
+        preparedPack("react-fullstack", "1.0.0", [
+          practice("react.api.layered-design"),
+          practice("react.state.redux"),
+        ]),
+      );
+
+      const upgraded = await store.upgrade(
+        preparedPack("react-fullstack", "1.1.0", [practice("react.api.layered-design")]),
+      );
+      expect(upgraded.kind).toBe("upgraded");
+      expect(upgraded.effectiveRevision).toBe(2);
+      expect(store.effectivePractice("react.state.redux")).toBeNull();
+      expect(store.installedPacks()[0]?.version).toBe("1.1.0");
+    });
+  });
+
+  test("increments effectiveRevision when an upgrade replaces effective content", async () => {
+    await withStore(async (store) => {
+      await store.install(
+        preparedPack("react-fullstack", "1.0.0", [practice("react.api.layered-design")]),
+      );
+
+      const upgraded = await store.upgrade(
+        preparedPack("react-fullstack", "1.1.0", [
+          practice("react.api.layered-design", { body: "Updated guidance." }),
+        ]),
+      );
+
+      expect(upgraded.effectiveRevision).toBe(2);
+      expect(store.effectivePractice("react.api.layered-design")?.body).toBe("Updated guidance.");
+      expect(store.effectivePractice("react.api.layered-design")?.effectiveRevision).toBe(2);
+    });
+  });
+
+  test("merges matching Practice sources without changing effectiveRevision", async () => {
+    await withStore(async (store) => {
+      const shared = practice("react.api.layered-design");
+      await store.install(preparedPack("react-base", "1.0.0", [shared]));
+      const second = await store.install(preparedPack("react-team", "1.0.0", [shared]));
+
+      expect(second.effectiveRevision).toBe(1);
+      expect(store.effectivePractice(shared.id)?.sourcePackNames).toEqual([
+        "react-base",
+        "react-team",
+      ]);
+
+      const firstUninstall = await store.uninstall("react-base");
+      expect(firstUninstall.effectiveRevision).toBe(1);
+      expect(store.effectivePractice(shared.id)?.sourcePackNames).toEqual(["react-team"]);
+
+      const finalUninstall = await store.uninstall("react-team");
+      expect(finalUninstall.effectiveRevision).toBe(2);
+      expect(store.effectivePractice(shared.id)).toBeNull();
+    });
+  });
+
+  test("removes an unreferenced artifact after uninstall", async () => {
+    await withStore(async (store, rootPath) => {
+      const installed = await store.install(
+        preparedPack("react-base", "1.0.0", [practice("react.api.layered-design")]),
+      );
+      const artifact = join(
+        rootPath,
+        "packs",
+        installed.pack.storageKey,
+        installed.pack.artifactDigest,
+      );
+
+      await store.uninstall("react-base");
+      await expect(stat(artifact)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  test("rejects same-id Practices with different canonical content", async () => {
+    await withStore(async (store) => {
+      await store.install(
+        preparedPack("react-base", "1.0.0", [practice("react.api.layered-design")]),
+      );
+
+      await expect(
+        store.install(
+          preparedPack("react-team", "1.0.0", [
+            practice("react.api.layered-design", { body: "Different guidance." }),
+          ]),
+        ),
+      ).rejects.toBeInstanceOf(PracticeConflictError);
+    });
+  });
+
+  test("rejects an upgrade that conflicts with another active source", async () => {
+    await withStore(async (store) => {
+      const shared = practice("react.api.layered-design");
+      await store.install(preparedPack("react-base", "1.0.0", [shared]));
+      await store.install(preparedPack("react-team", "1.0.0", [shared]));
+
+      await expect(
+        store.upgrade(
+          preparedPack("react-base", "1.1.0", [
+            practice("react.api.layered-design", { body: "Different guidance." }),
+          ]),
+        ),
+      ).rejects.toBeInstanceOf(PracticeConflictError);
+
+      expect(store.installedPacks().find((pack) => pack.name === "react-base")?.version).toBe(
+        "1.0.0",
+      );
+    });
+  });
+
+  test("keeps same-title Practices with different ids as independent effective records", async () => {
+    await withStore(async (store) => {
+      const title = "Use an API layer";
+      await store.install(
+        preparedPack("react-base", "1.0.0", [
+          practice("react.api.base", { title }),
+          practice("react.api.team", { title }),
+        ]),
+      );
+
+      expect(store.effectivePractices().map((item) => item.id)).toEqual([
+        "react.api.base",
+        "react.api.team",
+      ]);
+    });
+  });
+
+  test("rejects invalid Pack input before any Pack becomes active", async () => {
+    await withStore(async (store) => {
+      const invalid = preparedPack("react-base", "1.0.0", [
+        practice("react.api.layered-design", { id: "not-dotted" }),
+      ]);
+
+      await expect(store.install(invalid)).rejects.toBeInstanceOf(PackValidationError);
+      expect(store.installedPacks()).toEqual([]);
+      expect(store.effectivePractices()).toEqual([]);
+    });
+  });
+
+  test("retains validation warnings without blocking installation", async () => {
+    await withStore(async (store) => {
+      const warned = preparedPack("react-base", "1.0.0", [
+        practice("react.api.layered-design", { severity: undefined }),
+      ]);
+      const installed = await store.install(warned);
+
+      expect(installed.validation.warnings.map((warning) => warning.code)).toContain(
+        "missing-severity",
+      );
+      expect(store.effectivePractice("react.api.layered-design")?.severity).toBe("warn");
+    });
+  });
+
+  test("rejects unsafe or missing Practice source paths", async () => {
+    await withStore(async (store) => {
+      const valid = preparedPack("react-base", "1.0.0", [practice("react.api.layered-design")]);
+      const invalid: PreparedPack = {
+        ...valid,
+        practiceSourcePaths: new Map([["react.api.layered-design", "../outside.md"]]),
+      };
+
+      await expect(store.install(invalid)).rejects.toBeInstanceOf(InvalidPreparedPackError);
+    });
+  });
+});

--- a/packages/engine/src/local-store/local-store.ts
+++ b/packages/engine/src/local-store/local-store.ts
@@ -1,0 +1,390 @@
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { validatePack, type Practice, type ValidationReport } from "@lorelum/format";
+
+import {
+  artifactDigest,
+  canonicalContent,
+  contentDigest,
+  normalizeSnapshotPath,
+  storageKey,
+} from "./canonicalize";
+import {
+  discardStagedArtifact,
+  promoteArtifact,
+  removeArtifact,
+  stageArtifact,
+} from "./artifact-store";
+import { StoreDatabase } from "./database";
+import {
+  InvalidPreparedPackError,
+  PackNotInstalledError,
+  PackUpgradeRequiredError,
+  PackValidationError,
+  PracticeConflictError,
+  StoreInvariantError,
+} from "./errors";
+import {
+  emptyManifest,
+  loadManifest,
+  type InstalledPacksManifest,
+  writeManifest,
+} from "./manifest";
+import { LocalStoreRepository } from "./repositories";
+import type {
+  EffectivePractice,
+  InstallResult,
+  InstalledPack,
+  LocalStoreOpenOptions,
+  LocalStoreState,
+  PreparedPack,
+  StorageRoot,
+  UninstallResult,
+} from "./types";
+
+interface CandidatePractice {
+  readonly practice: Practice;
+  readonly canonicalContent: string;
+  readonly contentDigest: string;
+  readonly sourcePath: string;
+}
+
+interface PackCandidate {
+  readonly prepared: PreparedPack;
+  readonly artifactDigest: string;
+  readonly storageKey: string;
+  readonly validation: ValidationReport;
+  readonly practices: readonly CandidatePractice[];
+}
+
+export function storageRoot(path: string): StorageRoot {
+  return { path };
+}
+
+export function defaultStorageRoot(): StorageRoot {
+  return storageRoot(join(homedir(), ".lorelum"));
+}
+
+export class LocalStore {
+  private readonly repository: LocalStoreRepository;
+
+  private constructor(
+    readonly root: StorageRoot,
+    private readonly database: StoreDatabase,
+    private manifest: InstalledPacksManifest,
+  ) {
+    this.repository = new LocalStoreRepository(database.connection);
+  }
+
+  static async open(options: LocalStoreOpenOptions = {}): Promise<LocalStore> {
+    const root = options.root ?? defaultStorageRoot();
+    await mkdir(root.path, { recursive: true });
+    const manifest = await loadManifest(root);
+    const database = new StoreDatabase(root);
+    const repository = new LocalStoreRepository(database.connection);
+    const state = repository.state();
+
+    if (state.installedPacksGeneration !== manifest.generation) {
+      database.close();
+      throw new StoreInvariantError(
+        `SQLite generation ${state.installedPacksGeneration} does not match manifest generation ${manifest.generation}`,
+      );
+    }
+
+    return new LocalStore(root, database, manifest);
+  }
+
+  close(): void {
+    this.database.close();
+  }
+
+  state(): LocalStoreState {
+    return this.repository.state();
+  }
+
+  installedPacks(): readonly InstalledPack[] {
+    return this.repository.allInstalledPacks();
+  }
+
+  effectivePractices(): readonly EffectivePractice[] {
+    return this.repository.allEffectivePractices();
+  }
+
+  effectivePractice(practiceId: string): EffectivePractice | null {
+    return this.repository.effectivePractice(practiceId);
+  }
+
+  async install(prepared: PreparedPack): Promise<InstallResult> {
+    const candidate = this.prepareCandidate(prepared);
+    const existing = this.manifest.packs.find((pack) => pack.name === prepared.input.pack.name);
+    if (existing !== undefined) {
+      if (existing.artifactDigest === candidate.artifactDigest) {
+        return {
+          kind: "unchanged",
+          pack: existing,
+          effectiveRevision: this.repository.state().effectiveRevision,
+          validation: candidate.validation,
+        };
+      }
+      throw new PackUpgradeRequiredError(existing.name);
+    }
+    return this.applyCandidate("installed", candidate, undefined);
+  }
+
+  async upgrade(prepared: PreparedPack): Promise<InstallResult> {
+    const candidate = this.prepareCandidate(prepared);
+    const existing = this.manifest.packs.find((pack) => pack.name === prepared.input.pack.name);
+    if (existing === undefined) {
+      throw new PackNotInstalledError(prepared.input.pack.name);
+    }
+    if (existing.artifactDigest === candidate.artifactDigest) {
+      return {
+        kind: "unchanged",
+        pack: existing,
+        effectiveRevision: this.repository.state().effectiveRevision,
+        validation: candidate.validation,
+      };
+    }
+    return this.applyCandidate("upgraded", candidate, existing);
+  }
+
+  async uninstall(packName: string): Promise<UninstallResult> {
+    const existing = this.manifest.packs.find((pack) => pack.name === packName);
+    if (existing === undefined) throw new PackNotInstalledError(packName);
+
+    const oldSources = this.repository.sourcesForPack(packName);
+    const affectedPracticeIds = new Set(oldSources.map((source) => source.practice_id));
+    const nextManifest = this.nextManifest(
+      this.manifest.packs.filter((pack) => pack.name !== packName),
+    );
+
+    await writeManifest(this.root, nextManifest);
+    const nextRevision = this.database.transaction(() => {
+      const currentState = this.repository.state();
+      this.repository.deletePack(packName);
+      const effectiveChanged = this.reconcileEffectivePractices(affectedPracticeIds, new Map());
+      const state = {
+        installedPacksGeneration: nextManifest.generation,
+        effectiveRevision: currentState.effectiveRevision + (effectiveChanged ? 1 : 0),
+      };
+      if (effectiveChanged) {
+        this.rewriteChangedEffectiveRevisions(affectedPracticeIds, state.effectiveRevision);
+      }
+      this.repository.setState(state);
+      return state.effectiveRevision;
+    });
+
+    this.manifest = nextManifest;
+    await removeArtifact(this.root, existing.storageKey, existing.artifactDigest);
+    return { packName, effectiveRevision: nextRevision };
+  }
+
+  private prepareCandidate(prepared: PreparedPack): PackCandidate {
+    const validation = validatePack(prepared.input);
+    if (!validation.valid) throw new PackValidationError(validation);
+
+    const normalizedFiles = new Map<string, Uint8Array>();
+    for (const file of prepared.files) {
+      const path = normalizeSnapshotPath(file.relativePath);
+      if (normalizedFiles.has(path)) {
+        throw new InvalidPreparedPackError(`Duplicate snapshot path "${path}"`);
+      }
+      normalizedFiles.set(path, file.bytes);
+    }
+    if (!normalizedFiles.has("pack.yaml")) {
+      throw new InvalidPreparedPackError('PreparedPack snapshot must contain "pack.yaml"');
+    }
+    if (prepared.practiceSourcePaths.size !== prepared.input.practices.length) {
+      throw new InvalidPreparedPackError("Every Practice must have exactly one source path");
+    }
+
+    const practices: CandidatePractice[] = [];
+    for (const practice of prepared.input.practices) {
+      const sourcePath = prepared.practiceSourcePaths.get(practice.id);
+      if (sourcePath === undefined) {
+        throw new InvalidPreparedPackError(`Practice "${practice.id}" has no source path`);
+      }
+      const normalizedSourcePath = normalizeSnapshotPath(sourcePath);
+      if (!normalizedFiles.has(normalizedSourcePath)) {
+        throw new InvalidPreparedPackError(
+          `Practice "${practice.id}" source path "${normalizedSourcePath}" is absent from snapshot`,
+        );
+      }
+      practices.push({
+        practice,
+        sourcePath: normalizedSourcePath,
+        canonicalContent: canonicalContent(practice),
+        contentDigest: contentDigest(practice),
+      });
+    }
+
+    return {
+      prepared,
+      artifactDigest: artifactDigest(prepared.files),
+      storageKey: storageKey(prepared.input.pack.name),
+      validation,
+      practices,
+    };
+  }
+
+  private async applyCandidate(
+    kind: "installed" | "upgraded",
+    candidate: PackCandidate,
+    previous: InstalledPack | undefined,
+  ): Promise<InstallResult> {
+    this.assertNoConflicts(candidate, previous?.name);
+    const operationId = crypto.randomUUID();
+    const staged = await stageArtifact(this.root, operationId, candidate.prepared.files);
+    const installedAt = new Date().toISOString();
+    const pack: InstalledPack = {
+      name: candidate.prepared.input.pack.name,
+      version: candidate.prepared.input.pack.version,
+      artifactDigest: candidate.artifactDigest,
+      storageKey: candidate.storageKey,
+      installedAt,
+    };
+
+    try {
+      await promoteArtifact(this.root, staged, pack.storageKey, pack.artifactDigest);
+      const nextManifest = this.nextManifest([
+        ...this.manifest.packs.filter((entry) => entry.name !== pack.name),
+        pack,
+      ]);
+      await writeManifest(this.root, nextManifest);
+
+      const nextRevision = this.database.transaction(() => {
+        const oldSources = this.repository.sourcesForPack(pack.name);
+        const affectedPracticeIds = new Set([
+          ...oldSources.map((source) => source.practice_id),
+          ...candidate.practices.map((practice) => practice.practice.id),
+        ]);
+        const currentState = this.repository.state();
+        this.repository.deletePack(pack.name);
+        this.repository.savePack(pack);
+        for (const practice of candidate.practices) {
+          this.repository.addSource(
+            pack.name,
+            practice.practice.id,
+            practice.contentDigest,
+            practice.sourcePath,
+          );
+        }
+        const candidatesById = new Map(
+          candidate.practices.map((practice) => [practice.practice.id, practice]),
+        );
+        const effectiveChanged = this.reconcileEffectivePractices(
+          affectedPracticeIds,
+          candidatesById,
+        );
+        const state = {
+          installedPacksGeneration: nextManifest.generation,
+          effectiveRevision: currentState.effectiveRevision + (effectiveChanged ? 1 : 0),
+        };
+        if (effectiveChanged) {
+          this.rewriteChangedEffectiveRevisions(
+            affectedPracticeIds,
+            state.effectiveRevision,
+            candidatesById,
+          );
+        }
+        this.repository.setState(state);
+        return state.effectiveRevision;
+      });
+
+      this.manifest = nextManifest;
+      if (previous !== undefined) {
+        await removeArtifact(this.root, previous.storageKey, previous.artifactDigest);
+      }
+      return { kind, pack, effectiveRevision: nextRevision, validation: candidate.validation };
+    } catch (error: unknown) {
+      await discardStagedArtifact(this.root, staged);
+      throw error;
+    }
+  }
+
+  private assertNoConflicts(candidate: PackCandidate, ignoredPackName: string | undefined): void {
+    for (const practice of candidate.practices) {
+      for (const source of this.repository.sourcesForPractice(practice.practice.id)) {
+        if (source.pack_name === ignoredPackName) continue;
+        if (source.content_digest !== practice.contentDigest) {
+          throw new PracticeConflictError(
+            practice.practice.id,
+            candidate.prepared.input.pack.name,
+            source.pack_name,
+          );
+        }
+      }
+    }
+  }
+
+  private reconcileEffectivePractices(
+    practiceIds: ReadonlySet<string>,
+    candidates: ReadonlyMap<string, CandidatePractice>,
+  ): boolean {
+    let changed = false;
+    for (const practiceId of practiceIds) {
+      const existing = this.repository.effectivePractice(practiceId);
+      const sources = this.repository.sourcesForPractice(practiceId);
+      if (sources.length === 0) {
+        if (existing !== null) {
+          this.repository.deleteEffectivePractice(practiceId);
+          changed = true;
+        }
+        continue;
+      }
+
+      const digest = sources[0]?.content_digest;
+      if (digest === undefined) {
+        throw new StoreInvariantError(`Practice "${practiceId}" has no readable source digest`);
+      }
+      if (sources.some((source) => source.content_digest !== digest)) {
+        throw new StoreInvariantError(`Practice "${practiceId}" has conflicting source digests`);
+      }
+      if (existing?.contentDigest === digest) continue;
+
+      const candidate = candidates.get(practiceId);
+      if (candidate === undefined || candidate.contentDigest !== digest) {
+        throw new StoreInvariantError(
+          `Practice "${practiceId}" needs effective content absent from the candidate pack`,
+        );
+      }
+      this.repository.saveEffectivePractice(
+        candidate.practice,
+        candidate.canonicalContent,
+        candidate.contentDigest,
+        existing?.effectiveRevision ?? 0,
+      );
+      changed = true;
+    }
+    return changed;
+  }
+
+  private rewriteChangedEffectiveRevisions(
+    practiceIds: ReadonlySet<string>,
+    effectiveRevision: number,
+    candidates: ReadonlyMap<string, CandidatePractice> = new Map(),
+  ): void {
+    for (const practiceId of practiceIds) {
+      const effective = this.repository.effectivePractice(practiceId);
+      if (effective === null || effective.effectiveRevision === effectiveRevision) continue;
+      const candidate = candidates.get(practiceId);
+      if (candidate === undefined || candidate.contentDigest !== effective.contentDigest) continue;
+      this.repository.saveEffectivePractice(
+        candidate.practice,
+        candidate.canonicalContent,
+        candidate.contentDigest,
+        effectiveRevision,
+      );
+    }
+  }
+
+  private nextManifest(packs: readonly InstalledPack[]): InstalledPacksManifest {
+    return {
+      ...emptyManifest(),
+      generation: this.manifest.generation + 1,
+      packs: [...packs].sort((left, right) => left.name.localeCompare(right.name)),
+    };
+  }
+}

--- a/packages/engine/src/local-store/local-store.ts
+++ b/packages/engine/src/local-store/local-store.ts
@@ -32,6 +32,7 @@ import {
   type InstalledPacksManifest,
   writeManifest,
 } from "./manifest";
+import { withMutationLock } from "./mutation-lock";
 import { LocalStoreRepository } from "./repositories";
 import type {
   EffectivePractice,
@@ -40,6 +41,7 @@ import type {
   LocalStoreOpenOptions,
   LocalStoreState,
   PreparedPack,
+  SnapshotCodec,
   StorageRoot,
   UninstallResult,
 } from "./types";
@@ -74,11 +76,12 @@ export class LocalStore {
     readonly root: StorageRoot,
     private readonly database: StoreDatabase,
     private manifest: InstalledPacksManifest,
+    private readonly snapshotCodec: SnapshotCodec,
   ) {
     this.repository = new LocalStoreRepository(database.connection);
   }
 
-  static async open(options: LocalStoreOpenOptions = {}): Promise<LocalStore> {
+  static async open(options: LocalStoreOpenOptions): Promise<LocalStore> {
     const root = options.root ?? defaultStorageRoot();
     await mkdir(root.path, { recursive: true });
     const manifest = await loadManifest(root);
@@ -93,7 +96,7 @@ export class LocalStore {
       );
     }
 
-    return new LocalStore(root, database, manifest);
+    return new LocalStore(root, database, manifest, options.snapshotCodec);
   }
 
   close(): void {
@@ -118,8 +121,32 @@ export class LocalStore {
 
   async install(prepared: PreparedPack): Promise<InstallResult> {
     const candidate = this.prepareCandidate(prepared);
-    const existing = this.manifest.packs.find((pack) => pack.name === prepared.input.pack.name);
-    if (existing !== undefined) {
+    return withMutationLock(this.root, async () => {
+      await this.reloadManifest();
+      const existing = this.manifest.packs.find((pack) => pack.name === prepared.input.pack.name);
+      if (existing !== undefined) {
+        if (existing.artifactDigest === candidate.artifactDigest) {
+          return {
+            kind: "unchanged",
+            pack: existing,
+            effectiveRevision: this.repository.state().effectiveRevision,
+            validation: candidate.validation,
+          };
+        }
+        throw new PackUpgradeRequiredError(existing.name);
+      }
+      return this.applyCandidate("installed", candidate, undefined);
+    });
+  }
+
+  async upgrade(prepared: PreparedPack): Promise<InstallResult> {
+    const candidate = this.prepareCandidate(prepared);
+    return withMutationLock(this.root, async () => {
+      await this.reloadManifest();
+      const existing = this.manifest.packs.find((pack) => pack.name === prepared.input.pack.name);
+      if (existing === undefined) {
+        throw new PackNotInstalledError(prepared.input.pack.name);
+      }
       if (existing.artifactDigest === candidate.artifactDigest) {
         return {
           kind: "unchanged",
@@ -128,57 +155,42 @@ export class LocalStore {
           validation: candidate.validation,
         };
       }
-      throw new PackUpgradeRequiredError(existing.name);
-    }
-    return this.applyCandidate("installed", candidate, undefined);
-  }
-
-  async upgrade(prepared: PreparedPack): Promise<InstallResult> {
-    const candidate = this.prepareCandidate(prepared);
-    const existing = this.manifest.packs.find((pack) => pack.name === prepared.input.pack.name);
-    if (existing === undefined) {
-      throw new PackNotInstalledError(prepared.input.pack.name);
-    }
-    if (existing.artifactDigest === candidate.artifactDigest) {
-      return {
-        kind: "unchanged",
-        pack: existing,
-        effectiveRevision: this.repository.state().effectiveRevision,
-        validation: candidate.validation,
-      };
-    }
-    return this.applyCandidate("upgraded", candidate, existing);
+      return this.applyCandidate("upgraded", candidate, existing);
+    });
   }
 
   async uninstall(packName: string): Promise<UninstallResult> {
-    const existing = this.manifest.packs.find((pack) => pack.name === packName);
-    if (existing === undefined) throw new PackNotInstalledError(packName);
+    return withMutationLock(this.root, async () => {
+      await this.reloadManifest();
+      const existing = this.manifest.packs.find((pack) => pack.name === packName);
+      if (existing === undefined) throw new PackNotInstalledError(packName);
 
-    const oldSources = this.repository.sourcesForPack(packName);
-    const affectedPracticeIds = new Set(oldSources.map((source) => source.practice_id));
-    const nextManifest = this.nextManifest(
-      this.manifest.packs.filter((pack) => pack.name !== packName),
-    );
+      const oldSources = this.repository.sourcesForPack(packName);
+      const affectedPracticeIds = new Set(oldSources.map((source) => source.practice_id));
+      const nextManifest = this.nextManifest(
+        this.manifest.packs.filter((pack) => pack.name !== packName),
+      );
 
-    await writeManifest(this.root, nextManifest);
-    const nextRevision = this.database.transaction(() => {
-      const currentState = this.repository.state();
-      this.repository.deletePack(packName);
-      const effectiveChanged = this.reconcileEffectivePractices(affectedPracticeIds, new Map());
-      const state = {
-        installedPacksGeneration: nextManifest.generation,
-        effectiveRevision: currentState.effectiveRevision + (effectiveChanged ? 1 : 0),
-      };
-      if (effectiveChanged) {
-        this.rewriteChangedEffectiveRevisions(affectedPracticeIds, state.effectiveRevision);
-      }
-      this.repository.setState(state);
-      return state.effectiveRevision;
+      await writeManifest(this.root, nextManifest);
+      const nextRevision = this.database.transaction(() => {
+        const currentState = this.repository.state();
+        this.repository.deletePack(packName);
+        const effectiveChanged = this.reconcileEffectivePractices(affectedPracticeIds, new Map());
+        const state = {
+          installedPacksGeneration: nextManifest.generation,
+          effectiveRevision: currentState.effectiveRevision + (effectiveChanged ? 1 : 0),
+        };
+        if (effectiveChanged) {
+          this.rewriteChangedEffectiveRevisions(affectedPracticeIds, state.effectiveRevision);
+        }
+        this.repository.setState(state);
+        return state.effectiveRevision;
+      });
+
+      this.manifest = nextManifest;
+      await removeArtifact(this.root, existing.storageKey, existing.artifactDigest);
+      return { packName, effectiveRevision: nextRevision };
     });
-
-    this.manifest = nextManifest;
-    await removeArtifact(this.root, existing.storageKey, existing.artifactDigest);
-    return { packName, effectiveRevision: nextRevision };
   }
 
   private prepareCandidate(prepared: PreparedPack): PackCandidate {
@@ -247,6 +259,7 @@ export class LocalStore {
     };
 
     try {
+      await this.assertSnapshotMatchesCandidate(candidate, staged.directory);
       await promoteArtifact(this.root, staged, pack.storageKey, pack.artifactDigest);
       const nextManifest = this.nextManifest([
         ...this.manifest.packs.filter((entry) => entry.name !== pack.name),
@@ -301,6 +314,66 @@ export class LocalStore {
     } catch (error: unknown) {
       await discardStagedArtifact(this.root, staged);
       throw error;
+    }
+  }
+
+  private async reloadManifest(): Promise<void> {
+    const manifest = await loadManifest(this.root);
+    const state = this.repository.state();
+    if (state.installedPacksGeneration !== manifest.generation) {
+      throw new StoreInvariantError(
+        `SQLite generation ${state.installedPacksGeneration} does not match manifest generation ${manifest.generation}`,
+      );
+    }
+    this.manifest = manifest;
+  }
+
+  private async assertSnapshotMatchesCandidate(
+    candidate: PackCandidate,
+    artifactDirectory: string,
+  ): Promise<void> {
+    const decoded = await this.snapshotCodec.decode(artifactDirectory);
+    const validation = validatePack(decoded.input);
+    if (!validation.valid) {
+      throw new InvalidPreparedPackError("Snapshot codec decoded an invalid Pack");
+    }
+    if (
+      decoded.input.pack.name !== candidate.prepared.input.pack.name ||
+      decoded.input.pack.version !== candidate.prepared.input.pack.version
+    ) {
+      throw new InvalidPreparedPackError(
+        "Snapshot pack metadata does not match the validated Pack",
+      );
+    }
+    if (!sameDecisions(decoded.input.decisions, candidate.prepared.input.decisions)) {
+      throw new InvalidPreparedPackError("Snapshot decisions do not match the validated Pack");
+    }
+
+    const decodedPractices = new Map(
+      decoded.input.practices.map((practice) => [practice.id, practice]),
+    );
+    if (decodedPractices.size !== candidate.practices.length) {
+      throw new InvalidPreparedPackError("Snapshot Practices do not match the validated Pack");
+    }
+    for (const candidatePractice of candidate.practices) {
+      const decodedPractice = decodedPractices.get(candidatePractice.practice.id);
+      if (
+        decodedPractice === undefined ||
+        canonicalContent(decodedPractice) !== candidatePractice.canonicalContent
+      ) {
+        throw new InvalidPreparedPackError(
+          `Snapshot Practice "${candidatePractice.practice.id}" does not match the validated Pack`,
+        );
+      }
+      const decodedSourcePath = decoded.practiceSourcePaths.get(candidatePractice.practice.id);
+      if (
+        decodedSourcePath === undefined ||
+        normalizeSnapshotPath(decodedSourcePath) !== candidatePractice.sourcePath
+      ) {
+        throw new InvalidPreparedPackError(
+          `Snapshot source path for Practice "${candidatePractice.practice.id}" does not match`,
+        );
+      }
     }
   }
 
@@ -387,4 +460,19 @@ export class LocalStore {
       packs: [...packs].sort((left, right) => left.name.localeCompare(right.name)),
     };
   }
+}
+
+function sameDecisions(left: unknown, right: unknown): boolean {
+  return canonicalJson(left) === canonicalJson(right);
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`;
 }

--- a/packages/engine/src/local-store/manifest.ts
+++ b/packages/engine/src/local-store/manifest.ts
@@ -1,0 +1,97 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { StoreInvariantError } from "./errors";
+import type { InstalledPack, StorageRoot } from "./types";
+
+const MANIFEST_SCHEMA_VERSION = 1;
+const MANIFEST_FILE = "installed-packs.json";
+
+export interface InstalledPacksManifest {
+  readonly schemaVersion: number;
+  readonly generation: number;
+  readonly packs: readonly InstalledPack[];
+}
+
+export function emptyManifest(): InstalledPacksManifest {
+  return { schemaVersion: MANIFEST_SCHEMA_VERSION, generation: 0, packs: [] };
+}
+
+export function manifestPath(root: StorageRoot): string {
+  return join(root.path, MANIFEST_FILE);
+}
+
+function isInstalledPack(value: unknown): value is InstalledPack {
+  if (value === null || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.name === "string" &&
+    typeof record.version === "string" &&
+    typeof record.artifactDigest === "string" &&
+    typeof record.storageKey === "string" &&
+    typeof record.installedAt === "string"
+  );
+}
+
+function parseManifest(value: unknown): InstalledPacksManifest {
+  if (value === null || typeof value !== "object") {
+    throw new StoreInvariantError("Installed-pack manifest is not an object");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.schemaVersion !== MANIFEST_SCHEMA_VERSION ||
+    typeof record.generation !== "number" ||
+    !Number.isSafeInteger(record.generation) ||
+    record.generation < 0 ||
+    !Array.isArray(record.packs) ||
+    !record.packs.every(isInstalledPack)
+  ) {
+    throw new StoreInvariantError("Installed-pack manifest has an unsupported shape");
+  }
+
+  const names = new Set<string>();
+  for (const pack of record.packs) {
+    if (names.has(pack.name)) {
+      throw new StoreInvariantError(
+        `Installed-pack manifest contains duplicate pack "${pack.name}"`,
+      );
+    }
+    names.add(pack.name);
+  }
+
+  return {
+    schemaVersion: record.schemaVersion,
+    generation: record.generation,
+    packs: [...record.packs].sort((left, right) => left.name.localeCompare(right.name)),
+  };
+}
+
+export async function loadManifest(root: StorageRoot): Promise<InstalledPacksManifest> {
+  try {
+    const content = await readFile(manifestPath(root), "utf8");
+    return parseManifest(JSON.parse(content) as unknown);
+  } catch (error: unknown) {
+    if (isNodeError(error, "ENOENT")) return emptyManifest();
+    if (error instanceof StoreInvariantError) throw error;
+    throw new StoreInvariantError(`Unable to read installed-pack manifest: ${errorMessage(error)}`);
+  }
+}
+
+export async function writeManifest(
+  root: StorageRoot,
+  manifest: InstalledPacksManifest,
+): Promise<void> {
+  const path = manifestPath(root);
+  await mkdir(root.path, { recursive: true });
+  const temporaryPath = `${path}.${crypto.randomUUID()}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  await rename(temporaryPath, path);
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/engine/src/local-store/migrations.ts
+++ b/packages/engine/src/local-store/migrations.ts
@@ -1,0 +1,75 @@
+import type { Database } from "bun:sqlite";
+
+import { StoreInvariantError } from "./errors";
+
+export const LOCAL_STORE_SCHEMA_VERSION = 1;
+
+export function migrateDatabase(database: Database): void {
+  database.exec("PRAGMA foreign_keys = ON");
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS store_metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS active_packs (
+      pack_name TEXT PRIMARY KEY,
+      pack_version TEXT NOT NULL,
+      artifact_digest TEXT NOT NULL,
+      storage_key TEXT NOT NULL,
+      installed_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS practice_sources (
+      pack_name TEXT NOT NULL REFERENCES active_packs(pack_name) ON DELETE CASCADE,
+      practice_id TEXT NOT NULL,
+      content_digest TEXT NOT NULL,
+      source_path TEXT NOT NULL,
+      PRIMARY KEY (pack_name, practice_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS effective_practices (
+      practice_id TEXT PRIMARY KEY,
+      content_digest TEXT NOT NULL,
+      canonical_content TEXT NOT NULL,
+      title TEXT NOT NULL,
+      stage TEXT NOT NULL,
+      tech_stack_json TEXT NOT NULL,
+      applies_when TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      body TEXT NOT NULL,
+      anti_patterns_json TEXT NOT NULL,
+      effective_revision INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS practice_sources_practice_id
+      ON practice_sources(practice_id);
+  `);
+
+  const schemaVersion = metadataValue(database, "schema_version");
+  if (schemaVersion === null) {
+    setMetadata(database, "schema_version", String(LOCAL_STORE_SCHEMA_VERSION));
+    setMetadata(database, "installed_packs_generation", "0");
+    setMetadata(database, "effective_revision", "0");
+    return;
+  }
+
+  if (schemaVersion !== String(LOCAL_STORE_SCHEMA_VERSION)) {
+    throw new StoreInvariantError(`Unsupported LocalStore schema version "${schemaVersion}"`);
+  }
+}
+
+function metadataValue(database: Database, key: string): string | null {
+  const row = database
+    .query<{ value: string }, [string]>("SELECT value FROM store_metadata WHERE key = ?")
+    .get(key);
+  return row?.value ?? null;
+}
+
+function setMetadata(database: Database, key: string, value: string): void {
+  database
+    .query<unknown, [string, string]>(
+      "INSERT INTO store_metadata(key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .run(key, value);
+}

--- a/packages/engine/src/local-store/mutation-lock.ts
+++ b/packages/engine/src/local-store/mutation-lock.ts
@@ -1,0 +1,49 @@
+import { mkdir, open, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { StoreBusyError } from "./errors";
+import type { StorageRoot } from "./types";
+
+const LOCK_FILE = "mutation.lock";
+const RETRY_DELAY_MS = 10;
+const MAX_ATTEMPTS = 500;
+
+export async function withMutationLock<T>(
+  root: StorageRoot,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const lockPath = join(root.path, LOCK_FILE);
+  const handle = await acquireMutationLock(root, lockPath);
+  try {
+    return await operation();
+  } finally {
+    await handle.close();
+    await rm(lockPath, { force: true });
+  }
+}
+
+async function acquireMutationLock(
+  root: StorageRoot,
+  lockPath: string,
+  attempt = 0,
+): Promise<Awaited<ReturnType<typeof open>>> {
+  await mkdir(root.path, { recursive: true });
+  try {
+    return await open(lockPath, "wx");
+  } catch (error: unknown) {
+    if (!isNodeError(error, "EEXIST")) throw error;
+    if (attempt + 1 >= MAX_ATTEMPTS) {
+      throw new StoreBusyError(lockPath);
+    }
+    await delay(RETRY_DELAY_MS);
+    return acquireMutationLock(root, lockPath, attempt + 1);
+  }
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === code;
+}

--- a/packages/engine/src/local-store/repositories.ts
+++ b/packages/engine/src/local-store/repositories.ts
@@ -1,0 +1,239 @@
+import type { Database } from "bun:sqlite";
+
+import type { AntiPattern, Practice } from "@lorelum/format";
+
+import type { InstalledPack, EffectivePractice, LocalStoreState } from "./types";
+
+interface SourceRow {
+  readonly pack_name: string;
+  readonly practice_id: string;
+  readonly content_digest: string;
+  readonly source_path: string;
+}
+
+interface EffectivePracticeRow {
+  readonly practice_id: string;
+  readonly content_digest: string;
+  readonly canonical_content: string;
+  readonly title: string;
+  readonly stage: string;
+  readonly tech_stack_json: string;
+  readonly applies_when: string;
+  readonly severity: NonNullable<Practice["severity"]>;
+  readonly body: string;
+  readonly anti_patterns_json: string;
+  readonly effective_revision: number;
+}
+
+interface ActivePackRow {
+  readonly pack_name: string;
+  readonly pack_version: string;
+  readonly artifact_digest: string;
+  readonly storage_key: string;
+  readonly installed_at: string;
+}
+
+export class LocalStoreRepository {
+  constructor(private readonly database: Database) {}
+
+  state(): LocalStoreState {
+    return {
+      installedPacksGeneration: this.metadataNumber("installed_packs_generation"),
+      effectiveRevision: this.metadataNumber("effective_revision"),
+    };
+  }
+
+  installedPack(name: string): InstalledPack | null {
+    const row = this.database
+      .query<ActivePackRow, [string]>(
+        `SELECT pack_name, pack_version, artifact_digest, storage_key, installed_at
+         FROM active_packs WHERE pack_name = ?`,
+      )
+      .get(name);
+    return row === null ? null : toInstalledPack(row);
+  }
+
+  allInstalledPacks(): readonly InstalledPack[] {
+    return this.database
+      .query<ActivePackRow, []>(
+        `SELECT pack_name, pack_version, artifact_digest, storage_key, installed_at
+         FROM active_packs ORDER BY pack_name`,
+      )
+      .all()
+      .map(toInstalledPack);
+  }
+
+  sourcesForPractice(practiceId: string): readonly SourceRow[] {
+    return this.database
+      .query<SourceRow, [string]>(
+        `SELECT pack_name, practice_id, content_digest, source_path
+         FROM practice_sources WHERE practice_id = ? ORDER BY pack_name`,
+      )
+      .all(practiceId);
+  }
+
+  sourcesForPack(packName: string): readonly SourceRow[] {
+    return this.database
+      .query<SourceRow, [string]>(
+        `SELECT pack_name, practice_id, content_digest, source_path
+         FROM practice_sources WHERE pack_name = ? ORDER BY practice_id`,
+      )
+      .all(packName);
+  }
+
+  effectivePractice(practiceId: string): EffectivePractice | null {
+    const row = this.database
+      .query<EffectivePracticeRow, [string]>(
+        `SELECT practice_id, content_digest, canonical_content, title, stage, tech_stack_json,
+                applies_when, severity, body, anti_patterns_json, effective_revision
+         FROM effective_practices WHERE practice_id = ?`,
+      )
+      .get(practiceId);
+    return row === null ? null : this.toEffectivePractice(row);
+  }
+
+  allEffectivePractices(): readonly EffectivePractice[] {
+    return this.database
+      .query<EffectivePracticeRow, []>(
+        `SELECT practice_id, content_digest, canonical_content, title, stage, tech_stack_json,
+                applies_when, severity, body, anti_patterns_json, effective_revision
+         FROM effective_practices ORDER BY practice_id`,
+      )
+      .all()
+      .map((row) => this.toEffectivePractice(row));
+  }
+
+  deletePack(packName: string): void {
+    this.database
+      .query<unknown, [string]>("DELETE FROM active_packs WHERE pack_name = ?")
+      .run(packName);
+  }
+
+  savePack(pack: InstalledPack): void {
+    this.database
+      .query<unknown, [string, string, string, string, string]>(
+        `INSERT INTO active_packs(pack_name, pack_version, artifact_digest, storage_key, installed_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(pack_name) DO UPDATE SET
+           pack_version = excluded.pack_version,
+           artifact_digest = excluded.artifact_digest,
+           storage_key = excluded.storage_key,
+           installed_at = excluded.installed_at`,
+      )
+      .run(pack.name, pack.version, pack.artifactDigest, pack.storageKey, pack.installedAt);
+  }
+
+  addSource(packName: string, practiceId: string, contentDigest: string, sourcePath: string): void {
+    this.database
+      .query<unknown, [string, string, string, string]>(
+        `INSERT INTO practice_sources(pack_name, practice_id, content_digest, source_path)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(packName, practiceId, contentDigest, sourcePath);
+  }
+
+  deleteSourcesForPack(packName: string): void {
+    this.database
+      .query<unknown, [string]>("DELETE FROM practice_sources WHERE pack_name = ?")
+      .run(packName);
+  }
+
+  saveEffectivePractice(
+    practice: Practice,
+    canonicalContent: string,
+    contentDigest: string,
+    effectiveRevision: number,
+  ): void {
+    this.database
+      .query<
+        unknown,
+        [string, string, string, string, string, string, string, string, string, string, number]
+      >(
+        `INSERT INTO effective_practices(
+           practice_id, content_digest, canonical_content, title, stage, tech_stack_json,
+           applies_when, severity, body, anti_patterns_json, effective_revision
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(practice_id) DO UPDATE SET
+           content_digest = excluded.content_digest,
+           canonical_content = excluded.canonical_content,
+           title = excluded.title,
+           stage = excluded.stage,
+           tech_stack_json = excluded.tech_stack_json,
+           applies_when = excluded.applies_when,
+           severity = excluded.severity,
+           body = excluded.body,
+           anti_patterns_json = excluded.anti_patterns_json,
+           effective_revision = excluded.effective_revision`,
+      )
+      .run(
+        practice.id,
+        contentDigest,
+        canonicalContent,
+        practice.title,
+        practice.stage,
+        JSON.stringify(practice.tech_stack),
+        practice.applies_when,
+        practice.severity ?? "warn",
+        practice.body ?? "",
+        JSON.stringify(practice.anti_patterns ?? []),
+        effectiveRevision,
+      );
+  }
+
+  deleteEffectivePractice(practiceId: string): void {
+    this.database
+      .query<unknown, [string]>("DELETE FROM effective_practices WHERE practice_id = ?")
+      .run(practiceId);
+  }
+
+  setState(state: LocalStoreState): void {
+    this.setMetadata("installed_packs_generation", String(state.installedPacksGeneration));
+    this.setMetadata("effective_revision", String(state.effectiveRevision));
+  }
+
+  private toEffectivePractice(row: EffectivePracticeRow): EffectivePractice {
+    const sourcePackNames = this.sourcesForPractice(row.practice_id).map(
+      (source) => source.pack_name,
+    );
+    return {
+      id: row.practice_id,
+      title: row.title,
+      stage: row.stage,
+      techStack: JSON.parse(row.tech_stack_json) as string[],
+      appliesWhen: row.applies_when,
+      severity: row.severity,
+      body: row.body,
+      antiPatterns: JSON.parse(row.anti_patterns_json) as AntiPattern[],
+      canonicalContent: row.canonical_content,
+      contentDigest: row.content_digest,
+      effectiveRevision: row.effective_revision,
+      sourcePackNames,
+    };
+  }
+
+  private metadataNumber(key: string): number {
+    const row = this.database
+      .query<{ value: string }, [string]>("SELECT value FROM store_metadata WHERE key = ?")
+      .get(key);
+    return Number(row?.value ?? "0");
+  }
+
+  private setMetadata(key: string, value: string): void {
+    this.database
+      .query<unknown, [string, string]>(
+        `INSERT INTO store_metadata(key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      )
+      .run(key, value);
+  }
+}
+
+function toInstalledPack(row: ActivePackRow): InstalledPack {
+  return {
+    name: row.pack_name,
+    version: row.pack_version,
+    artifactDigest: row.artifact_digest,
+    storageKey: row.storage_key,
+    installedAt: row.installed_at,
+  };
+}

--- a/packages/engine/src/local-store/types.ts
+++ b/packages/engine/src/local-store/types.ts
@@ -49,6 +49,11 @@ export interface LocalStoreState {
 
 export interface LocalStoreOpenOptions {
   readonly root?: StorageRoot;
+  /**
+   * Decodes the immutable snapshot representation. LocalStore verifies that
+   * the decoded snapshot matches the validated input before publishing it.
+   */
+  readonly snapshotCodec: SnapshotCodec;
 }
 
 export interface InstallResult {

--- a/packages/engine/src/local-store/types.ts
+++ b/packages/engine/src/local-store/types.ts
@@ -1,0 +1,64 @@
+import type { AntiPattern, PackInput, Practice, ValidationReport } from "@lorelum/format";
+
+export interface StorageRoot {
+  readonly path: string;
+}
+
+export interface SnapshotFile {
+  readonly relativePath: string;
+  readonly bytes: Uint8Array;
+}
+
+export interface PreparedPack {
+  readonly input: PackInput;
+  readonly files: readonly SnapshotFile[];
+  readonly practiceSourcePaths: ReadonlyMap<string, string>;
+}
+
+export interface SnapshotCodec {
+  decode(artifactDirectory: string): Promise<PreparedPack>;
+}
+
+export interface InstalledPack {
+  readonly name: string;
+  readonly version: string;
+  readonly artifactDigest: string;
+  readonly storageKey: string;
+  readonly installedAt: string;
+}
+
+export interface EffectivePractice {
+  readonly id: string;
+  readonly title: string;
+  readonly stage: string;
+  readonly techStack: readonly string[];
+  readonly appliesWhen: string;
+  readonly severity: NonNullable<Practice["severity"]>;
+  readonly body: string;
+  readonly antiPatterns: readonly AntiPattern[];
+  readonly canonicalContent: string;
+  readonly contentDigest: string;
+  readonly effectiveRevision: number;
+  readonly sourcePackNames: readonly string[];
+}
+
+export interface LocalStoreState {
+  readonly installedPacksGeneration: number;
+  readonly effectiveRevision: number;
+}
+
+export interface LocalStoreOpenOptions {
+  readonly root?: StorageRoot;
+}
+
+export interface InstallResult {
+  readonly kind: "installed" | "upgraded" | "unchanged";
+  readonly pack: InstalledPack;
+  readonly effectiveRevision: number;
+  readonly validation: ValidationReport;
+}
+
+export interface UninstallResult {
+  readonly packName: string;
+  readonly effectiveRevision: number;
+}


### PR DESCRIPTION
## Summary

Implements PR 1 of the `@lorelum/engine` LocalStore lifecycle. Validated Packs persist as immutable artifacts with an active manifest; SQLite materializes Active Pack, Practice Source, Effective Practice, and `effectiveRevision` state.

The lifecycle supports install, digest-idempotent install, explicit upgrade, uninstall, source merging for identical Practice content, and deterministic rejection of same-id content conflicts. It consumes `@lorelum/format` validation without changing the public format contract.

Decision records:
- Finalized Feishu design: https://jcnv104g7m1c.feishu.cn/wiki/UgRGwhGsii1a05kzV9Ics30DnNb
- Implementation plan: https://jcnv104g7m1c.feishu.cn/wiki/QwwywYQsHiSOfSkeygZc8irknTb
- ADR 0007: `docs/adr/0007-local-practice-store.md`

This PR intentionally excludes operation journaling, crash recovery, reindex, full corruption recovery, vector indexing, embedding, and semantic query. Those belong to the planned PR 2 / vector-index work.

This replaces closed PR #16, which GitHub automatically closed when its fork head branch was renamed.

## Linked issue

Closes #15

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Docs only
- [ ] Refactor / chore

## How was this tested?

- `bun run lint` - passed
- `bun run typecheck` - passed
- `bun test` - 119 passed, 0 failed
- `bunx --no-install oxfmt --check docs/adr/0007-local-practice-store.md packages/engine/src/index.ts packages/engine/src/local-store` - passed
- `bun run fmt:check` - not clean: the pre-existing repository baseline reports 61 unrelated files. No repository-wide formatting was applied.

## Checklist

- [x] Linked the issue this closes (`Closes #15`)
- [x] Product behavior design was finalized in Feishu and recorded in ADR 0007
- [x] Added tests for the new lifecycle behavior
- [x] Lint, type-check, and tests pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private information in the diff

## AI assistance

- [x] Parts of this PR were generated or assisted by an AI tool
- [x] I have reviewed every line of the AI-generated code and take full responsibility for it

## Notes for reviewers

- Review the canonical-content/digest boundary and the same-id conflict rule; `title` is never an identity key.
- Review `effectiveRevision`: it changes only when the effective Practice set or effective content changes, not for an additional identical source.
- Manifest publication and SQLite state are not journaled in this PR. PR 2 will add fail-closed recovery and reindex rather than treating this PR as crash-recoverable.