### PR TITLE
feat(engine): add LocalStore storage foundation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
       "dependencies": {
         "@lorelum/shared": "workspace:*",
         "gray-matter": "4.0.3",
-        "js-yaml": "3.14.2",
+        "js-yaml": "4.3.1",
         "zod": "4.4.3",
       },
       "devDependencies": {
@@ -61,7 +61,7 @@
     },
   },
   "overrides": {
-    "js-yaml": "3.14.2",
+    "js-yaml": "4.3.1",
   },
   "packages": {
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
@@ -166,7 +166,7 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
@@ -209,8 +209,6 @@
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
-
-    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
@@ -268,7 +266,7 @@
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
-    "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -343,8 +341,6 @@
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
-
-    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,11 @@
       "dependencies": {
         "@lorelum/shared": "workspace:*",
         "gray-matter": "4.0.3",
+        "js-yaml": "3.14.2",
         "zod": "4.4.3",
+      },
+      "devDependencies": {
+        "@types/js-yaml": "4.0.9",
       },
     },
     "packages/mcp": {
@@ -151,6 +155,8 @@
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.74.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA=="],
 
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 

--- a/docs/adr/0007-engine-local-store.md
+++ b/docs/adr/0007-engine-local-store.md
@@ -1,0 +1,240 @@
+# ADR 0007: Engine LocalStore storage & lifecycle contract
+
+- **Date:** 2026-07-27
+- **Status:** Accepted
+- **Related:** ADR 0002 (`bun:sqlite` is the local store), ADR 0003 (Practice/Pack fields and validation the store consumes). Internal docs (Lorelum wiki, "技术规范" section): "定稿：本地 Practice 索引与存储 v1" and "实施计划（重写版）：@lorelum/engine LocalStore".
+
+## Context
+
+`@lorelum/engine` must persist installed Knowledge Packs locally and answer `lore query/get/decide/check` without a network round-trip. ADR 0002 already committed the medium (`bun:sqlite`, no native addons) and ADR 0003 froze the Practice/Pack fields the store consumes. What was **not** frozen is the LocalStore's own contract: the on-disk layout, the SQLite entities, the rules for merging Practices that come from different packs, the meaning of the version counter that coordinates the store with the (not-yet-built) vector layer, and the recovery invariants when SQLite and the filesystem disagree.
+
+The "定稿：本地 Practice 索引与存储 v1" doc specifies the intent; this ADR freezes the _contract_ into immutable repo history before code lands. It also resolves four gaps the doc left open, each of which would otherwise force a guess during implementation:
+
+1. **Where is `effectiveRevision` durably recorded?** The doc stored it only in SQLite, but SQLite can corrupt — and the doc simultaneously requires `reindex` to produce a monotonically increasing revision. With the only source of the counter inside SQLite, a corrupt DB breaks the monotonic guarantee. The doc's own reindex rule ("always produces a new revision") needs an independent recovery fact.
+2. **What exactly is `canonicalContent`, byte-for-byte?** It is the input to `contentDigest`, and `contentDigest` is the merge/conflict key (same digest → mergeable; different digest → `PracticeConflictError`). So the canonicalization must be reproducible and unambiguous. The doc fixed object field order and LF line endings but left the serialization format, array ordering, and which anti-pattern fields participate unspecified.
+3. **What is `storageKey`?** The doc requires it be a "deterministic filesystem-safe encoding" of `pack.name`, but `pack.name` is already constrained to `[a-z0-9-]+` by ADR 0003 — so whether an extra encoding pass is needed was unclear.
+4. **Where does LocalStore end and the vector layer begin?** The doc repeatedly has LocalStore write the vector layer's `building` index state and "call the vector layer" inside its own SQLite transaction. But the vector layer (VectorIndex, embeddings, Float32 BLOB, query) is a separate non-goal of this task. Without an explicit seam, an implementation would either invade the non-goal or silently violate the doc.
+
+Finally, the doc and the "实施计划（重写版）" doc referenced "ADR 0007" and "ADR-005" before this ADR existed; this ADR is that referenced artifact, numbered to match the planning docs rather than the strict 0004-next sequence.
+
+## Decision
+
+The "定稿：本地 Practice 索引与存储 v1" doc is the normative specification. This ADR ratifies it as the frozen contract and pins the four open points below. Where this ADR and the doc disagree, **this ADR's §1–§4 govern**, and the doc is updated to match (see the change list in the References/follow-up).
+
+### 0. Scope (ratified from the doc)
+
+LocalStore owns: the user-level storage root (`~/.lorelum/`), immutable Pack snapshots, the active Pack manifest, the operation journal, the SQLite-derived LocalStore state, Practice canonicalization/digest, source merge and conflict rules, `effectiveRevision` allocation/persistence/read, `install`/`upgrade`/`uninstall`, cold open, recovery, and `reindex`.
+
+LocalStore does **not** own: VectorIndex, embedding providers, vector tables, Float32 BLOBs, sqlite-vec/LanceDB, ANN, in-memory vector snapshots, or semantic query. The vector layer will consume LocalStore's Effective Practice output and `effectiveRevision` and must not re-parse Packs or re-adjudicate source conflicts. Pack-to-pack dependencies are not supported in v1.
+
+### 1. `effectiveRevision` recovery source — written to the active manifest
+
+`effectiveRevision` is recorded in **two** places, with the manifest as the authoritative recovery fact:
+
+- **Active manifest (`installed-packs.json`)** gains a top-level `effectiveRevision: number` field, alongside the existing `schemaVersion` and `generation`. This is the recovery source of truth.
+- **SQLite store metadata** keeps a derived `effectiveRevision` copy (§3.1) for transactional consistency on the read/write path.
+
+Increment rules (frozen):
+
+- A normal mutation (`install`/`upgrade`/`uninstall`) increments `effectiveRevision` **iff** the Effective Practice _set_ changes or an existing Practice's _effective content_ changes.
+- Adding or removing a source whose content is identical to what is already effective does **not** increment (it only adjusts source rows).
+- A successful `reindex` **always** produces a new `effectiveRevision`.
+- **Generation coupling:** `generation` increments on **any** active-manifest content change — including a reindex that only changes `effectiveRevision`. A reindex is a manifest mutation: it bumps `generation` _and_ `effectiveRevision` together. SQLite metadata carries both `installedPacksGeneration` and `effectiveRevision` as derived copies, and the two move together atomically in the manifest.
+
+- On recovery, the journal records a `(oldGeneration, targetGeneration, oldEffectiveRevision, targetEffectiveRevision)` tuple, and recovery compares **both** fields: see §8 for the full state machine. (The earlier rule "manifest wins, then reindex issues a fresh revision" is superseded by §8's explicit generation+revision comparison; generation alone can mask a stale revision.)
+
+_Why both places:_ SQLite alone cannot guarantee monotonicity after corruption (the very failure mode `reindex` exists for). The manifest is already an atomic-rename, corruption-recoverable artifact. Storing the counter there costs one integer and removes the gap. _Rejected:_ storing it only in SQLite (doc's original form — fails the recovery invariant); storing it only in the manifest (then every read path pays a manifest parse and loses SQLite's transactional read consistency).
+
+### 2. `canonicalContent` and `contentDigest` — exact serialization
+
+`canonicalContent` is a UTF-8 string produced by `JSON.stringify` over an object with **fixed key order**, LF line endings applied to any multiline text fields, and severity defaults expanded. The canonical object is:
+
+```jsonc
+{
+  "id": "<string>",
+  "title": "<string>",
+  "stage": "<string>",
+  "tech_stack": ["<string>", "..."],   // author's original array order, preserved as-is
+  "applies_when": "<string>",
+  "severity": "info" | "warn" | "critical",  // if absent on input, default "warn"
+  "body": "<string | ''>",              // absent on input → ""
+  "anti_patterns": [                    // author's original order, preserved as-is
+    { "id": "<string>", "name": "<string>", "description": "<string>", "severity": "info"|"warn"|"critical" }
+    // `check` is EXCLUDED — reserved, format undefined in v1 (ADR 0003 §6)
+  ]
+}
+```
+
+`contentDigest` = `SHA-256(canonicalContent)` as a lowercase hex string. Two Practices with equal `contentDigest` are considered to carry identical content (mergeable).
+
+Frozen choices and why:
+
+- **JSON (stable key order), not YAML or a custom text format.** JSON serialization is deterministic and cheaply comparable; ADR 0003 already treats the Practice as structured data. `JSON.stringify` with a fixed insertion order is reproducible across processes.
+- **Author's original `tech_stack` and `anti_patterns` order preserved.** Sorting would change digests retroactively and give no benefit; the order is part of what the author wrote. (Object _key_ order is fixed by this ADR; _array_ order is the author's.)
+- **`severity` default `"warn"` injected here**, matching ADR 0003's spec default. This is why `@lorelum/format`'s schema deliberately has _no_ default (it must surface "author omitted severity" as a validate warning) — canonicalization is the consumer that injects the default. _This is the canonicalizer's responsibility, living in `model/canonical-practice.ts`._
+- **`body` absent → `""`.** An empty body is still distinct from no body at the schema level, but for digest purposes both canonicalize to an empty string (an author who omits guidance and one who writes nothing are indistinguishable to retrieval).
+- **`anti_patterns[].check` excluded.** ADR 0003 leaves `check` undefined in v1; including an unknown-shaped field in the digest would make digests unstable if the field's representation changes. Excluding it keeps v1 digests forward-compatible.
+
+### 3. SQLite data contract (ratified field-for-field from the doc §3)
+
+Implementation SQL table names may differ; the entities, fields, and uniqueness constraints below are the v1 contract.
+
+- **3.1 Store metadata** — `schemaVersion` (LocalStore schema version), `installedPacksGeneration` (the active-manifest `generation` applied to SQLite), `effectiveRevision` (derived copy; the manifest is authoritative — see §1).
+- **3.2 Active Pack** — `packName` (unique; = `pack.yaml.name`), `packVersion`, `artifactDigest`, `storageKey`, `installedAt`. `(packName, artifactDigest)` must match an active-manifest entry.
+- **3.3 Practice source** — `packName`, `practiceId` (composite key, `(packName, practiceId)` unique), `contentDigest` (SHA-256 of this source's canonical content), `sourcePath` (relative to the Pack snapshot, for diagnostics and rebuild verification).
+- **3.4 Effective Practice** — `practiceId` (unique), `contentDigest` (current effective content digest), `canonicalContent` + retrieval metadata (materialized from the verified Practice parse), `effectiveRevision` (the revision this record was written under).
+
+The **read path** uses a single, deterministically ordered SQL statement that returns Effective Practice rows joined with their source rows, materialized in memory grouped by `practiceId`. Both the public read API and the cold-open verifier use the same materializer. **No N+1 queries** (read effective row, then per-practice source lookup) — this was a defect in the prior abandoned implementation.
+
+### 4. Vector layer seam — LocalStore does not write vector state
+
+This ADR clarifies the boundary the doc left ambiguous:
+
+- LocalStore owns **its own SQLite tables only** (§3.1–§3.4). It does **not** write the vector layer's `profile` / `vector record` / `binding` / index-`status` tables, and it does not perform or await embedding.
+- `install`/`upgrade`/`uninstall` commit LocalStore state in one SQLite transaction. The increment of `effectiveRevision` happens in that transaction (§1). On commit, LocalStore invokes a **pluggable hook** (default: no-op) that the future vector layer will implement to receive `(newRevision, delta: { added, changed, invalidated })`. The hook is invoked **after** the transaction commits, never inside it.
+- For this task (LocalStore only), install/upgrade/uninstall return success based on **LocalStore commit** alone. The doc's rule "CLI returns success only when the semantic index reaches the target `ready` revision" is **deferred** to the task that implements the vector layer; until then, LocalStore's own success/failure is the whole truth. This is recorded so a future PR does not need to re-litigate it.
+
+_Why not write vector state in the LocalStore transaction (as the doc literally said):_ the vector layer is an explicit non-goal of this task, embedding calls must not run inside a SQLite write transaction (the vector doc requires this), and coupling the two layers' writes would re-introduce the "half-installed readable state" defect the doc's journal protocol exists to prevent. A post-commit hook keeps LocalStore the single writer of its own tables while letting the vector layer observe revisions.
+Hook failure and ordering (frozen):
+
+- **Hook failure never rolls back a committed mutation.** The hook runs _after_ the SQLite transaction commits. If it throws or rejects, the LocalStore mutation **stays successful**; the result object carries a `notificationPending` diagnostic (which hook revision failed, the error). This is non-negotiable: the whole point of the post-commit seam is that a future vector-layer outage must not turn a completed install/upgrade/uninstall into a reported failure (the defect the §3.3 GC rule and this ADR exist to prevent). Recovery of a pending notification is the vector layer's concern (`lore reindex` re-emits the delta for the current revision).
+- **Strict serial, in-revision-order delivery.** The hook is invoked serially per LocalStore instance, in monotonically increasing `effectiveRevision` order, never concurrently. A revision's delta is delivered at most once per process; a missed revision (process crash between commit and hook) is recovered by `lore reindex`, which re-derives and re-emits. The vector layer may rely on receiving a contiguous, ordered delta stream — it must not have to de-dupe or reorder.
+- **No-op default means no blocking.** Until the vector layer registers a real hook, the default no-op returns immediately; install/upgrade/uninstall latency is unaffected.
+
+### 5. `storageKey` — `p-${pack.name}`
+
+`storageKey` is the string `` `p-${pack.name}` `` (the literal prefix `p-` followed by `pack.name`). It is **not** `pack.name` verbatim. ADR 0003's `PACK_NAME_REGEX` (`^[a-z0-9]+(-[a-z0-9]+)*$`) admits Windows reserved device names — `con`, `aux`, `nul`, `prn`, `com1`–`com9`, `lpt1`–`lpt9` — which are illegal or behave as devices when used as directory names on Windows, so the earlier "no reserved-name risk" claim does not hold across platforms. The fixed `p-` prefix sidesteps this without touching the public Pack schema (`pack.name` remains the stable install identity and the regex stays unchanged): no value matching `PACK_NAME_REGEX` can equal a Windows reserved name once `p-` is prepended, the mapping is trivially reversible (`pack.name = storageKey.slice(2)`), and the prefix is filesystem-safe on all supported platforms. The manifest carries `storageKey` per entry and the reverse mapping is structural, not a separate index. _Follow-up:_ if `PACK_NAME_REGEX` is widened (e.g. upper case, Unicode), re-validate that `p-` prefixing alone still excludes reserved names and path-traversal; if not, `storageKey` gains a real encoding pass in its own ADR. Rejected alternatives: extending `PACK_NAME_REGEX` to forbid reserved names (changes the public schema every pack author sees, and the reserved set is Windows-specific); percent/hex encoding (reversible but obscures the directory name and gains nothing over a prefix).
+
+### 6. Disk layout and atomicity (ratified from the doc §2)
+
+```
+~/.lorelum/
+  installed-packs.json                     # active manifest (schemaVersion, generation, effectiveRevision, packs[])
+  store.sqlite                             # LocalStore tables + (future) vector layer tables
+  packs/<storageKey>/<artifactDigest>/     # immutable, expanded Pack snapshot + .lorelum/local-store-projection.json
+  staging/<operation-id>/                  # in-progress operation scratch
+  operations/<operation-id>.json           # operation journal
+```
+
+`StorageRoot` must be caller-injectable (default `~/.lorelum/`); tests and CI use an injected root. v1 does not read or create a project-level `.lorelum/`. All file writes use a temp path + atomic rename; no in-place overwrite of an active snapshot or the active manifest. `staging/` and `operations/` are never read by the query path. Directory names never trust an external Pack name directly — they use `storageKey` (`` `p-${pack.name}` ``, §5).
+
+### 7. Merge, conflict, and install/upgrade/uninstall semantics (ratified from the doc §4–§6)
+
+- Practice identity = `practice.id`. Title is not an identity key.
+- Same `practice.id` + same `contentDigest` → establish an additional Practice source; exactly one Effective Practice.
+- Same `practice.id` + different `contentDigest` → reject the install/upgrade with `PracticeConflictError` (carries `practiceId`, candidate pack, conflicting active pack). Not resolved by install order, version, or title.
+- `install` = first install of a not-yet-active `pack.name`. Same `artifactDigest` re-install is idempotent-success, no state change; different `artifactDigest` requires `upgrade`.
+- `upgrade` of a `packName` first removes that pack's current sources from the candidate set before computing conflicts — so only this pack's uniquely-provided Practices can change content; if another active pack still provides the old content, the upgrade must fail on conflict.
+- `uninstall` removes the pack's Practice sources; an Effective Practice is deleted only when it has zero remaining sources. Deleting a non-existent pack returns `PackNotInstalledError` (never silent success).
+
+### 8. Cold open, recovery, reindex (ratified from the doc §7)
+
+- **Cold open** runs schema migration, parses the active manifest, checks SQLite readability/integrity, checks each active artifact exists with a matching digest, and reads the digest-protected projection. It reconciles SQLite's Active Pack / Practice source / Effective Practice against the projection (re-canonicalizing materialized fields and checking they still hash to the stored `contentDigest`). It does **not** scan all Packs, re-parse Practice files, or regenerate embeddings. On any inconsistency it returns `StoreRecoveryRequiredError`.
+- **`lore reindex` is the recovery entry point and bypasses cold open.** It does **not** call the normal `open()` path — cold open refuses a corrupt/missing/inconsistent SQLite with `StoreRecoveryRequiredError`, but `reindex` must succeed _precisely_ in that situation. `reindex` takes the active manifest's Pack snapshots as its only input, re-runs format validation and LocalStore derived-data construction (Active Pack, Practice source, Effective Practice, projection re-canonicalization), generates a fresh `effectiveRevision`, and hands the delta to the vector seam (§4). If `store.sqlite` is missing or corrupt, `reindex` recreates it from scratch (re-run migrations, repopulate all derived tables from the manifest + artifacts); if it is merely inconsistent (wrong generation/revision tuple), `reindex` overwrites the derived state to match the manifest. It verifies re-parsed Pack/Practice/source paths match the sealed projection. It never scans historical artifacts or revives uninstalled packs. If the active manifest, original artifacts, or format validation itself is unavailable, it fails and preserves diagnostics; it must not delete the only remaining recovery source. (Normal `install`/`upgrade`/`uninstall` still go through `open()`; only `reindex` is the bypass.)
+
+- **Operation journal & cross-medium recovery state machine.** The filesystem and SQLite have no shared transaction, so each manifest-mutating operation (`install`/`upgrade`/`uninstall`/`reindex`) writes a journal record carrying `{oldGeneration, targetGeneration, oldEffectiveRevision, targetEffectiveRevision, oldManifest, targetManifest}` before publishing the target manifest. `oldManifest` and `targetManifest` are complete, schema-validated manifest payloads, not deltas; they are the recovery preimage and target image, so rollback never reconstructs a Pack list from tuple values. On success, the operation advances the manifest's `generation` and (if applicable) `effectiveRevision` together. Recovery compares **both** `(generation, effectiveRevision)` from the journal against SQLite's derived `(installedPacksGeneration, effectiveRevision)` — generation alone is insufficient because a reindex that only advanced the revision leaves `installedPacksGeneration` unchanged while the revision differs. The state machine: (a) SQLite tuple == journal `target` tuple → atomically publish `targetManifest` if it is not already active, then clear the journal. (b) SQLite tuple == journal `old` tuple → atomically restore `oldManifest`, then clear the journal. (c) SQLite tuple matches neither (partial commit, corrupt SQLite, schema mismatch, or any single-field mismatch where the other matches) → return `StoreRecoveryRequiredError` and require `lore reindex`; never expose a queryable half-state. Cold open (§8 bullet 1) runs this check; it never silently picks "the newer one." A reindex is not special-cased: it is a manifest mutation that bumps `generation` and `revision` together and journals both, so its recovery path is identical to install/upgrade/uninstall.
+
+- **Lock-free read consistency protocol.** A public read or cold-open verification may not assume a separately read manifest and SQLite transaction form a coherent pair. It reads and validates manifest A, opens one SQLite read transaction and materializes metadata plus Effective Practices, validates the metadata tuple against A, then reads and validates manifest B. It returns data only when A and B have identical canonical manifest bytes and the SQLite tuple equals their `(generation, effectiveRevision)`; otherwise it retries a bounded number of times and then returns `StoreBusyError`. A mismatch that is stable after retries is treated as `StoreRecoveryRequiredError`, not as an opportunity to select one side.
+
+### 9. Acceptance matrix (maps the doc's §9 to this task's scope)
+
+The doc's §9 lists seven acceptance behaviors. Their disposition under this ADR:
+
+| Doc §9 behavior                                                                                                                                                            | Disposition                                                  |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| 1. Default root + StorageRoot injection + manifest/artifact write & restart read                                                                                           | **Implement** (PR 2)                                         |
+| 2. install / idempotent install / upgrade-required / upgrade removes old sources                                                                                           | **Implement** (PR 2)                                         |
+| 3. Same-title-different-id coexist; same-id-same-digest merge; same-id-different-digest reject; upgrade-vs-other-source conflict reject                                    | **Implement pure rule** (PR 1a model) **+ integrate** (PR 2) |
+| 4. Uninstall keeps still-sourced Effective Practice; last-source removal deletes it; vector invalidation hook fires                                                        | **Implement** (PR 2); vector invalidation = no-op hook (§4)  |
+| 5. Crash recovery via journal comparing the `(generation, effectiveRevision)` tuple (not generation alone); reindex bumps both together; no queryable half-installed state | **Implement** (PR 2)                                         |
+
+| 6. Source-only change does not increment revision; effective content change does increment and passes the same revision to the vector seam | **Implement pure rule** (PR 1a) **+ integrate** (PR 2); "passes to vector seam" = hook call (§4) |
+| 7. Corrupt/missing SQLite, schema-incompatible, missing/digest-mismatched artifact, invalid projection, manifest↔SQLite/generation mismatch, tampered source digest or Effective Practice content → `StoreRecoveryRequiredError`; `reindex` restores from active manifest + original snapshot without reviving history | **Implement** (PR 2) |
+| (doc §9 integration with vector layer) target revision ready before query succeeds | **Deferred** to the vector-layer task (§4); not in scope here |
+
+### 10. Validation gating and Pack snapshot parsing (SnapshotCodec)
+
+Freeze how LocalStore consumes `@lorelum/format` so the storage layer never guesses at edge cases.
+
+- **Gate on `report.valid` only.** `validatePack()` returns `{ valid, errors, warnings, infos }`. LocalStore proceeds to staging **iff `report.valid === true`** (errors empty). `warnings` and `infos` **do not block** installation; they are surfaced through the install result object (each carries `code`/`path`/`message`) so the CLI can show them, but they are not errors. This matches ADR 0003's reframe: warnings are author quality-signals, not runtime blockers.
+- **SnapshotCodec owns Pack-file → PackInput assembly.** A new `SnapshotCodec` (the planning doc's name; lives under `storage/artifacts/` alongside `artifact-store.ts` and `projection.ts`) is the sole component that reads the on-disk Pack snapshot and assembles the `{ pack, practices, decisions }` consumed by `validatePack`. Responsibilities: read `pack.yaml`; discover Practice files; parse each Practice's frontmatter via `@lorelum/format`'s `parseFrontmatter`; assemble `PackInput`.- **File path & YAML parsing ownership.** The codec lives at `packages/engine/src/local-store/storage/artifacts/snapshot-codec.ts` (PR 1 storage scope). `@lorelum/format` exposes `parseFrontmatter` (Markdown frontmatter) but **not** a general YAML parser; `pack.yaml` and `decisions.yaml` are pure YAML, not Markdown. To avoid reaching into `gray-matter`'s transitive `js-yaml` dependency (a private implementation detail of format), YAML parsing is owned as follows: **`@lorelum/format` gains a thin `parseYaml(text): unknown` entry point** that wraps the same `js-yaml` it already pulls in for frontmatter, re-exported from `@lorelum/format`'s public surface. `SnapshotCodec` calls `parseYaml` for `pack.yaml`/`decisions.yaml` and `parseFrontmatter` for Practice `.md` files. This keeps a single YAML dependency in the workspace (no engine-side `js-yaml`), and a future swap of the YAML library (per ADR 0002's gray-matter note) stays a one-package change. _If `@lorelum/format` declines to expose `parseYaml`, the fallback is a direct, declared `js-yaml` dependency in `@lorelum/engine/package.json` — never an implicit transitive import._
+
+- **`body` is injected by the codec, not authored in YAML.** The Practice frontmatter carries structural fields (`id`/`title`/`stage`/`tech_stack`/`applies_when`/`severity`); the guidance `body` is the Practice Markdown's content (frontmatter body), injected by `SnapshotCodec` into the `Practice` object. Pack authors write guidance as Markdown prose, not as a YAML string. (This is why `Practice.body` is optional in the schema — it's absent in raw frontmatter and present after codec assembly.)
+- **`decisions.yaml` is optional and has one v1 shape.** A Pack with no `decisions.yaml` is valid and assembles an empty `DecisionNode[]` (not an error). When present, the YAML document must be a top-level sequence of Decision Nodes (for example, `- id: state.client-vs-server`); wrapper objects such as `{ decisions: [...] }`, `null`, and an empty document are format errors. This maps directly to `PackInput.decisions`.
+- **Practice discovery + source path normalization.** Practice files live under `practices/**/*.md` relative to the Pack root. The `sourcePath` recorded in the Practice-source table is the POSIX-style relative path from the Pack root (forward slashes, normalized, no `./`/`../`, no trailing slash), stable across platforms. Only `.md` files are discovered. The discovery set is fixed at snapshot-seal time and recorded in the projection, so re-parse during reindex finds the identical set.
+
+### 11. Artifact digest — exact algorithm
+
+`artifactDigest` must be reproducible across processes and platforms (it gates artifact promotion and cold-open verification). Frozen algorithm:
+
+- **File set.** Recursively include every file under the expanded Pack snapshot directory, **including** the engine-generated `.lorelum/local-store-projection.json` — it is the _only_ `.lorelum/` file in the snapshot, and including it binds the projection cryptographically to the author's bytes (closing the "synchronous tampering" gap: an attacker who edits the projection must also re-derive `artifactDigest`, which requires changing author bytes that the digest also covers). Dotfiles elsewhere and empty directories are ignored; symlinks are not followed (snapshots are materialized). The file set is fixed at seal time; the projection is generated **before** the digest is computed, so the digest covers it.
+
+- **Path sorting.** Files are sorted by their POSIX relative path (forward slashes, Unicode code-point order — i.e. JS default string sort on the UTF-16 units, equivalent to byte order for the BMP). Sort happens before concatenation.
+- **Encoding.** The digest input is the concatenation, for each file in sorted order, of: the literal relative path bytes (UTF-8), a single `NUL` byte (`0x00`) as a path/content separator, the file's raw bytes, and a single newline byte (`0x0A`). No length prefix (the NUL terminator disambiguates). The whole concatenation is hashed with SHA-256, lowercase hex.
+- **Line endings.** Text files keep their on-disk bytes verbatim — the digest does **not** normalize CRLF→LF (that normalization is canonical-content's job, §2, applied per-Practice at digest time). The artifact digest protects the exact bytes the author shipped; reindex re-parses those exact bytes.
+- **Projection role.** `.lorelum/local-store-projection.json` is **generated by the engine** (not authored), is the only `.lorelum/` file in the snapshot, and is **included** in the artifact-digest file set (see File set above). Two consequences: (a) the projection's integrity is enforced by `artifactDigest` — a projection edited in isolation recomputes the directory digest to a different value than the active manifest's recorded `artifactDigest`, so cold open rejects it without needing to re-parse Practices; (b) **the projection object must NOT carry an `artifactDigest` field** (it would be self-referential and circular — the digest is computed over a file set that includes the projection). The projection's fields are `pack` metadata + per-Practice `{ id, contentDigest, canonicalContent, sourcePath }`. Cold open _additionally_ re-canonicalizes each Practice from the snapshot bytes and asserts the recomputed `contentDigest` equals the projection's — this catches a synchronous tamper of _both_ the author bytes and the projection (which would force a matching `artifactDigest`) by re-deriving canonical content from the (altered) bytes and finding it no longer matches the (altered) projection's stored digests, since the attacker cannot make arbitrary byte edits hash to the same canonical digest. This is why both protections — digest-coverage of the projection _and_ cold-open re-canonicalization — are required; neither alone suffices.
+
+- **Promotion rule.** When promoting a staged snapshot to `packs/<storageKey>/<artifactDigest>/`, if the target directory already exists, LocalStore verifies the staged digest equals the on-disk artifact digest (re-derive it from the target's files). If they match, the promotion is a no-op (idempotent). If they differ, the target is an unrelated/corrupt artifact — promotion is rejected unless the target is unreferenced by the active manifest, in which case it is replaced (the §3.3 GC-safe rule).
+
+### 12. Mutation lock — minimal contract
+
+The `mutation-lock.ts` component (PR 2) gets a frozen minimal contract so concurrency behavior is not invented ad hoc.
+
+- **Scope: cross-process, per-StorageRoot.** The lock is a single advisory lock per storage root (`~/.lorelum/`), enforced across processes (two `lore` invocations must not mutate concurrently), held by exactly one writer at a time. Lock file lives under the storage root (e.g. `<root>/.lock`), acquired by atomic create-or-fail (e.g. `O_EXCL`), released on process exit.
+- **Mutations are exclusive; reads are lock-free.** `install`/`upgrade`/`uninstall`/`reindex` acquire the lock for the whole operation. Cold open and the public read path (Effective Practice materialization) do **not** acquire the lock — they read a consistent `(manifest, SQLite snapshot)` pair. This is safe because manifest writes are atomic-rename and SQLite gives a transactional snapshot; a read never blocks on embedding or cleanup.
+- **Wait vs. fail.** Default: a mutation that finds the lock held **waits** with a bounded timeout, then fails with `StoreBusyError` (typed, surfaced to CLI) rather than silently spinning or clobbering.
+- **Stale-lock recovery.** On open, if a lock file exists but its holder is not alive (the lock record carries PID + start time; the holder process is gone), the lock is reclaimable. Reclaim is allowed only after the operation journal's recovery check (§8) has run and the store is in a consistent `(generation, revision)` state — reclaiming a lock never skips recovery. If recovery is required, the lock is not reclaimed; `StoreRecoveryRequiredError` is returned instead.
+- **Failure model.** Lock acquisition failure, timeout, and stale-lock-with-pending-recovery are the only lock-related error modes. None of them corrupt state; all surface as typed errors. A crash mid-mutation leaves a stale lock + a journal record, both resolved by the next open's recovery path.
+
+### 13. Minimal public API and recovery entry (frozen for PR 2)
+
+PR 2 exposes the LocalStore public surface from `packages/engine/src/index.ts` (PR 1a/1b do not export it). The minimal API (PR 1 model types may be re-exported as types only):
+
+```
+type StorageRoot = { readonly rootPath: string };   // injectable; default resolves ~/.lorelum/
+
+interface LocalStore {
+  open(root: StorageRoot): Promise<OpenResult>;       // cold open; throws StoreRecoveryRequiredError on inconsistency
+  install(root: StorageRoot, candidate: PackCandidate): Promise<InstallResult>;
+  upgrade (root: StorageRoot, candidate: PackCandidate): Promise<InstallResult>;
+  uninstall(root: StorageRoot, packName: string):     Promise<UninstallResult>;
+  reindex (root: StorageRoot):             Promise<ReindexResult>;   // recovery entry; bypasses open()
+  // read path (lock-free): Effective Practice materialization for a consistent (manifest, SQLite) snapshot
+  readEffectivePractices(root: StorageRoot): Promise<EffectivePractice[]>;
+  // vector seam (default no-op; vector layer registers a real impl)
+  onEffectiveRevisionAdvanced?: (rev: number, delta: RevisionDelta) => void | Promise<void>;
+}
+```
+
+Result objects (`InstallResult`/`UninstallResult`/`ReindexResult`) carry: the committed `(generation, effectiveRevision)` tuple; the list of Practice ids added/changed/invalidated; any non-blocking `validatePack` warnings/infos; and a `cleanupPending: boolean` + `notificationPending?: { revision; error }` diagnostic (§3.3 GC, §4 hook). Typed errors: `PracticeConflictError`, `PackNotInstalledError`, `StoreBusyError`, `StoreRecoveryRequiredError` (recovery entry: `reindex`). A mutation that committed but whose post-commit hook/notification or GC failed is **success** with a pending diagnostic — never re-reported as failure (§3.3, §4).
+
+## Consequences
+
+**Positive:**
+
+- The LocalStore contract is now frozen in immutable repo history, decoupled from the (mutable) spec doc. Code can point at this ADR as the authority, matching how ADR 0003 underpins `@lorelum/format`.
+- `effectiveRevision` has an independent recovery source, so `reindex`'s monotonic guarantee survives SQLite corruption — closing the gap that motivated this ADR.
+- `contentDigest` is now unambiguous and reproducible, which is load-bearing because the digest is the merge/conflict key. Two implementations or two runs over the same Practice produce the same digest.
+- The LocalStore/vector boundary is explicit, so this task can ship a complete, correct LocalStore without invading the vector-layer non-goal — and the vector layer has a defined hook to consume.
+- The `p-${pack.name}` storage key avoids Windows reserved device names without changing the public Pack schema.
+
+**Negative / accepted risk:**
+
+- **`effectiveRevision` in two places** means a write must update both (manifest on atomic rename, SQLite in its transaction) and a recovery path must reconcile them. The §1 reconciliation rule ("manifest wins; SQLite rebuilt") keeps the invariant but adds a small amount of recovery code. Accepted: the alternative (SQLite only) is strictly worse.
+- **Canonical-content choices are now frozen.** Any later change to severity default, field inclusion, or serialization changes every existing digest and forces a re-index of all installed packs. Mitigation: `canonicalizerVersion` is carried by the (future) vector embedding profile, so a canonicalizer change is detectable and recoverable via `reindex`; but LocalStore's own digest comparison must use the canonical content this ADR fixes. Changing any of §2 requires a superseding ADR.
+- **`check` excluded from the digest** means two anti-patterns that differ only in an experimental `check` value would share a digest. Accepted: `check` is undefined in v1 and packs do not carry it; when it is defined, that definition lives in its own ADR and this exclusion is revisited.
+- **Vector seam deferred.** Until the vector layer lands, install/upgrade/uninstall succeed based on LocalStore commit alone, so there is no moment where "LocalStore says success but the index isn't ready." This is correct for this task but the doc's stronger rule (success requires ready index) is intentionally not yet in force — future PRs must not assume it is.
+- **Gap in ADR numbering.** This ADR is numbered 0007 to match references already present in the planning docs and the "定稿" doc, leaving 0004–0006 unused. The repo's ADR convention requires monotonic _non-reused_ numbers, which 0007 satisfies; the gap is cosmetic.
+
+**Follow-ups:**
+
+- Update the internal "定稿：本地 Practice 索引与存储 v1" doc to match §1 (add `effectiveRevision` to the manifest field list and §3.1), §2 (canonical-content definition), §4 (vector seam clarification), §5 (`storageKey = p-${pack.name}`), and §9 (acceptance-matrix dispositions). The doc and this ADR must not drift.
+- Implementation lands in the `@lorelum/engine` package per "实施计划（重写版）": `model/` (pure rules) → `storage/` (SQLite + filesystem) → `lifecycle/` (open/install/upgrade/uninstall/reindex/recovery), with a pluggable `onEffectiveRevisionAdvanced` hook defaulting to no-op.
+- When the vector layer task opens, it implements the hook (§4) and activates the doc's "success requires ready revision" rule; that work carries its own ADR referencing this one.
+- If `PACK_NAME_REGEX` is widened, `storageKey` gains an encoding pass (new ADR).
+
+## References
+
+- ADR 0002 — `bun:sqlite` is the local store medium; native Node addons (`better-sqlite3`) are deliberately avoided.
+- ADR 0003 — Practice/Pack fields consumed by LocalStore; `PACK_NAME_REGEX` whose Windows-reserved names are made safe by the `p-` storage-key prefix; `severity` default `warn` injected by the canonicalizer.
+- Internal docs (Lorelum wiki, "技术规范" section): "定稿：本地 Practice 索引与存储 v1" (normative spec — disk layout, SQLite contract, merge/conflict rules, cold open/recovery/reindex), "定稿：本地向量索引存储方案v1" (downstream vector-layer contract this ADR's seam feeds), "实施计划（重写版）：@lorelum/engine LocalStore" (three-layer implementation plan this ADR unblocks).

--- a/docs/adr/0007-engine-local-store.md
+++ b/docs/adr/0007-engine-local-store.md
@@ -1,8 +1,8 @@
 # ADR 0007: Engine LocalStore storage & lifecycle contract
 
 - **Date:** 2026-07-27
-- **Status:** Accepted
-- **Related:** ADR 0002 (`bun:sqlite` is the local store), ADR 0003 (Practice/Pack fields and validation the store consumes). Internal docs (Lorelum wiki, "技术规范" section): "定稿：本地 Practice 索引与存储 v1" and "实施计划（重写版）：@lorelum/engine LocalStore".
+- **Status:** Proposed
+- **Related:** ADR 0002 (`bun:sqlite` is the local store), ADR 0003 (Practice/Pack fields and validation the store consumes). Internal docs (Lorelum wiki, "技术规范" section): "定稿：本地 Practice 索引与存储 v1" and "实施计划（重写版）：@lorelum/engine LocalStore". The wiki docs are background and provenance only — this ADR is the authoritative contract (see Decision).
 
 ## Context
 
@@ -19,7 +19,7 @@ Finally, the doc and the "实施计划（重写版）" doc referenced "ADR 0007"
 
 ## Decision
 
-The "定稿：本地 Practice 索引与存储 v1" doc is the normative specification. This ADR ratifies it as the frozen contract and pins the four open points below. Where this ADR and the doc disagree, **this ADR's §1–§4 govern**, and the doc is updated to match (see the change list in the References/follow-up).
+**This ADR is the authoritative, self-contained contract.** The wiki docs (internal to the Lorelum wiki, not visible to outside contributors) specify the intent and are referenced for provenance; they are background only, not normative — contributors review this ADR alone. Where this ADR and the wiki docs disagree, **this ADR governs**, and the docs are updated to match (see the change list in the References/follow-up).
 
 ### 0. Scope (ratified from the doc)
 
@@ -237,4 +237,4 @@ Result objects (`InstallResult`/`UninstallResult`/`ReindexResult`) carry: the co
 
 - ADR 0002 — `bun:sqlite` is the local store medium; native Node addons (`better-sqlite3`) are deliberately avoided.
 - ADR 0003 — Practice/Pack fields consumed by LocalStore; `PACK_NAME_REGEX` whose Windows-reserved names are made safe by the `p-` storage-key prefix; `severity` default `warn` injected by the canonicalizer.
-- Internal docs (Lorelum wiki, "技术规范" section): "定稿：本地 Practice 索引与存储 v1" (normative spec — disk layout, SQLite contract, merge/conflict rules, cold open/recovery/reindex), "定稿：本地向量索引存储方案v1" (downstream vector-layer contract this ADR's seam feeds), "实施计划（重写版）：@lorelum/engine LocalStore" (three-layer implementation plan this ADR unblocks).
+- Internal docs (Lorelum wiki, "技术规范" section — background only, not normative): "定稿：本地 Practice 索引与存储 v1" (provenance for disk layout, SQLite contract, merge/conflict rules, cold open/recovery/reindex), "定稿：本地向量索引存储方案v1" (downstream vector-layer contract this ADR's seam feeds), "实施计划（重写版）：@lorelum/engine LocalStore" (three-layer implementation plan this ADR unblocks).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@ docs/adr/
 ├── 0003-practice-pack-format.md               # Practice/pack format & validation semantics
 ├── 0004-agent-first-cli-protocol.md            # candidate CLI protocol contract
 ├── 0005-...                                   # subsequent decisions
+├── 0007-engine-local-store.md                 # @lorelum/engine LocalStore storage & lifecycle contract
 └── 0000-template.md                           # copy this to start a new ADR
 ```
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,7 +25,7 @@ docs/adr/
 ├── 0002-bun-typescript-toolchain.md           # the first real decision
 ├── 0003-practice-pack-format.md               # Practice/pack format & validation semantics
 ├── 0004-agent-first-cli-protocol.md            # candidate CLI protocol contract
-├── 0005-...                                   # subsequent decisions
+├── 0005-0006                                   # reserved for in-flight planning numbers; 0007 is numbered to match planning docs, not the strict next-free sequence
 ├── 0007-engine-local-store.md                 # @lorelum/engine LocalStore storage & lifecycle contract
 └── 0000-template.md                           # copy this to start a new ADR
 ```

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typescript": "5.7.2"
   },
   "overrides": {
-    "js-yaml": "3.14.2"
+    "js-yaml": "4.3.1"
   },
   "packageManager": "bun@1.3.8"
 }

--- a/packages/engine/src/local-store/model/candidate.test.ts
+++ b/packages/engine/src/local-store/model/candidate.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+
+import { reactPack } from "@lorelum/format";
+
+import { createPackCandidate } from "./candidate";
+import { InvalidSourcePathError, PackValidationError } from "./errors";
+
+function sourcePaths(): Record<string, string> {
+  return {
+    "react.api.layered-design": "practices/api/layered-design.md",
+    "react.state.redux": "practices/state/redux.md",
+    "react.auth.guard": "practices/auth/guard.md",
+  };
+}
+
+describe("createPackCandidate", () => {
+  test("creates canonical sources and returns non-blocking validation diagnostics", () => {
+    const input = reactPack();
+    input.practices[0]!.severity = undefined;
+    const { candidate, diagnostics } = createPackCandidate(input, sourcePaths());
+
+    expect(candidate.sources).toHaveLength(3);
+    expect(candidate.sources[0]?.packName).toBe("react-fullstack");
+    expect(diagnostics.some((diagnostic) => diagnostic.code === "missing-severity")).toBe(true);
+  });
+
+  test("rejects format-invalid candidates before they become sources", () => {
+    const input = reactPack();
+    input.practices[0]!.id = "invalid";
+    expect(() => createPackCandidate(input, sourcePaths())).toThrow(PackValidationError);
+  });
+
+  test("rejects missing, traversal, non-Practice, and unexpected source paths", () => {
+    const input = reactPack();
+    expect(() => createPackCandidate(input, {})).toThrow(InvalidSourcePathError);
+
+    const paths = sourcePaths();
+    paths["react.api.layered-design"] = "practices/../escape.md";
+    expect(() => createPackCandidate(input, paths)).toThrow(InvalidSourcePathError);
+
+    paths["react.api.layered-design"] = "docs/api.md";
+    expect(() => createPackCandidate(input, paths)).toThrow(InvalidSourcePathError);
+
+    const platformUnsafe = sourcePaths();
+    platformUnsafe["react.api.layered-design"] = "practices/C:unsafe.md";
+    expect(() => createPackCandidate(input, platformUnsafe)).toThrow(InvalidSourcePathError);
+
+    const reservedName = sourcePaths();
+    reservedName["react.api.layered-design"] = "practices/con.md";
+    expect(() => createPackCandidate(input, reservedName)).toThrow(InvalidSourcePathError);
+
+    const illegalCharacter = sourcePaths();
+    illegalCharacter["react.api.layered-design"] = `practices/unsafe${String.fromCharCode(63)}.md`;
+    expect(() => createPackCandidate(input, illegalCharacter)).toThrow(InvalidSourcePathError);
+
+    const unexpected = sourcePaths();
+    unexpected["react.extra.practice"] = "practices/guide..draft.md";
+    expect(() => createPackCandidate(input, unexpected)).toThrow(InvalidSourcePathError);
+
+    const acceptedName = sourcePaths();
+    acceptedName["react.api.layered-design"] = "practices/guide..draft.md";
+    expect(() => createPackCandidate(input, acceptedName)).not.toThrow();
+
+    const duplicate = sourcePaths();
+    duplicate["react.state.redux"] = duplicate["react.api.layered-design"]!;
+    expect(() => createPackCandidate(input, duplicate)).toThrow(InvalidSourcePathError);
+  });
+
+  test("returns frozen Pack and Practice snapshots", () => {
+    const input = reactPack();
+    const { candidate } = createPackCandidate(input, sourcePaths());
+    input.pack.version = "0.2.0";
+    input.practices[0]!.body = "mutated after canonicalization";
+
+    expect(candidate.pack.version).toBe("0.1.0");
+    expect(candidate.sources[0]?.canonicalPractice.practice.body).not.toBe(
+      "mutated after canonicalization",
+    );
+    expect(Object.isFrozen(candidate.sources)).toBe(true);
+    expect(Object.isFrozen(candidate)).toBe(true);
+    expect(Object.isFrozen(candidate.sources[0])).toBe(true);
+    expect(Object.isFrozen(candidate.sources[0]?.canonicalPractice.practice)).toBe(true);
+  });
+
+  test("does not read a source path from an inherited property", () => {
+    const inheritedPaths = Object.create({
+      "react.api.layered-design": "practices/api/layered-design.md",
+    }) as Record<string, string>;
+    expect(() => createPackCandidate(reactPack(), inheritedPaths)).toThrow(InvalidSourcePathError);
+  });
+});

--- a/packages/engine/src/local-store/model/candidate.ts
+++ b/packages/engine/src/local-store/model/candidate.ts
@@ -2,6 +2,7 @@ import { validatePack, type PackInput, type ValidationIssue } from "@lorelum/for
 
 import { canonicalizePractice } from "./canonical-practice";
 import { InvalidSourcePathError, PackValidationError } from "./errors";
+import { deepFreeze } from "./freeze";
 import type { PackCandidate, PackSnapshot, PracticeSource } from "./types";
 
 function isWindowsReservedPathSegment(segment: string): boolean {
@@ -40,11 +41,7 @@ export function isPracticeSourcePath(path: string): boolean {
 
 function snapshotPack(input: PackInput["pack"]): PackSnapshot {
   const snapshot = structuredClone(input);
-  if (snapshot.applies_to !== undefined) Object.freeze(snapshot.applies_to);
-  if (snapshot.depends_on !== undefined) Object.freeze(snapshot.depends_on);
-  if (typeof snapshot.author === "object" && snapshot.author !== null)
-    Object.freeze(snapshot.author);
-  return Object.freeze(snapshot) as PackSnapshot;
+  return deepFreeze(snapshot) as PackSnapshot;
 }
 
 /** Construct a storage-ready candidate only after the format authoring gate passes. */

--- a/packages/engine/src/local-store/model/candidate.ts
+++ b/packages/engine/src/local-store/model/candidate.ts
@@ -17,7 +17,8 @@ function isWindowsReservedPathSegment(segment: string): boolean {
   );
 }
 
-function isNormalizedPracticePath(path: string): boolean {
+/** Verify a Pack-root-relative Practice source path without resolving it on disk. */
+export function isPracticeSourcePath(path: string): boolean {
   return (
     /^practices\/(?:[^/]+\/)*[^/]+\.md$/.test(path) &&
     !path.includes("\\") &&
@@ -67,7 +68,7 @@ export function createPackCandidate(
     const sourcePath = Object.hasOwn(sourcePathsByPracticeId, practice.id)
       ? sourcePathsByPracticeId[practice.id]
       : undefined;
-    if (sourcePath === undefined || !isNormalizedPracticePath(sourcePath)) {
+    if (sourcePath === undefined || !isPracticeSourcePath(sourcePath)) {
       throw new InvalidSourcePathError(practice.id, sourcePath ?? "(missing)");
     }
 

--- a/packages/engine/src/local-store/model/candidate.ts
+++ b/packages/engine/src/local-store/model/candidate.ts
@@ -1,0 +1,95 @@
+import { validatePack, type PackInput, type ValidationIssue } from "@lorelum/format";
+
+import { canonicalizePractice } from "./canonical-practice";
+import { InvalidSourcePathError, PackValidationError } from "./errors";
+import type { PackCandidate, PackSnapshot, PracticeSource } from "./types";
+
+function isWindowsReservedPathSegment(segment: string): boolean {
+  const baseName = segment.split(".", 1)[0]?.toLowerCase();
+  return (
+    baseName === "con" ||
+    baseName === "prn" ||
+    baseName === "aux" ||
+    baseName === "nul" ||
+    baseName === "clock$" ||
+    /^com[1-9]$/.test(baseName ?? "") ||
+    /^lpt[1-9]$/.test(baseName ?? "")
+  );
+}
+
+function isNormalizedPracticePath(path: string): boolean {
+  return (
+    /^practices\/(?:[^/]+\/)*[^/]+\.md$/.test(path) &&
+    !path.includes("\\") &&
+    !path.includes(":") &&
+    !path.includes("*") &&
+    !path.includes("<") &&
+    !path.includes(">") &&
+    !path.includes("|") &&
+    !path.includes(String.fromCharCode(34)) &&
+    !path.includes(String.fromCharCode(63)) &&
+    !path.includes(String.fromCharCode(0)) &&
+    !path
+      .split("/")
+      .some(
+        (segment) => segment === "." || segment === ".." || isWindowsReservedPathSegment(segment),
+      )
+  );
+}
+
+function snapshotPack(input: PackInput["pack"]): PackSnapshot {
+  const snapshot = structuredClone(input);
+  if (snapshot.applies_to !== undefined) Object.freeze(snapshot.applies_to);
+  if (snapshot.depends_on !== undefined) Object.freeze(snapshot.depends_on);
+  if (typeof snapshot.author === "object" && snapshot.author !== null)
+    Object.freeze(snapshot.author);
+  return Object.freeze(snapshot) as PackSnapshot;
+}
+
+/** Construct a storage-ready candidate only after the format authoring gate passes. */
+export function createPackCandidate(
+  input: PackInput,
+  sourcePathsByPracticeId: Readonly<Record<string, string>>,
+): { candidate: PackCandidate; diagnostics: readonly ValidationIssue[] } {
+  const report = validatePack(input);
+  if (!report.valid) throw new PackValidationError(report);
+  const practiceIds = new Set(input.practices.map((practice) => practice.id));
+  for (const sourcePracticeId of Object.keys(sourcePathsByPracticeId)) {
+    if (!practiceIds.has(sourcePracticeId)) {
+      throw new InvalidSourcePathError(
+        sourcePracticeId,
+        sourcePathsByPracticeId[sourcePracticeId] ?? "(missing)",
+      );
+    }
+  }
+
+  const sources: PracticeSource[] = input.practices.map((practice) => {
+    const sourcePath = Object.hasOwn(sourcePathsByPracticeId, practice.id)
+      ? sourcePathsByPracticeId[practice.id]
+      : undefined;
+    if (sourcePath === undefined || !isNormalizedPracticePath(sourcePath)) {
+      throw new InvalidSourcePathError(practice.id, sourcePath ?? "(missing)");
+    }
+
+    const canonicalPractice = canonicalizePractice(practice);
+    return Object.freeze({
+      packName: input.pack.name,
+      practiceId: practice.id,
+      contentDigest: canonicalPractice.contentDigest,
+      sourcePath,
+      canonicalPractice,
+    });
+  });
+  const sourcePaths = new Set<string>();
+  for (const source of sources) {
+    if (sourcePaths.has(source.sourcePath)) {
+      throw new InvalidSourcePathError(source.practiceId, `${source.sourcePath} (duplicate)`);
+    }
+    sourcePaths.add(source.sourcePath);
+  }
+
+  return {
+    candidate: Object.freeze({ pack: snapshotPack(input.pack), sources: Object.freeze(sources) }),
+    diagnostics: [...report.warnings, ...report.infos],
+  };
+}

--- a/packages/engine/src/local-store/model/candidate.ts
+++ b/packages/engine/src/local-store/model/candidate.ts
@@ -1,4 +1,10 @@
-import { validatePack, type PackInput, type ValidationIssue } from "@lorelum/format";
+import {
+  parsePackInput,
+  validateParsedPack,
+  type Pack,
+  type UnvalidatedPackInput,
+  type ValidationIssue,
+} from "@lorelum/format";
 
 import { canonicalizePractice } from "./canonical-practice";
 import { InvalidSourcePathError, PackValidationError } from "./errors";
@@ -39,19 +45,24 @@ export function isPracticeSourcePath(path: string): boolean {
   );
 }
 
-function snapshotPack(input: PackInput["pack"]): PackSnapshot {
-  const snapshot = structuredClone(input);
+function snapshotPack(pack: Pack): PackSnapshot {
+  const snapshot = structuredClone(pack);
   return deepFreeze(snapshot) as PackSnapshot;
 }
 
 /** Construct a storage-ready candidate only after the format authoring gate passes. */
 export function createPackCandidate(
-  input: PackInput,
+  input: UnvalidatedPackInput,
   sourcePathsByPracticeId: Readonly<Record<string, string>>,
 ): { candidate: PackCandidate; diagnostics: readonly ValidationIssue[] } {
-  const report = validatePack(input);
+  const parsed = parsePackInput(input);
+  if (!parsed.ok) throw new PackValidationError(parsed.report);
+  const { pack, practices } = parsed.value;
+  // Full report: format gate already passed, so the semantic stages decide
+  // validity (reference integrity, cycles) and provide diagnostics.
+  const report = validateParsedPack(parsed.value);
   if (!report.valid) throw new PackValidationError(report);
-  const practiceIds = new Set(input.practices.map((practice) => practice.id));
+  const practiceIds = new Set(practices.map((practice) => practice.id));
   for (const sourcePracticeId of Object.keys(sourcePathsByPracticeId)) {
     if (!practiceIds.has(sourcePracticeId)) {
       throw new InvalidSourcePathError(
@@ -61,7 +72,7 @@ export function createPackCandidate(
     }
   }
 
-  const sources: PracticeSource[] = input.practices.map((practice) => {
+  const sources: PracticeSource[] = practices.map((practice) => {
     const sourcePath = Object.hasOwn(sourcePathsByPracticeId, practice.id)
       ? sourcePathsByPracticeId[practice.id]
       : undefined;
@@ -71,7 +82,7 @@ export function createPackCandidate(
 
     const canonicalPractice = canonicalizePractice(practice);
     return Object.freeze({
-      packName: input.pack.name,
+      packName: pack.name,
       practiceId: practice.id,
       contentDigest: canonicalPractice.contentDigest,
       sourcePath,
@@ -87,7 +98,7 @@ export function createPackCandidate(
   }
 
   return {
-    candidate: Object.freeze({ pack: snapshotPack(input.pack), sources: Object.freeze(sources) }),
+    candidate: Object.freeze({ pack: snapshotPack(pack), sources: Object.freeze(sources) }),
     diagnostics: [...report.warnings, ...report.infos],
   };
 }

--- a/packages/engine/src/local-store/model/canonical-practice.test.ts
+++ b/packages/engine/src/local-store/model/canonical-practice.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { layeredDesignPractice } from "@lorelum/format";
+
+import { canonicalizePractice } from "./canonical-practice";
+
+describe("canonicalizePractice", () => {
+  test("uses fixed keys, defaults, LF line endings, and excludes check", () => {
+    const result = canonicalizePractice({
+      ...layeredDesignPractice,
+      severity: undefined,
+      body: "line one\r\nline two\rline three",
+      anti_patterns: [
+        {
+          id: "api.direct-axios-in-component",
+          name: "Direct axios",
+          description: "Avoid it\r\nUse a hook.",
+          check: { experimental: true },
+        },
+      ],
+    });
+
+    expect(result.canonicalContent).toBe(
+      '{"id":"react.api.layered-design","title":"Layered API Design","stage":"api-layer","tech_stack":["react","typescript"],"applies_when":"building an API layer in a React SPA","severity":"warn","body":"line one\\nline two\\nline three","anti_patterns":[{"id":"api.direct-axios-in-component","name":"Direct axios","description":"Avoid it\\nUse a hook.","severity":"warn"}]}',
+    );
+    expect(result.contentDigest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test("does not let an undefined v1 check field alter a digest", () => {
+    const withoutCheck = canonicalizePractice(layeredDesignPractice);
+    const withCheck = canonicalizePractice({
+      ...layeredDesignPractice,
+      anti_patterns: layeredDesignPractice.anti_patterns?.map((antiPattern) => ({
+        ...antiPattern,
+        check: "future-rule",
+      })),
+    });
+    expect(withCheck.contentDigest).toBe(withoutCheck.contentDigest);
+  });
+});

--- a/packages/engine/src/local-store/model/canonical-practice.test.ts
+++ b/packages/engine/src/local-store/model/canonical-practice.test.ts
@@ -37,4 +37,23 @@ describe("canonicalizePractice", () => {
     });
     expect(withCheck.contentDigest).toBe(withoutCheck.contentDigest);
   });
+
+  test("returns the normalized canonical snapshot used by storage and retrieval", () => {
+    const result = canonicalizePractice({
+      ...layeredDesignPractice,
+      severity: undefined,
+      body: "line one\r\nline two",
+      anti_patterns: layeredDesignPractice.anti_patterns?.map((antiPattern) => ({
+        ...antiPattern,
+        severity: undefined,
+        check: "reserved",
+      })),
+    });
+
+    expect(result.practice.body).toBe("line one\nline two");
+    expect(result.practice.severity).toBe("warn");
+    expect(result.practice.anti_patterns?.[0]?.severity).toBe("warn");
+    expect(result.practice.anti_patterns?.[0]).not.toHaveProperty("check");
+    expect(Object.isFrozen(result)).toBe(true);
+  });
 });

--- a/packages/engine/src/local-store/model/canonical-practice.ts
+++ b/packages/engine/src/local-store/model/canonical-practice.ts
@@ -25,8 +25,9 @@ type ReadonlyPractice = {
     | undefined;
 };
 
-function snapshotPractice(practice: Practice): PracticeSnapshot {
-  const snapshot: Practice = structuredClone(practice);
+function snapshotPractice(practice: ReadonlyPractice): PracticeSnapshot {
+  const canonical = canonicalPracticeObject(practice);
+  const snapshot = structuredClone(canonical) as Practice;
   deepFreeze(snapshot);
   return snapshot as PracticeSnapshot;
 }
@@ -54,7 +55,8 @@ function canonicalPracticeObject(practice: ReadonlyPractice): object {
  * The object literal fixes key order; author-provided array order is retained.
  */
 export function canonicalizePractice(practice: ReadonlyPractice): CanonicalPractice {
-  const canonicalContent = JSON.stringify(canonicalPracticeObject(practice));
+  const canonicalObject = canonicalPracticeObject(practice);
+  const canonicalContent = JSON.stringify(canonicalObject);
   const contentDigest = new Bun.CryptoHasher("sha256").update(canonicalContent).digest("hex");
-  return { practice: snapshotPractice(practice as Practice), canonicalContent, contentDigest };
+  return Object.freeze({ practice: snapshotPractice(practice), canonicalContent, contentDigest });
 }

--- a/packages/engine/src/local-store/model/canonical-practice.ts
+++ b/packages/engine/src/local-store/model/canonical-practice.ts
@@ -1,15 +1,10 @@
 import type { Practice } from "@lorelum/format";
 
+import { deepFreeze } from "./freeze";
 import type { CanonicalPractice, PracticeSnapshot } from "./types";
 
 function normalizeLineEndings(value: string): string {
   return value.replace(/\r\n?/g, "\n");
-}
-
-function deepFreeze(value: unknown): void {
-  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return;
-  for (const child of Object.values(value)) deepFreeze(child);
-  Object.freeze(value);
 }
 
 type ReadonlyPractice = {
@@ -28,8 +23,7 @@ type ReadonlyPractice = {
 function snapshotPractice(practice: ReadonlyPractice): PracticeSnapshot {
   const canonical = canonicalPracticeObject(practice);
   const snapshot = structuredClone(canonical) as Practice;
-  deepFreeze(snapshot);
-  return snapshot as PracticeSnapshot;
+  return deepFreeze(snapshot) as PracticeSnapshot;
 }
 
 function canonicalPracticeObject(practice: ReadonlyPractice): object {

--- a/packages/engine/src/local-store/model/canonical-practice.ts
+++ b/packages/engine/src/local-store/model/canonical-practice.ts
@@ -1,0 +1,60 @@
+import type { Practice } from "@lorelum/format";
+
+import type { CanonicalPractice, PracticeSnapshot } from "./types";
+
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n?/g, "\n");
+}
+
+function deepFreeze(value: unknown): void {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return;
+  for (const child of Object.values(value)) deepFreeze(child);
+  Object.freeze(value);
+}
+
+type ReadonlyPractice = {
+  readonly id: string;
+  readonly title: string;
+  readonly stage: string;
+  readonly tech_stack: readonly string[];
+  readonly applies_when: string;
+  readonly severity?: Practice["severity"] | undefined;
+  readonly body?: string | undefined;
+  readonly anti_patterns?:
+    | readonly Readonly<NonNullable<Practice["anti_patterns"]>[number]>[]
+    | undefined;
+};
+
+function snapshotPractice(practice: Practice): PracticeSnapshot {
+  const snapshot: Practice = structuredClone(practice);
+  deepFreeze(snapshot);
+  return snapshot as PracticeSnapshot;
+}
+
+function canonicalPracticeObject(practice: ReadonlyPractice): object {
+  return {
+    id: normalizeLineEndings(practice.id),
+    title: normalizeLineEndings(practice.title),
+    stage: normalizeLineEndings(practice.stage),
+    tech_stack: practice.tech_stack.map(normalizeLineEndings),
+    applies_when: normalizeLineEndings(practice.applies_when),
+    severity: practice.severity ?? "warn",
+    body: normalizeLineEndings(practice.body ?? ""),
+    anti_patterns: (practice.anti_patterns ?? []).map((antiPattern) => ({
+      id: normalizeLineEndings(antiPattern.id),
+      name: normalizeLineEndings(antiPattern.name),
+      description: normalizeLineEndings(antiPattern.description),
+      severity: antiPattern.severity ?? "warn",
+    })),
+  };
+}
+
+/**
+ * Build the ADR 0007 canonical JSON and SHA-256 digest for one Practice.
+ * The object literal fixes key order; author-provided array order is retained.
+ */
+export function canonicalizePractice(practice: ReadonlyPractice): CanonicalPractice {
+  const canonicalContent = JSON.stringify(canonicalPracticeObject(practice));
+  const contentDigest = new Bun.CryptoHasher("sha256").update(canonicalContent).digest("hex");
+  return { practice: snapshotPractice(practice as Practice), canonicalContent, contentDigest };
+}

--- a/packages/engine/src/local-store/model/effective-practices.test.ts
+++ b/packages/engine/src/local-store/model/effective-practices.test.ts
@@ -125,4 +125,12 @@ describe("Effective Practice reconciliation", () => {
       InvalidPracticeSourceError,
     );
   });
+
+  test("rejects existing sources with an unsafe path before reconciliation", () => {
+    const valid = candidate("react-core");
+    const source = valid.sources[0]!;
+    expect(() =>
+      reconcileEffectivePractices([{ ...source, sourcePath: "practices/../escape.md" }], valid),
+    ).toThrow(InvalidPracticeSourceError);
+  });
 });

--- a/packages/engine/src/local-store/model/effective-practices.test.ts
+++ b/packages/engine/src/local-store/model/effective-practices.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+
+import { reactPack } from "@lorelum/format";
+
+import { createPackCandidate } from "./candidate";
+import { InvalidPracticeSourceError, PracticeConflictError } from "./errors";
+import { reconcileEffectivePractices, removePackSources } from "./effective-practices";
+
+function candidate(name = "react-fullstack", version = "0.1.0", body?: string) {
+  const input = reactPack();
+  input.pack.name = name;
+  input.pack.version = version;
+  if (body !== undefined) input.practices[0]!.body = body;
+  return createPackCandidate(input, {
+    "react.api.layered-design": "practices/api/layered-design.md",
+    "react.state.redux": "practices/state/redux.md",
+    "react.auth.guard": "practices/auth/guard.md",
+  }).candidate;
+}
+
+describe("Effective Practice reconciliation", () => {
+  test("coexists for different ids and merges identical multi-Pack sources without a revision", () => {
+    const first = candidate("react-core");
+    const initially = reconcileEffectivePractices([], first);
+    const duplicate = candidate("react-fullstack");
+    const reconciled = reconcileEffectivePractices(initially.sources, duplicate);
+
+    expect(initially.delta.added).toHaveLength(3);
+    expect(reconciled.effectivePractices).toHaveLength(3);
+    expect(reconciled.effectivePractices[0]?.sources).toHaveLength(2);
+    expect(reconciled.advancesEffectiveRevision).toBe(false);
+  });
+
+  test("rejects a same-id source whose canonical content differs", () => {
+    const initial = reconcileEffectivePractices([], candidate("react-core"));
+    expect(() =>
+      reconcileEffectivePractices(initial.sources, candidate("react-alt", "0.1.0", "Different")),
+    ).toThrow(PracticeConflictError);
+  });
+
+  test("reports candidate and retained Pack names regardless of source sort order", () => {
+    const initial = reconcileEffectivePractices([], candidate("react-z"));
+    try {
+      reconcileEffectivePractices(initial.sources, candidate("react-a", "0.1.0", "Different"));
+      throw new Error("expected conflict");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PracticeConflictError);
+      const conflict = error as PracticeConflictError;
+      expect(conflict.candidatePackName).toBe("react-a");
+      expect(conflict.conflictingPackName).toBe("react-z");
+    }
+  });
+
+  test("upgrade removes the old Pack sources before testing its replacement", () => {
+    const initial = reconcileEffectivePractices([], candidate("react-core"));
+    const upgraded = reconcileEffectivePractices(
+      initial.sources,
+      candidate("react-core", "0.2.0", "Changed guidance"),
+      "react-core",
+    );
+
+    expect(upgraded.delta.changed).toEqual(["react.api.layered-design"]);
+    expect(upgraded.advancesEffectiveRevision).toBe(true);
+  });
+
+  test("rejects an upgrade whose replacement name differs from the candidate", () => {
+    const initial = reconcileEffectivePractices([], candidate("react-core"));
+    expect(() =>
+      reconcileEffectivePractices(initial.sources, candidate("react-alt"), "react-core"),
+    ).toThrow(InvalidPracticeSourceError);
+  });
+
+  test("an upgrade conflicts when a second Pack still provides the old content", () => {
+    const initial = reconcileEffectivePractices([], candidate("react-core"));
+    const shared = reconcileEffectivePractices(initial.sources, candidate("react-fullstack"));
+
+    expect(() =>
+      reconcileEffectivePractices(
+        shared.sources,
+        candidate("react-core", "0.2.0", "Changed guidance"),
+        "react-core",
+      ),
+    ).toThrow(PracticeConflictError);
+  });
+
+  test("only invalidates a Practice after its final source is removed", () => {
+    const first = reconcileEffectivePractices([], candidate("react-core"));
+    const shared = reconcileEffectivePractices(first.sources, candidate("react-fullstack"));
+    const afterFirstRemoval = removePackSources(shared.sources, "react-core");
+    const afterLastRemoval = removePackSources(afterFirstRemoval.sources, "react-fullstack");
+
+    expect(afterFirstRemoval.advancesEffectiveRevision).toBe(false);
+    expect(afterLastRemoval.delta.invalidated).toEqual([
+      "react.api.layered-design",
+      "react.auth.guard",
+      "react.state.redux",
+    ]);
+  });
+
+  test("rejects sources whose canonical metadata was corrupted", () => {
+    const corrupted = candidate("react-core");
+    const source = corrupted.sources[0]!;
+    const invalidCandidate = {
+      ...corrupted,
+      sources: [{ ...source, contentDigest: "0".repeat(64) }],
+    };
+    expect(() => reconcileEffectivePractices([], invalidCandidate)).toThrow(
+      InvalidPracticeSourceError,
+    );
+  });
+
+  test("rejects a source whose nested canonical digest was corrupted", () => {
+    const valid = candidate("react-core");
+    const source = valid.sources[0]!;
+    const invalidCandidate = {
+      ...valid,
+      sources: [
+        {
+          ...source,
+          canonicalPractice: { ...source.canonicalPractice, contentDigest: "f".repeat(64) },
+        },
+      ],
+    };
+    expect(() => reconcileEffectivePractices([], invalidCandidate)).toThrow(
+      InvalidPracticeSourceError,
+    );
+  });
+});

--- a/packages/engine/src/local-store/model/effective-practices.ts
+++ b/packages/engine/src/local-store/model/effective-practices.ts
@@ -20,6 +20,17 @@ function compareSources(left: PracticeSource, right: PracticeSource): number {
   );
 }
 
+/**
+ * Fully re-canonicalize a source before trusting it. This is deliberate
+ * defense-in-depth: at this stage sources may come from an untrusted caller
+ * (snapshot decode, cold open, recovery), so the stored digest and canonical
+ * content are re-derived and compared rather than assumed consistent.
+ * `createPackCandidate` already validated sources at build time; this second
+ * pass guards the merge boundary itself. The cost is O(canonicalization) per
+ * source — negligible at P1/P2 scale; if a future lifecycle layer can prove
+ * sources were validated at a trusted boundary, this can be relaxed to the
+ * cheap id/digest/path checks below.
+ */
 function assertValidSource(source: PracticeSource, expectedPackName?: string): void {
   if (expectedPackName !== undefined && source.packName !== expectedPackName) {
     throw new InvalidPracticeSourceError(source.practiceId, "pack name differs from its candidate");

--- a/packages/engine/src/local-store/model/effective-practices.ts
+++ b/packages/engine/src/local-store/model/effective-practices.ts
@@ -1,4 +1,5 @@
 import { InvalidPracticeSourceError, PracticeConflictError } from "./errors";
+import { isPracticeSourcePath } from "./candidate";
 import { canonicalizePractice } from "./canonical-practice";
 import type {
   EffectivePractice,
@@ -27,6 +28,12 @@ function assertValidSource(source: PracticeSource, expectedPackName?: string): v
     throw new InvalidPracticeSourceError(
       source.practiceId,
       "practice id differs from canonical snapshot",
+    );
+  }
+  if (!isPracticeSourcePath(source.sourcePath)) {
+    throw new InvalidPracticeSourceError(
+      source.practiceId,
+      "source path is not a normalized Practice path",
     );
   }
   const canonical = canonicalizePractice(source.canonicalPractice.practice);

--- a/packages/engine/src/local-store/model/effective-practices.ts
+++ b/packages/engine/src/local-store/model/effective-practices.ts
@@ -1,0 +1,164 @@
+import { InvalidPracticeSourceError, PracticeConflictError } from "./errors";
+import { canonicalizePractice } from "./canonical-practice";
+import type {
+  EffectivePractice,
+  PackCandidate,
+  PracticeSource,
+  ReconciledPractices,
+  RevisionDelta,
+} from "./types";
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareSources(left: PracticeSource, right: PracticeSource): number {
+  return (
+    compareCodeUnits(left.packName, right.packName) ||
+    compareCodeUnits(left.sourcePath, right.sourcePath)
+  );
+}
+
+function assertValidSource(source: PracticeSource, expectedPackName?: string): void {
+  if (expectedPackName !== undefined && source.packName !== expectedPackName) {
+    throw new InvalidPracticeSourceError(source.practiceId, "pack name differs from its candidate");
+  }
+  if (source.practiceId !== source.canonicalPractice.practice.id) {
+    throw new InvalidPracticeSourceError(
+      source.practiceId,
+      "practice id differs from canonical snapshot",
+    );
+  }
+  const canonical = canonicalizePractice(source.canonicalPractice.practice);
+  if (
+    source.contentDigest !== canonical.contentDigest ||
+    source.canonicalPractice.contentDigest !== canonical.contentDigest ||
+    source.canonicalPractice.canonicalContent !== canonical.canonicalContent
+  ) {
+    throw new InvalidPracticeSourceError(source.practiceId, "canonical content or digest mismatch");
+  }
+}
+
+function buildEffectivePractices(sources: readonly PracticeSource[]): readonly EffectivePractice[] {
+  const byPracticeId = new Map<string, PracticeSource[]>();
+  for (const source of sources) {
+    assertValidSource(source);
+    const group = byPracticeId.get(source.practiceId);
+    if (group === undefined) byPracticeId.set(source.practiceId, [source]);
+    else group.push(source);
+  }
+
+  const effectivePractices: EffectivePractice[] = [];
+  for (const [practiceId, group] of byPracticeId) {
+    const orderedSources = [...group].sort(compareSources);
+    const primary = orderedSources[0];
+    if (primary === undefined) continue;
+    for (const source of orderedSources.slice(1)) {
+      if (source.contentDigest !== primary.contentDigest) {
+        throw new PracticeConflictError(practiceId, source.packName, primary.packName);
+      }
+    }
+    effectivePractices.push(
+      Object.freeze({
+        practiceId,
+        contentDigest: primary.contentDigest,
+        canonicalContent: primary.canonicalPractice.canonicalContent,
+        practice: primary.canonicalPractice.practice,
+        sources: Object.freeze(orderedSources),
+      }),
+    );
+  }
+  return [...effectivePractices].sort((left, right) =>
+    compareCodeUnits(left.practiceId, right.practiceId),
+  );
+}
+
+function effectiveDigestMap(practices: readonly EffectivePractice[]): Map<string, string> {
+  return new Map(practices.map((practice) => [practice.practiceId, practice.contentDigest]));
+}
+
+function calculateDelta(
+  previous: readonly EffectivePractice[],
+  next: readonly EffectivePractice[],
+): RevisionDelta {
+  const previousDigests = effectiveDigestMap(previous);
+  const nextDigests = effectiveDigestMap(next);
+  const added: string[] = [];
+  const changed: string[] = [];
+  const invalidated: string[] = [];
+
+  for (const [practiceId, digest] of nextDigests) {
+    const previousDigest = previousDigests.get(practiceId);
+    if (previousDigest === undefined) added.push(practiceId);
+    else if (previousDigest !== digest) changed.push(practiceId);
+  }
+  for (const practiceId of previousDigests.keys()) {
+    if (!nextDigests.has(practiceId)) invalidated.push(practiceId);
+  }
+  return Object.freeze({
+    added: Object.freeze([...added].sort(compareCodeUnits)),
+    changed: Object.freeze([...changed].sort(compareCodeUnits)),
+    invalidated: Object.freeze([...invalidated].sort(compareCodeUnits)),
+  });
+}
+
+/**
+ * Reconcile one candidate into the complete active source set. Set
+ * `replacePackName` for an upgrade, which removes that Pack's old sources
+ * before conflict checking the candidate's complete replacement snapshot.
+ */
+export function reconcileEffectivePractices(
+  existingSources: readonly PracticeSource[],
+  candidate: PackCandidate,
+  replacePackName?: string,
+): ReconciledPractices {
+  if (replacePackName !== undefined && replacePackName !== candidate.pack.name) {
+    throw new InvalidPracticeSourceError(
+      candidate.pack.name,
+      "replacement pack name differs from candidate pack name",
+    );
+  }
+  for (const source of candidate.sources) assertValidSource(source, candidate.pack.name);
+  const previous = buildEffectivePractices(existingSources);
+  const retainedSources = existingSources.filter((source) => source.packName !== replacePackName);
+  for (const source of candidate.sources) {
+    const conflict = retainedSources.find(
+      (retained) =>
+        retained.practiceId === source.practiceId &&
+        retained.contentDigest !== source.contentDigest,
+    );
+    if (conflict !== undefined) {
+      throw new PracticeConflictError(source.practiceId, candidate.pack.name, conflict.packName);
+    }
+  }
+  const sources = [...retainedSources, ...candidate.sources].sort(compareSources);
+  const effectivePractices = buildEffectivePractices(sources);
+  const delta = calculateDelta(previous, effectivePractices);
+  return Object.freeze({
+    sources: Object.freeze(sources),
+    effectivePractices: Object.freeze(effectivePractices),
+    delta,
+    advancesEffectiveRevision:
+      delta.added.length > 0 || delta.changed.length > 0 || delta.invalidated.length > 0,
+  });
+}
+
+/** Rebuild the Effective Practice view after removing all sources of one Pack. */
+export function removePackSources(
+  existingSources: readonly PracticeSource[],
+  packName: string,
+): ReconciledPractices {
+  const previous = buildEffectivePractices(existingSources);
+  const sources = existingSources
+    .filter((source) => source.packName !== packName)
+    .sort(compareSources);
+  const effectivePractices = buildEffectivePractices(sources);
+  const delta = calculateDelta(previous, effectivePractices);
+  return Object.freeze({
+    sources: Object.freeze(sources),
+    effectivePractices: Object.freeze(effectivePractices),
+    delta,
+    advancesEffectiveRevision:
+      delta.added.length > 0 || delta.changed.length > 0 || delta.invalidated.length > 0,
+  });
+}

--- a/packages/engine/src/local-store/model/errors.ts
+++ b/packages/engine/src/local-store/model/errors.ts
@@ -1,0 +1,45 @@
+import type { ValidationReport } from "@lorelum/format";
+
+/** A candidate Pack failed the author-facing format validation gate. */
+export class PackValidationError extends Error {
+  constructor(readonly report: ValidationReport) {
+    super("Pack failed format validation");
+    this.name = "PackValidationError";
+  }
+}
+
+/** A candidate attempts to replace a globally stable Practice id with different content. */
+export class PracticeConflictError extends Error {
+  constructor(
+    readonly practiceId: string,
+    readonly candidatePackName: string,
+    readonly conflictingPackName: string,
+  ) {
+    super(
+      `Practice "${practiceId}" from pack "${candidatePackName}" conflicts with active pack "${conflictingPackName}"`,
+    );
+    this.name = "PracticeConflictError";
+  }
+}
+
+/** Candidate source metadata violates LocalStore's Pack-root path contract. */
+export class InvalidSourcePathError extends Error {
+  constructor(
+    readonly practiceId: string,
+    readonly sourcePath: string,
+  ) {
+    super(`Practice "${practiceId}" has invalid source path "${sourcePath}"`);
+    this.name = "InvalidSourcePathError";
+  }
+}
+
+/** A source passed back from storage does not match its canonical metadata. */
+export class InvalidPracticeSourceError extends Error {
+  constructor(
+    readonly practiceId: string,
+    readonly reason: string,
+  ) {
+    super(`Practice source "${practiceId}" is invalid: ${reason}`);
+    this.name = "InvalidPracticeSourceError";
+  }
+}

--- a/packages/engine/src/local-store/model/freeze.ts
+++ b/packages/engine/src/local-store/model/freeze.ts
@@ -1,0 +1,7 @@
+/** Deeply freeze a structured snapshot while tolerating repeated references. */
+export function deepFreeze<T>(value: T, visited = new WeakSet<object>()): T {
+  if (typeof value !== "object" || value === null || visited.has(value)) return value;
+  visited.add(value);
+  for (const child of Object.values(value)) deepFreeze(child, visited);
+  return Object.freeze(value);
+}

--- a/packages/engine/src/local-store/model/index.ts
+++ b/packages/engine/src/local-store/model/index.ts
@@ -1,0 +1,5 @@
+export * from "./types";
+export * from "./errors";
+export * from "./canonical-practice";
+export * from "./candidate";
+export * from "./effective-practices";

--- a/packages/engine/src/local-store/model/index.ts
+++ b/packages/engine/src/local-store/model/index.ts
@@ -1,5 +1,6 @@
 export * from "./types";
 export * from "./errors";
+export * from "./freeze";
 export * from "./canonical-practice";
 export * from "./candidate";
 export * from "./effective-practices";

--- a/packages/engine/src/local-store/model/types.ts
+++ b/packages/engine/src/local-store/model/types.ts
@@ -1,0 +1,61 @@
+import type { Pack, Practice } from "@lorelum/format";
+
+/** Deeply frozen snapshot retained after canonicalization. */
+export type PracticeSnapshot = Readonly<
+  Omit<Practice, "tech_stack" | "anti_patterns"> & {
+    tech_stack: readonly string[];
+    anti_patterns?: readonly Readonly<NonNullable<Practice["anti_patterns"]>[number]>[];
+  }
+>;
+
+export type PackSnapshot = Readonly<
+  Omit<Pack, "applies_to" | "depends_on"> & {
+    applies_to?: readonly string[];
+    depends_on?: readonly string[];
+  }
+>;
+
+/** A Practice plus the deterministic representation used for merge decisions. */
+export interface CanonicalPractice {
+  practice: PracticeSnapshot;
+  canonicalContent: string;
+  contentDigest: string;
+}
+
+/** One Pack's claim to a Practice. Source paths are Pack-root-relative POSIX paths. */
+export interface PracticeSource {
+  packName: string;
+  practiceId: string;
+  contentDigest: string;
+  sourcePath: string;
+  canonicalPractice: CanonicalPractice;
+}
+
+/** The deduplicated Practice presented to the future retrieval layer. */
+export interface EffectivePractice {
+  practiceId: string;
+  contentDigest: string;
+  canonicalContent: string;
+  practice: PracticeSnapshot;
+  sources: readonly PracticeSource[];
+}
+
+/** A format-valid Pack ready for the storage/lifecycle layer to install. */
+export interface PackCandidate {
+  pack: PackSnapshot;
+  sources: readonly PracticeSource[];
+}
+
+/** Changes to Effective Practices resulting from one source-set reconciliation. */
+export interface RevisionDelta {
+  added: readonly string[];
+  changed: readonly string[];
+  invalidated: readonly string[];
+}
+
+export interface ReconciledPractices {
+  sources: readonly PracticeSource[];
+  effectivePractices: readonly EffectivePractice[];
+  delta: RevisionDelta;
+  advancesEffectiveRevision: boolean;
+}

--- a/packages/engine/src/local-store/storage/artifacts/artifact-store.test.ts
+++ b/packages/engine/src/local-store/storage/artifacts/artifact-store.test.ts
@@ -43,6 +43,24 @@ test("promotion verifies an existing artifact before treating it as idempotent",
   });
 });
 
+test("promotion rejects a digest-mismatched target for lifecycle to handle safely", async () => {
+  await withDirectory(async (root) => {
+    const firstStaging = join(root, "first-staging");
+    await mkdir(firstStaging);
+    await writeFile(join(firstStaging, "pack.yaml"), "name: platform\n");
+    const digest = await calculateArtifactDigest(firstStaging);
+    const target = await promoteArtifact(root, "p-platform", digest, firstStaging);
+
+    await writeFile(join(target, "pack.yaml"), "tampered\n");
+    const secondStaging = join(root, "second-staging");
+    await mkdir(secondStaging);
+    await writeFile(join(secondStaging, "pack.yaml"), "name: platform\n");
+    await expect(promoteArtifact(root, "p-platform", digest, secondStaging)).rejects.toThrow(
+      "existing artifact digest differs",
+    );
+  });
+});
+
 test("artifact digest rejects symbolic links instead of following them", async () => {
   await withDirectory(async (path) => {
     await writeFile(join(path, "outside.txt"), "outside");

--- a/packages/engine/src/local-store/storage/artifacts/artifact-store.test.ts
+++ b/packages/engine/src/local-store/storage/artifacts/artifact-store.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createPackCandidate } from "../../model";
+import { calculateArtifactDigest, promoteArtifact, sealSnapshot } from "./artifact-store";
+import { createProjection } from "./projection";
+
+async function withDirectory(run: (path: string) => Promise<void>): Promise<void> {
+  const path = await mkdtemp(join(tmpdir(), "lorelum-artifact-"));
+  try {
+    await run(path);
+  } finally {
+    await rm(path, { recursive: true, force: true });
+  }
+}
+
+test("artifact digest is stable across file creation order and reacts to raw bytes", async () => {
+  await withDirectory(async (path) => {
+    const first = join(path, "first");
+    const second = join(path, "second");
+    await mkdir(join(first, "nested"), { recursive: true });
+    await mkdir(join(second, "nested"), { recursive: true });
+    await writeFile(join(first, "nested", "b.txt"), "b\r\n");
+    await writeFile(join(first, "a.txt"), "a\n");
+    await writeFile(join(second, "a.txt"), "a\n");
+    await writeFile(join(second, "nested", "b.txt"), "b\r\n");
+    expect(await calculateArtifactDigest(first)).toBe(await calculateArtifactDigest(second));
+    await writeFile(join(second, "nested", "b.txt"), "b\n");
+    expect(await calculateArtifactDigest(first)).not.toBe(await calculateArtifactDigest(second));
+  });
+});
+
+test("promotion verifies an existing artifact before treating it as idempotent", async () => {
+  await withDirectory(async (root) => {
+    const staging = join(root, "staging");
+    await mkdir(staging);
+    await writeFile(join(staging, "pack.yaml"), "name: platform\n");
+    const digest = await calculateArtifactDigest(staging);
+    const target = await promoteArtifact(root, "p-platform", digest, staging);
+    expect(target).toContain(digest);
+  });
+});
+
+test("artifact digest rejects symbolic links instead of following them", async () => {
+  await withDirectory(async (path) => {
+    await writeFile(join(path, "outside.txt"), "outside");
+    try {
+      await symlink(join(path, "outside.txt"), join(path, "linked.txt"));
+    } catch (error) {
+      if (typeof error === "object" && error !== null && "code" in error && error.code === "EPERM")
+        return;
+      throw error;
+    }
+    expect(calculateArtifactDigest(path)).rejects.toThrow("symbolic links are not allowed");
+  });
+});
+
+test("sealing publishes the generated projection before calculating the digest", async () => {
+  await withDirectory(async (path) => {
+    const { candidate } = createPackCandidate(
+      {
+        pack: { name: "platform", version: "1.0.0" },
+        practices: [],
+        decisions: [],
+      },
+      {},
+    );
+    const digest = await sealSnapshot(path, createProjection(candidate.pack, candidate.sources));
+    expect(await readFile(join(path, ".lorelum", "local-store-projection.json"), "utf8")).toContain(
+      '"projectionVersion":1',
+    );
+    expect(digest).toBe(await calculateArtifactDigest(path));
+  });
+});

--- a/packages/engine/src/local-store/storage/artifacts/artifact-store.ts
+++ b/packages/engine/src/local-store/storage/artifacts/artifact-store.ts
@@ -1,0 +1,123 @@
+import { createHash } from "node:crypto";
+import { cp, lstat, mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+
+import { ArtifactIntegrityError } from "../errors";
+
+import {
+  PROJECTION_RELATIVE_PATH,
+  type SnapshotProjection,
+  serializeProjection,
+} from "./projection";
+
+function posixRelative(rootPath: string, path: string): string {
+  return relative(rootPath, path).split(sep).join("/");
+}
+
+async function collectFiles(rootPath: string, directory = rootPath): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nestedFiles = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name);
+      if (entry.isSymbolicLink()) {
+        throw new ArtifactIntegrityError(path, "symbolic links are not allowed in a snapshot");
+      }
+      if (entry.isDirectory()) return collectFiles(rootPath, path);
+      return entry.isFile() ? [path] : [];
+    }),
+  );
+  const files = nestedFiles.flat();
+  return files.sort((left, right) => {
+    const leftRelative = posixRelative(rootPath, left);
+    const rightRelative = posixRelative(rootPath, right);
+    return leftRelative < rightRelative ? -1 : leftRelative > rightRelative ? 1 : 0;
+  });
+}
+
+/** Hash every regular snapshot file using ADR 0007's path-NUL-content-LF encoding. */
+export async function calculateArtifactDigest(snapshotPath: string): Promise<string> {
+  const hash = createHash("sha256");
+  const paths = await collectFiles(snapshotPath);
+  const contents = await Promise.all(paths.map((path) => readFile(path)));
+  for (const [index, path] of paths.entries()) {
+    const content = contents[index];
+    if (content === undefined) throw new ArtifactIntegrityError(path, "file content was not read");
+    hash.update(posixRelative(snapshotPath, path), "utf8");
+    hash.update(Buffer.from([0]));
+    hash.update(content);
+    hash.update(Buffer.from([10]));
+  }
+  return hash.digest("hex");
+}
+
+/** Write the generated projection before calculating the sealed artifact digest. */
+export async function sealSnapshot(
+  snapshotPath: string,
+  projection: SnapshotProjection,
+): Promise<string> {
+  const projectionPath = join(snapshotPath, PROJECTION_RELATIVE_PATH);
+  const temporaryPath = projectionPath + ".tmp-" + crypto.randomUUID();
+  await mkdir(join(snapshotPath, ".lorelum"), { recursive: true });
+  try {
+    await writeFile(temporaryPath, serializeProjection(projection), "utf8");
+    await rename(temporaryPath, projectionPath);
+  } catch {
+    await rm(temporaryPath, { force: true });
+    throw new ArtifactIntegrityError(snapshotPath, "cannot publish the generated projection");
+  }
+  return calculateArtifactDigest(snapshotPath);
+}
+
+export function artifactPath(rootPath: string, storageKey: string, artifactDigest: string): string {
+  if (!/^p-[a-z0-9]+(?:-[a-z0-9]+)*$/.test(storageKey) || !/^[a-f0-9]{64}$/.test(artifactDigest)) {
+    throw new ArtifactIntegrityError(rootPath, "storage key or artifact digest is unsafe");
+  }
+  return join(rootPath, "packs", storageKey, artifactDigest);
+}
+
+/**
+ * Promote a staged snapshot into its immutable location. Existing artifacts are
+ * accepted only after recomputing their complete digest.
+ */
+export async function promoteArtifact(
+  rootPath: string,
+  storageKey: string,
+  artifactDigest: string,
+  stagedSnapshotPath: string,
+  replaceExisting = false,
+): Promise<string> {
+  const stagedDigest = await calculateArtifactDigest(stagedSnapshotPath);
+  if (stagedDigest !== artifactDigest) {
+    throw new ArtifactIntegrityError(
+      stagedSnapshotPath,
+      "staged digest does not match requested artifact digest",
+    );
+  }
+  const target = artifactPath(rootPath, storageKey, artifactDigest);
+  try {
+    const existing = await lstat(target);
+    if (existing.isSymbolicLink())
+      throw new ArtifactIntegrityError(target, "target must not be a symbolic link");
+    if (!existing.isDirectory())
+      throw new ArtifactIntegrityError(target, "target is not a directory");
+    if ((await calculateArtifactDigest(target)) === artifactDigest) return target;
+    if (!replaceExisting)
+      throw new ArtifactIntegrityError(target, "existing artifact digest differs");
+    await rm(target, { recursive: true, force: false });
+  } catch (error) {
+    if (
+      !(typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT")
+    ) {
+      if (error instanceof ArtifactIntegrityError) throw error;
+      throw new ArtifactIntegrityError(target, "cannot inspect promotion target");
+    }
+  }
+  await mkdir(join(rootPath, "packs", storageKey), { recursive: true });
+  await rename(stagedSnapshotPath, target);
+  return target;
+}
+
+/** Convenience for tests and future lifecycle staging; it never follows symlinks. */
+export async function copySnapshot(sourcePath: string, stagingPath: string): Promise<void> {
+  await cp(sourcePath, stagingPath, { recursive: true, dereference: false, errorOnExist: true });
+}

--- a/packages/engine/src/local-store/storage/artifacts/artifact-store.ts
+++ b/packages/engine/src/local-store/storage/artifacts/artifact-store.ts
@@ -16,17 +16,22 @@ function posixRelative(rootPath: string, path: string): string {
 
 async function collectFiles(rootPath: string, directory = rootPath): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true });
-  const nestedFiles = await Promise.all(
-    entries.map(async (entry) => {
-      const path = join(directory, entry.name);
-      if (entry.isSymbolicLink()) {
-        throw new ArtifactIntegrityError(path, "symbolic links are not allowed in a snapshot");
-      }
-      if (entry.isDirectory()) return collectFiles(rootPath, path);
-      return entry.isFile() ? [path] : [];
-    }),
-  );
-  const files = nestedFiles.flat();
+  const files: string[] = [];
+  async function visit(index: number): Promise<void> {
+    const entry = entries[index];
+    if (entry === undefined) return;
+    const path = join(directory, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new ArtifactIntegrityError(path, "symbolic links are not allowed in a snapshot");
+    }
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(rootPath, path)));
+    } else if (entry.isFile()) {
+      files.push(path);
+    }
+    await visit(index + 1);
+  }
+  await visit(0);
   return files.sort((left, right) => {
     const leftRelative = posixRelative(rootPath, left);
     const rightRelative = posixRelative(rootPath, right);
@@ -38,15 +43,16 @@ async function collectFiles(rootPath: string, directory = rootPath): Promise<str
 export async function calculateArtifactDigest(snapshotPath: string): Promise<string> {
   const hash = createHash("sha256");
   const paths = await collectFiles(snapshotPath);
-  const contents = await Promise.all(paths.map((path) => readFile(path)));
-  for (const [index, path] of paths.entries()) {
-    const content = contents[index];
-    if (content === undefined) throw new ArtifactIntegrityError(path, "file content was not read");
+  async function hashFile(index: number): Promise<void> {
+    const path = paths[index];
+    if (path === undefined) return;
     hash.update(posixRelative(snapshotPath, path), "utf8");
     hash.update(Buffer.from([0]));
-    hash.update(content);
+    hash.update(await readFile(path));
     hash.update(Buffer.from([10]));
+    await hashFile(index + 1);
   }
+  await hashFile(0);
   return hash.digest("hex");
 }
 
@@ -84,7 +90,6 @@ export async function promoteArtifact(
   storageKey: string,
   artifactDigest: string,
   stagedSnapshotPath: string,
-  replaceExisting = false,
 ): Promise<string> {
   const stagedDigest = await calculateArtifactDigest(stagedSnapshotPath);
   if (stagedDigest !== artifactDigest) {
@@ -101,9 +106,7 @@ export async function promoteArtifact(
     if (!existing.isDirectory())
       throw new ArtifactIntegrityError(target, "target is not a directory");
     if ((await calculateArtifactDigest(target)) === artifactDigest) return target;
-    if (!replaceExisting)
-      throw new ArtifactIntegrityError(target, "existing artifact digest differs");
-    await rm(target, { recursive: true, force: false });
+    throw new ArtifactIntegrityError(target, "existing artifact digest differs");
   } catch (error) {
     if (
       !(typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT")

--- a/packages/engine/src/local-store/storage/artifacts/projection.test.ts
+++ b/packages/engine/src/local-store/storage/artifacts/projection.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+
+import { createPackCandidate } from "../../model";
+import { createProjection, parseProjection, serializeProjection } from "./projection";
+
+test("projection records canonical source data in source-path order", () => {
+  const { candidate } = createPackCandidate(
+    {
+      pack: { name: "platform", version: "1.0.0" },
+      practices: [
+        {
+          id: "platform.second",
+          title: "Second",
+          stage: "api",
+          tech_stack: ["typescript"],
+          applies_when: "always",
+        },
+        {
+          id: "platform.first",
+          title: "First",
+          stage: "api",
+          tech_stack: ["typescript"],
+          applies_when: "always",
+        },
+      ],
+      decisions: [],
+    },
+    {
+      "platform.second": "practices/z.md",
+      "platform.first": "practices/a.md",
+    },
+  );
+  const projection = createProjection(candidate.pack, candidate.sources);
+
+  expect(projection.practices.map((practice) => practice.sourcePath)).toEqual([
+    "practices/a.md",
+    "practices/z.md",
+  ]);
+  expect(parseProjection(serializeProjection(projection), "snapshot")).toEqual(projection);
+});
+
+test("projection rejects untrusted JSON shapes", () => {
+  expect(() =>
+    parseProjection('{"projectionVersion":1,"pack":{},"practices":[{}]}', "snapshot"),
+  ).toThrow("projection Pack metadata is invalid");
+});
+
+test("projection rejects a forged canonical payload or unsafe source metadata", () => {
+  expect(() =>
+    parseProjection(
+      '{"projectionVersion":1,"pack":{"name":"platform","version":"1.0.0"},"practices":[{"id":"platform.api","contentDigest":"' +
+        "a".repeat(64) +
+        '","canonicalContent":"{}","sourcePath":"../api.md"}]}',
+      "snapshot",
+    ),
+  ).toThrow("projection canonical content violates Practice schema");
+});

--- a/packages/engine/src/local-store/storage/artifacts/projection.test.ts
+++ b/packages/engine/src/local-store/storage/artifacts/projection.test.ts
@@ -6,7 +6,7 @@ import { createProjection, parseProjection, serializeProjection } from "./projec
 test("projection records canonical source data in source-path order", () => {
   const { candidate } = createPackCandidate(
     {
-      pack: { name: "platform", version: "1.0.0" },
+      pack: { name: "platform", version: "1.0.0", applies_to: ["typescript"] },
       practices: [
         {
           id: "platform.second",
@@ -36,7 +36,9 @@ test("projection records canonical source data in source-path order", () => {
     "practices/a.md",
     "practices/z.md",
   ]);
-  expect(parseProjection(serializeProjection(projection), "snapshot")).toEqual(projection);
+  const parsed = parseProjection(serializeProjection(projection), "snapshot");
+  expect(parsed).toEqual(projection);
+  expect(Object.isFrozen(parsed.pack.applies_to)).toBe(true);
 });
 
 test("projection rejects untrusted JSON shapes", () => {

--- a/packages/engine/src/local-store/storage/artifacts/projection.ts
+++ b/packages/engine/src/local-store/storage/artifacts/projection.ts
@@ -1,0 +1,132 @@
+import { PackSchema, PracticeSchema } from "@lorelum/format";
+
+import {
+  canonicalizePractice,
+  isPracticeSourcePath,
+  type PackSnapshot,
+  type PracticeSource,
+} from "../../model";
+
+import { ArtifactIntegrityError } from "../errors";
+
+export const PROJECTION_RELATIVE_PATH = ".lorelum/local-store-projection.json";
+export const PROJECTION_VERSION = 1;
+
+export interface SnapshotProjection {
+  projectionVersion: number;
+  pack: PackSnapshot;
+  practices: readonly ProjectionPractice[];
+}
+
+export interface ProjectionPractice {
+  id: string;
+  contentDigest: string;
+  canonicalContent: string;
+  sourcePath: string;
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function createProjection(
+  pack: PackSnapshot,
+  sources: readonly PracticeSource[],
+): SnapshotProjection {
+  return Object.freeze({
+    projectionVersion: PROJECTION_VERSION,
+    pack,
+    practices: Object.freeze(
+      sources
+        .map((source) =>
+          Object.freeze({
+            id: source.practiceId,
+            contentDigest: source.contentDigest,
+            canonicalContent: source.canonicalPractice.canonicalContent,
+            sourcePath: source.sourcePath,
+          }),
+        )
+        .sort((left, right) => compareCodeUnits(left.sourcePath, right.sourcePath)),
+    ),
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Decode generated JSON without trusting arbitrary projection shapes. */
+export function parseProjection(text: string, artifactPath: string): SnapshotProjection {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    throw new ArtifactIntegrityError(artifactPath, "projection is not valid JSON");
+  }
+  if (!isRecord(value) || value.projectionVersion !== PROJECTION_VERSION || !isRecord(value.pack)) {
+    throw new ArtifactIntegrityError(artifactPath, "projection has an unsupported shape");
+  }
+  if (!Array.isArray(value.practices)) {
+    throw new ArtifactIntegrityError(artifactPath, "projection practices must be an array");
+  }
+  const pack = PackSchema.safeParse(value.pack);
+  if (!pack.success)
+    throw new ArtifactIntegrityError(artifactPath, "projection Pack metadata is invalid");
+  const practiceIds = new Set<string>();
+  const sourcePaths = new Set<string>();
+  const practices: ProjectionPractice[] = value.practices.map((practice) => {
+    if (
+      !isRecord(practice) ||
+      typeof practice.id !== "string" ||
+      typeof practice.contentDigest !== "string" ||
+      typeof practice.canonicalContent !== "string" ||
+      typeof practice.sourcePath !== "string"
+    ) {
+      throw new ArtifactIntegrityError(
+        artifactPath,
+        "projection contains an invalid practice entry",
+      );
+    }
+    let canonicalPractice: unknown;
+    try {
+      canonicalPractice = JSON.parse(practice.canonicalContent);
+    } catch {
+      throw new ArtifactIntegrityError(artifactPath, "projection canonical content is not JSON");
+    }
+    const parsedPractice = PracticeSchema.safeParse(canonicalPractice);
+    if (!parsedPractice.success) {
+      throw new ArtifactIntegrityError(
+        artifactPath,
+        "projection canonical content violates Practice schema",
+      );
+    }
+    const canonical = canonicalizePractice(parsedPractice.data);
+    if (
+      canonical.canonicalContent !== practice.canonicalContent ||
+      canonical.contentDigest !== practice.contentDigest ||
+      canonical.practice.id !== practice.id ||
+      !isPracticeSourcePath(practice.sourcePath) ||
+      practiceIds.has(practice.id) ||
+      sourcePaths.has(practice.sourcePath)
+    ) {
+      throw new ArtifactIntegrityError(artifactPath, "projection practice data is inconsistent");
+    }
+    practiceIds.add(practice.id);
+    sourcePaths.add(practice.sourcePath);
+    return Object.freeze({
+      id: practice.id,
+      contentDigest: practice.contentDigest,
+      canonicalContent: practice.canonicalContent,
+      sourcePath: practice.sourcePath,
+    });
+  });
+  return Object.freeze({
+    projectionVersion: PROJECTION_VERSION,
+    pack: Object.freeze(structuredClone(pack.data)) as PackSnapshot,
+    practices: Object.freeze(practices),
+  });
+}
+
+export function serializeProjection(projection: SnapshotProjection): string {
+  return JSON.stringify(projection) + "\n";
+}

--- a/packages/engine/src/local-store/storage/artifacts/projection.ts
+++ b/packages/engine/src/local-store/storage/artifacts/projection.ts
@@ -2,6 +2,7 @@ import { PackSchema, PracticeSchema } from "@lorelum/format";
 
 import {
   canonicalizePractice,
+  deepFreeze,
   isPracticeSourcePath,
   type PackSnapshot,
   type PracticeSource,
@@ -122,7 +123,7 @@ export function parseProjection(text: string, artifactPath: string): SnapshotPro
   });
   return Object.freeze({
     projectionVersion: PROJECTION_VERSION,
-    pack: Object.freeze(structuredClone(pack.data)) as PackSnapshot,
+    pack: deepFreeze(structuredClone(pack.data)) as PackSnapshot,
     practices: Object.freeze(practices),
   });
 }

--- a/packages/engine/src/local-store/storage/artifacts/snapshot-codec.test.ts
+++ b/packages/engine/src/local-store/storage/artifacts/snapshot-codec.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -43,5 +43,23 @@ test("SnapshotCodec delegates duplicate Practice ids to the format validation ga
       "---\nid: platform.api\ntitle: Duplicate\nstage: api\ntech_stack: [typescript]\napplies_when: always\n---\nDuplicate.\n",
     );
     await expect(decodeSnapshot(path)).rejects.toBeInstanceOf(PackValidationError);
+  });
+});
+
+test("SnapshotCodec rejects a symbolic pack manifest before parsing it", async () => {
+  await withSnapshot(async (path) => {
+    const manifestPath = join(path, "pack.yaml");
+    const outsidePath = join(path, "outside-pack.yaml");
+    await writeFile(outsidePath, "name: platform\nversion: 1.0.0\n");
+    await rm(manifestPath);
+    try {
+      await symlink(outsidePath, manifestPath);
+    } catch (error) {
+      if (typeof error === "object" && error !== null && "code" in error && error.code === "EPERM")
+        return;
+      throw error;
+    }
+
+    await expect(decodeSnapshot(path)).rejects.toThrow("symbolic links are not allowed");
   });
 });

--- a/packages/engine/src/local-store/storage/artifacts/snapshot-codec.test.ts
+++ b/packages/engine/src/local-store/storage/artifacts/snapshot-codec.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { PackValidationError } from "../../model";
+import { decodeSnapshot } from "./snapshot-codec";
+
+async function withSnapshot(run: (path: string) => Promise<void>): Promise<void> {
+  const path = await mkdtemp(join(tmpdir(), "lorelum-snapshot-"));
+  try {
+    await mkdir(join(path, "practices"));
+    await writeFile(join(path, "pack.yaml"), "name: platform\nversion: 1.0.0\n");
+    await writeFile(
+      join(path, "practices", "api.md"),
+      "---\nid: platform.api\ntitle: API\nstage: api\ntech_stack: [typescript]\napplies_when: always\n---\nUse APIs.\n",
+    );
+    await run(path);
+  } finally {
+    await rm(path, { recursive: true, force: true });
+  }
+}
+
+test("SnapshotCodec injects Markdown body and normalizes source paths", async () => {
+  await withSnapshot(async (path) => {
+    const decoded = await decodeSnapshot(path);
+    expect(decoded.candidate.sources[0]?.sourcePath).toBe("practices/api.md");
+    expect(decoded.candidate.sources[0]?.canonicalPractice.practice.body).toBe("Use APIs.\n");
+  });
+});
+
+test("SnapshotCodec rejects a decisions wrapper object", async () => {
+  await withSnapshot(async (path) => {
+    await writeFile(join(path, "decisions.yaml"), "decisions: []\n");
+    expect(decodeSnapshot(path)).rejects.toThrow("top-level sequence");
+  });
+});
+
+test("SnapshotCodec delegates duplicate Practice ids to the format validation gate", async () => {
+  await withSnapshot(async (path) => {
+    await writeFile(
+      join(path, "practices", "duplicate.md"),
+      "---\nid: platform.api\ntitle: Duplicate\nstage: api\ntech_stack: [typescript]\napplies_when: always\n---\nDuplicate.\n",
+    );
+    await expect(decodeSnapshot(path)).rejects.toBeInstanceOf(PackValidationError);
+  });
+});

--- a/packages/engine/src/local-store/storage/artifacts/snapshot-codec.ts
+++ b/packages/engine/src/local-store/storage/artifacts/snapshot-codec.ts
@@ -1,4 +1,5 @@
-import { readdir, readFile } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import { lstat, readdir, readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 import { parseFrontmatter, parseYaml, type PackInput, type ValidationIssue } from "@lorelum/format";
@@ -12,33 +13,82 @@ function relativePath(rootPath: string, filePath: string): string {
 }
 
 async function discoverPractices(directory: string): Promise<string[]> {
-  let entries;
+  let entries: Dirent[];
   try {
     entries = await readdir(directory, { withFileTypes: true });
   } catch (error) {
     throw new SnapshotFormatError(directory, "cannot read practices directory", error);
   }
-  const discovered = await Promise.all(
-    entries.map(async (entry) => {
-      const path = join(directory, entry.name);
-      if (entry.isDirectory()) return discoverPractices(path);
-      return entry.isFile() && entry.name.endsWith(".md") ? [path] : [];
-    }),
-  );
-  const paths = discovered.flat();
+  const paths: string[] = [];
+  async function visit(index: number): Promise<void> {
+    const entry = entries[index];
+    if (entry === undefined) return;
+    const path = join(directory, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new SnapshotFormatError(directory, "symbolic links are not allowed in a snapshot");
+    }
+    if (entry.isDirectory()) {
+      paths.push(...(await discoverPractices(path)));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      paths.push(path);
+    }
+    await visit(index + 1);
+  }
+  await visit(0);
   return paths.sort();
+}
+
+async function readSnapshotFile(snapshotPath: string, path: string): Promise<string> {
+  try {
+    const metadata = await lstat(path);
+    if (metadata.isSymbolicLink()) {
+      throw new SnapshotFormatError(snapshotPath, "symbolic links are not allowed in a snapshot");
+    }
+    if (!metadata.isFile()) {
+      throw new SnapshotFormatError(snapshotPath, "snapshot path is not a regular file");
+    }
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (error instanceof SnapshotFormatError) throw error;
+    throw new SnapshotFormatError(
+      snapshotPath,
+      "cannot read " + relativePath(snapshotPath, path),
+      error,
+    );
+  }
+}
+
+async function decodePracticeFiles(
+  snapshotPath: string,
+  practicePaths: readonly string[],
+): Promise<unknown[]> {
+  const practices: unknown[] = [];
+  async function visit(index: number): Promise<void> {
+    const path = practicePaths[index];
+    if (path === undefined) return;
+    practices.push(await decodePracticeFile(snapshotPath, path));
+    await visit(index + 1);
+  }
+  await visit(0);
+  return practices;
 }
 
 async function decodeDecisions(snapshotPath: string): Promise<unknown[]> {
   const path = join(snapshotPath, "decisions.yaml");
   let raw: string;
   try {
-    raw = await readFile(path, "utf8");
+    raw = await readSnapshotFile(snapshotPath, path);
   } catch (error) {
-    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+    if (
+      error instanceof SnapshotFormatError &&
+      typeof error.rootCause === "object" &&
+      error.rootCause !== null &&
+      "code" in error.rootCause &&
+      error.rootCause.code === "ENOENT"
+    ) {
       return [];
     }
-    throw new SnapshotFormatError(snapshotPath, "cannot read decisions.yaml", error);
+    throw error;
   }
   let value: unknown;
   try {
@@ -60,8 +110,9 @@ export interface DecodedSnapshot {
 async function decodePracticeFile(snapshotPath: string, path: string): Promise<unknown> {
   let frontmatter;
   try {
-    frontmatter = parseFrontmatter(await readFile(path, "utf8"));
+    frontmatter = parseFrontmatter(await readSnapshotFile(snapshotPath, path));
   } catch (error) {
+    if (error instanceof SnapshotFormatError) throw error;
     throw new SnapshotFormatError(
       snapshotPath,
       "cannot parse " + relativePath(snapshotPath, path),
@@ -73,12 +124,7 @@ async function decodePracticeFile(snapshotPath: string, path: string): Promise<u
 
 /** Reads Pack files and applies the format validation gate before storage sees a candidate. */
 export async function decodeSnapshot(snapshotPath: string): Promise<DecodedSnapshot> {
-  let rawPack: string;
-  try {
-    rawPack = await readFile(join(snapshotPath, "pack.yaml"), "utf8");
-  } catch (error) {
-    throw new SnapshotFormatError(snapshotPath, "cannot read pack.yaml", error);
-  }
+  const rawPack = await readSnapshotFile(snapshotPath, join(snapshotPath, "pack.yaml"));
   let parsedYaml: unknown;
   try {
     parsedYaml = parseYaml(rawPack);
@@ -86,9 +132,7 @@ export async function decodeSnapshot(snapshotPath: string): Promise<DecodedSnaps
     throw new SnapshotFormatError(snapshotPath, "pack.yaml cannot be parsed as YAML", error);
   }
   const practicePaths = await discoverPractices(join(snapshotPath, "practices"));
-  const practices = await Promise.all(
-    practicePaths.map((practicePath) => decodePracticeFile(snapshotPath, practicePath)),
-  );
+  const practices = await decodePracticeFiles(snapshotPath, practicePaths);
   const sourcePaths: Record<string, string> = Object.create(null) as Record<string, string>;
   for (const [index, practice] of practices.entries()) {
     const practicePath = practicePaths[index];

--- a/packages/engine/src/local-store/storage/artifacts/snapshot-codec.ts
+++ b/packages/engine/src/local-store/storage/artifacts/snapshot-codec.ts
@@ -2,7 +2,7 @@ import type { Dirent } from "node:fs";
 import { lstat, readdir, readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
-import { parseFrontmatter, parseYaml, type PackInput, type ValidationIssue } from "@lorelum/format";
+import { parseFrontmatter, parseYaml, type ValidationIssue } from "@lorelum/format";
 
 import { createPackCandidate, type PackCandidate } from "../../model";
 
@@ -148,11 +148,12 @@ export async function decodeSnapshot(snapshotPath: string): Promise<DecodedSnaps
       sourcePaths[practice.id] = relativePath(snapshotPath, practicePath);
     }
   }
-  // Candidate construction validates all external YAML and frontmatter values.
+  // Candidate construction validates all external YAML and frontmatter
+  // values (parsePackInput gates on format before anything is trusted).
   const input = {
     pack: parsedYaml,
     practices,
     decisions: await decodeDecisions(snapshotPath),
-  } as PackInput;
+  };
   return Object.freeze(createPackCandidate(input, sourcePaths));
 }

--- a/packages/engine/src/local-store/storage/artifacts/snapshot-codec.ts
+++ b/packages/engine/src/local-store/storage/artifacts/snapshot-codec.ts
@@ -1,0 +1,114 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+
+import { parseFrontmatter, parseYaml, type PackInput, type ValidationIssue } from "@lorelum/format";
+
+import { createPackCandidate, type PackCandidate } from "../../model";
+
+import { SnapshotFormatError } from "../errors";
+
+function relativePath(rootPath: string, filePath: string): string {
+  return relative(rootPath, filePath).split(sep).join("/");
+}
+
+async function discoverPractices(directory: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    throw new SnapshotFormatError(directory, "cannot read practices directory", error);
+  }
+  const discovered = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) return discoverPractices(path);
+      return entry.isFile() && entry.name.endsWith(".md") ? [path] : [];
+    }),
+  );
+  const paths = discovered.flat();
+  return paths.sort();
+}
+
+async function decodeDecisions(snapshotPath: string): Promise<unknown[]> {
+  const path = join(snapshotPath, "decisions.yaml");
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+    throw new SnapshotFormatError(snapshotPath, "cannot read decisions.yaml", error);
+  }
+  let value: unknown;
+  try {
+    value = parseYaml(raw);
+  } catch (error) {
+    throw new SnapshotFormatError(snapshotPath, "decisions.yaml cannot be parsed as YAML", error);
+  }
+  if (!Array.isArray(value)) {
+    throw new SnapshotFormatError(snapshotPath, "decisions.yaml must be a top-level sequence");
+  }
+  return value;
+}
+
+export interface DecodedSnapshot {
+  candidate: PackCandidate;
+  diagnostics: readonly ValidationIssue[];
+}
+
+async function decodePracticeFile(snapshotPath: string, path: string): Promise<unknown> {
+  let frontmatter;
+  try {
+    frontmatter = parseFrontmatter(await readFile(path, "utf8"));
+  } catch (error) {
+    throw new SnapshotFormatError(
+      snapshotPath,
+      "cannot parse " + relativePath(snapshotPath, path),
+      error,
+    );
+  }
+  return { ...frontmatter.data, body: frontmatter.content };
+}
+
+/** Reads Pack files and applies the format validation gate before storage sees a candidate. */
+export async function decodeSnapshot(snapshotPath: string): Promise<DecodedSnapshot> {
+  let rawPack: string;
+  try {
+    rawPack = await readFile(join(snapshotPath, "pack.yaml"), "utf8");
+  } catch (error) {
+    throw new SnapshotFormatError(snapshotPath, "cannot read pack.yaml", error);
+  }
+  let parsedYaml: unknown;
+  try {
+    parsedYaml = parseYaml(rawPack);
+  } catch (error) {
+    throw new SnapshotFormatError(snapshotPath, "pack.yaml cannot be parsed as YAML", error);
+  }
+  const practicePaths = await discoverPractices(join(snapshotPath, "practices"));
+  const practices = await Promise.all(
+    practicePaths.map((practicePath) => decodePracticeFile(snapshotPath, practicePath)),
+  );
+  const sourcePaths: Record<string, string> = Object.create(null) as Record<string, string>;
+  for (const [index, practice] of practices.entries()) {
+    const practicePath = practicePaths[index];
+    if (practicePath === undefined) {
+      throw new SnapshotFormatError(snapshotPath, "practice discovery changed unexpectedly");
+    }
+    if (
+      typeof practice === "object" &&
+      practice !== null &&
+      "id" in practice &&
+      typeof practice.id === "string"
+    ) {
+      sourcePaths[practice.id] = relativePath(snapshotPath, practicePath);
+    }
+  }
+  // Candidate construction validates all external YAML and frontmatter values.
+  const input = {
+    pack: parsedYaml,
+    practices,
+    decisions: await decodeDecisions(snapshotPath),
+  } as PackInput;
+  return Object.freeze(createPackCandidate(input, sourcePaths));
+}

--- a/packages/engine/src/local-store/storage/errors.ts
+++ b/packages/engine/src/local-store/storage/errors.ts
@@ -9,13 +9,17 @@ export class LocalStoreStorageError extends Error {
   }
 }
 
-/** An immutable snapshot is missing, altered, or cannot be promoted safely. */
+/**
+ * An immutable snapshot is missing, altered, or cannot be promoted safely.
+ * The path stays a structured field — the message stays generic so CLI/MCP
+ * boundaries decide what to surface (paths may contain sensitive names).
+ */
 export class ArtifactIntegrityError extends LocalStoreStorageError {
   constructor(
     readonly artifactPath: string,
     message: string,
   ) {
-    super('Artifact at "' + artifactPath + '" is invalid: ' + message);
+    super("Artifact is invalid: " + message);
     this.name = "ArtifactIntegrityError";
   }
 }
@@ -27,7 +31,7 @@ export class SnapshotFormatError extends LocalStoreStorageError {
     message: string,
     cause?: unknown,
   ) {
-    super('Pack snapshot at "' + snapshotPath + '" is invalid: ' + message, cause);
+    super("Pack snapshot is invalid: " + message, cause);
     this.name = "SnapshotFormatError";
   }
 }
@@ -39,7 +43,7 @@ export class ManifestError extends LocalStoreStorageError {
     message: string,
     cause?: unknown,
   ) {
-    super('Installed-pack manifest at "' + manifestPath + '" is invalid: ' + message, cause);
+    super("Installed-pack manifest is invalid: " + message, cause);
     this.name = "ManifestError";
   }
 }

--- a/packages/engine/src/local-store/storage/errors.ts
+++ b/packages/engine/src/local-store/storage/errors.ts
@@ -1,0 +1,53 @@
+/** A snapshot, manifest, or derived SQLite state violates LocalStore's storage contract. */
+export class LocalStoreStorageError extends Error {
+  constructor(
+    message: string,
+    readonly rootCause?: unknown,
+  ) {
+    super(message, rootCause === undefined ? undefined : { cause: rootCause });
+    this.name = "LocalStoreStorageError";
+  }
+}
+
+/** An immutable snapshot is missing, altered, or cannot be promoted safely. */
+export class ArtifactIntegrityError extends LocalStoreStorageError {
+  constructor(
+    readonly artifactPath: string,
+    message: string,
+  ) {
+    super('Artifact at "' + artifactPath + '" is invalid: ' + message);
+    this.name = "ArtifactIntegrityError";
+  }
+}
+
+/** A Pack snapshot cannot be assembled into the public format input. */
+export class SnapshotFormatError extends LocalStoreStorageError {
+  constructor(
+    readonly snapshotPath: string,
+    message: string,
+    cause?: unknown,
+  ) {
+    super('Pack snapshot at "' + snapshotPath + '" is invalid: ' + message, cause);
+    this.name = "SnapshotFormatError";
+  }
+}
+
+/** The active manifest is absent or structurally invalid. */
+export class ManifestError extends LocalStoreStorageError {
+  constructor(
+    readonly manifestPath: string,
+    message: string,
+    cause?: unknown,
+  ) {
+    super('Installed-pack manifest at "' + manifestPath + '" is invalid: ' + message, cause);
+    this.name = "ManifestError";
+  }
+}
+
+/** SQLite-derived LocalStore state cannot be decoded or does not meet its contract. */
+export class SqliteStateError extends LocalStoreStorageError {
+  constructor(message: string, cause?: unknown) {
+    super("LocalStore SQLite state is invalid: " + message, cause);
+    this.name = "SqliteStateError";
+  }
+}

--- a/packages/engine/src/local-store/storage/manifest/manifest-store.test.ts
+++ b/packages/engine/src/local-store/storage/manifest/manifest-store.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createEmptyManifest, parseManifest, readManifest, writeManifest } from "./manifest-store";
+
+test("manifest atomically round-trips its authoritative tuple", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lorelum-manifest-"));
+  try {
+    const manifest = {
+      ...createEmptyManifest(),
+      generation: 2,
+      effectiveRevision: 5,
+      packs: [
+        {
+          packName: "platform",
+          packVersion: "1.0.0",
+          artifactDigest: "a".repeat(64),
+          storageKey: "p-platform",
+          installedAt: "2026-07-27T00:00:00.000Z",
+        },
+      ],
+    };
+    await writeManifest(root, manifest);
+    expect(await readManifest(root)).toEqual(manifest);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("manifest rejects unstable or unsafe Pack entries", () => {
+  expect(() =>
+    parseManifest(
+      '{"schemaVersion":1,"generation":0,"effectiveRevision":0,"packs":[{"packName":"con","packVersion":"1.0.0","artifactDigest":"' +
+        "a".repeat(64) +
+        '","storageKey":"con","installedAt":"2026-07-27T00:00:00.000Z"}]}',
+      "manifest",
+    ),
+  ).toThrow("invalid Pack entry");
+});
+
+test("manifest rejects a path-like Pack name before it reaches filesystem code", () => {
+  expect(() =>
+    parseManifest(
+      '{"schemaVersion":1,"generation":0,"effectiveRevision":0,"packs":[{"packName":"../../escape","packVersion":"1.0.0","artifactDigest":"' +
+        "a".repeat(64) +
+        '","storageKey":"p-../../escape","installedAt":"2026-07-27T00:00:00.000Z"}]}',
+      "manifest",
+    ),
+  ).toThrow("invalid Pack entry");
+});

--- a/packages/engine/src/local-store/storage/manifest/manifest-store.ts
+++ b/packages/engine/src/local-store/storage/manifest/manifest-store.ts
@@ -1,0 +1,147 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { PackSchema } from "@lorelum/format";
+
+import { ManifestError } from "../errors";
+
+export const MANIFEST_FILE_NAME = "installed-packs.json";
+export const MANIFEST_SCHEMA_VERSION = 1;
+
+export interface InstalledPackManifestEntry {
+  packName: string;
+  packVersion: string;
+  artifactDigest: string;
+  storageKey: string;
+  installedAt: string;
+}
+
+export interface InstalledPacksManifest {
+  schemaVersion: number;
+  generation: number;
+  effectiveRevision: number;
+  packs: readonly InstalledPackManifestEntry[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function manifestPath(rootPath: string): string {
+  return join(rootPath, MANIFEST_FILE_NAME);
+}
+
+/** Validate and freeze the recovery-source manifest before any caller uses it. */
+export function parseManifest(text: string, path: string): InstalledPacksManifest {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch (error) {
+    throw new ManifestError(path, "not valid JSON", error);
+  }
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== MANIFEST_SCHEMA_VERSION ||
+    !isNonNegativeInteger(value.generation) ||
+    !isNonNegativeInteger(value.effectiveRevision) ||
+    !Array.isArray(value.packs)
+  ) {
+    throw new ManifestError(path, "has an unsupported shape");
+  }
+  const seenNames = new Set<string>();
+  const packs = value.packs.map((entry) => {
+    const packIdentity =
+      isRecord(entry) &&
+      PackSchema.pick({ name: true, version: true }).safeParse({
+        name: entry.packName,
+        version: entry.packVersion,
+      }).success;
+    if (
+      !isRecord(entry) ||
+      !packIdentity ||
+      typeof entry.packName !== "string" ||
+      typeof entry.packVersion !== "string" ||
+      typeof entry.artifactDigest !== "string" ||
+      !/^[a-f0-9]{64}$/.test(entry.artifactDigest) ||
+      typeof entry.storageKey !== "string" ||
+      entry.storageKey !== "p-" + entry.packName ||
+      typeof entry.installedAt !== "string" ||
+      Number.isNaN(Date.parse(entry.installedAt)) ||
+      new Date(entry.installedAt).toISOString() !== entry.installedAt ||
+      seenNames.has(entry.packName)
+    ) {
+      throw new ManifestError(path, "contains an invalid Pack entry");
+    }
+    seenNames.add(entry.packName);
+    return Object.freeze({
+      packName: entry.packName,
+      packVersion: entry.packVersion,
+      artifactDigest: entry.artifactDigest,
+      storageKey: entry.storageKey,
+      installedAt: entry.installedAt,
+    });
+  });
+  if (
+    packs.some(
+      (entry, index) =>
+        index > 0 && compareCodeUnits(packs[index - 1]?.packName ?? "", entry.packName) >= 0,
+    )
+  ) {
+    throw new ManifestError(path, "Pack entries must be ordered by packName");
+  }
+  return Object.freeze({
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    generation: value.generation,
+    effectiveRevision: value.effectiveRevision,
+    packs: Object.freeze(packs),
+  });
+}
+
+export function createEmptyManifest(): InstalledPacksManifest {
+  return Object.freeze({
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    generation: 0,
+    effectiveRevision: 0,
+    packs: Object.freeze([]),
+  });
+}
+
+export function serializeManifest(manifest: InstalledPacksManifest): string {
+  return JSON.stringify(manifest) + "\n";
+}
+
+export async function readManifest(rootPath: string): Promise<InstalledPacksManifest> {
+  const path = manifestPath(rootPath);
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch (error) {
+    throw new ManifestError(path, "cannot be read", error);
+  }
+  return parseManifest(text, path);
+}
+
+/** Atomically publish the sole recovery-source manifest. */
+export async function writeManifest(
+  rootPath: string,
+  manifest: InstalledPacksManifest,
+): Promise<void> {
+  const path = manifestPath(rootPath);
+  const temporaryPath = path + ".tmp-" + crypto.randomUUID();
+  parseManifest(serializeManifest(manifest), path);
+  await mkdir(dirname(path), { recursive: true });
+  try {
+    await writeFile(temporaryPath, serializeManifest(manifest), "utf8");
+    await rename(temporaryPath, path);
+  } catch (error) {
+    throw new ManifestError(path, "cannot be published atomically", error);
+  }
+}

--- a/packages/engine/src/local-store/storage/sqlite/database.ts
+++ b/packages/engine/src/local-store/storage/sqlite/database.ts
@@ -1,0 +1,28 @@
+import { Database } from "bun:sqlite";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { SqliteStateError } from "../errors";
+
+import { migrateDatabase } from "./migrations";
+
+export const SQLITE_FILE_NAME = "store.sqlite";
+
+export function sqlitePath(rootPath: string): string {
+  return join(rootPath, SQLITE_FILE_NAME);
+}
+
+/** Opens and migrates a LocalStore database; callers own the returned handle. */
+export async function openStoreDatabase(rootPath: string): Promise<Database> {
+  let database: Database | undefined;
+  try {
+    await mkdir(rootPath, { recursive: true });
+    database = new Database(sqlitePath(rootPath));
+    migrateDatabase(database);
+    return database;
+  } catch (error) {
+    database?.close();
+    if (error instanceof SqliteStateError) throw error;
+    throw new SqliteStateError("cannot open LocalStore database", error);
+  }
+}

--- a/packages/engine/src/local-store/storage/sqlite/migrations.test.ts
+++ b/packages/engine/src/local-store/storage/sqlite/migrations.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { LOCAL_STORE_SCHEMA_VERSION, migrateDatabase } from "./migrations";
+
+test("migrations create the LocalStore-only schema and are idempotent", () => {
+  const database = new Database(":memory:");
+  try {
+    migrateDatabase(database);
+    migrateDatabase(database);
+
+    expect(database.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: LOCAL_STORE_SCHEMA_VERSION,
+    });
+    expect(
+      database
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('local_store_metadata', 'active_packs', 'practice_sources', 'effective_practices') ORDER BY name",
+        )
+        .all()
+        .map((row) => (row as { name: string }).name),
+    ).toEqual(["active_packs", "effective_practices", "local_store_metadata", "practice_sources"]);
+  } finally {
+    database.close();
+  }
+});
+
+test("migrations reject a database from a newer LocalStore schema", () => {
+  const database = new Database(":memory:");
+  try {
+    database.exec("PRAGMA user_version = 2");
+    expect(() => migrateDatabase(database)).toThrow("schema version is unsupported");
+  } finally {
+    database.close();
+  }
+});

--- a/packages/engine/src/local-store/storage/sqlite/migrations.ts
+++ b/packages/engine/src/local-store/storage/sqlite/migrations.ts
@@ -1,0 +1,45 @@
+import type { Database } from "bun:sqlite";
+
+import { SqliteStateError } from "../errors";
+
+export const LOCAL_STORE_SCHEMA_VERSION = 1;
+
+const INITIAL_SCHEMA = [
+  "CREATE TABLE IF NOT EXISTS local_store_metadata (singleton INTEGER PRIMARY KEY CHECK (singleton = 1), schema_version INTEGER NOT NULL, installed_packs_generation INTEGER NOT NULL, effective_revision INTEGER NOT NULL)",
+  "CREATE TABLE IF NOT EXISTS active_packs (pack_name TEXT PRIMARY KEY, pack_version TEXT NOT NULL, artifact_digest TEXT NOT NULL, storage_key TEXT NOT NULL, installed_at TEXT NOT NULL)",
+  "CREATE TABLE IF NOT EXISTS practice_sources (pack_name TEXT NOT NULL, practice_id TEXT NOT NULL, content_digest TEXT NOT NULL, source_path TEXT NOT NULL, PRIMARY KEY (pack_name, practice_id), FOREIGN KEY (pack_name) REFERENCES active_packs(pack_name) ON DELETE CASCADE, FOREIGN KEY (practice_id) REFERENCES effective_practices(practice_id) ON DELETE CASCADE)",
+  "CREATE TABLE IF NOT EXISTS effective_practices (practice_id TEXT PRIMARY KEY, content_digest TEXT NOT NULL, canonical_content TEXT NOT NULL, title TEXT NOT NULL, stage TEXT NOT NULL, tech_stack_json TEXT NOT NULL, applies_when TEXT NOT NULL, severity TEXT NOT NULL, effective_revision INTEGER NOT NULL)",
+  "CREATE INDEX IF NOT EXISTS practice_sources_by_practice ON practice_sources(practice_id, pack_name, source_path)",
+].join(";");
+
+function userVersion(database: Database): number {
+  const row = database.prepare("PRAGMA user_version").get() as Record<string, unknown> | undefined;
+  if (
+    row === undefined ||
+    typeof row.user_version !== "number" ||
+    !Number.isSafeInteger(row.user_version)
+  ) {
+    throw new SqliteStateError("SQLite user_version is malformed");
+  }
+  return row.user_version;
+}
+
+/** Applies LocalStore-owned schema migrations in one SQLite transaction. */
+export function migrateDatabase(database: Database): void {
+  try {
+    database.exec("PRAGMA foreign_keys = ON");
+    database.transaction(() => {
+      const currentVersion = userVersion(database);
+      if (currentVersion < 0 || currentVersion > LOCAL_STORE_SCHEMA_VERSION) {
+        throw new SqliteStateError("SQLite schema version is unsupported");
+      }
+      if (currentVersion === 0) {
+        database.exec(INITIAL_SCHEMA);
+        database.exec("PRAGMA user_version = " + LOCAL_STORE_SCHEMA_VERSION);
+      }
+    })();
+  } catch (error) {
+    if (error instanceof SqliteStateError) throw error;
+    throw new SqliteStateError("SQLite migration failed", error);
+  }
+}

--- a/packages/engine/src/local-store/storage/sqlite/snapshot-reader.ts
+++ b/packages/engine/src/local-store/storage/sqlite/snapshot-reader.ts
@@ -1,0 +1,166 @@
+import type { Database } from "bun:sqlite";
+
+import { PracticeSchema } from "@lorelum/format";
+
+import {
+  canonicalizePractice,
+  isPracticeSourcePath,
+  type EffectivePractice,
+  type PracticeSource,
+} from "../../model";
+
+import { SqliteStateError } from "../errors";
+
+import { LOCAL_STORE_SCHEMA_VERSION } from "./migrations";
+
+export interface StoreMetadataSnapshot {
+  schemaVersion: number;
+  generation: number;
+  effectiveRevision: number;
+}
+
+export interface EffectivePracticeSnapshot {
+  metadata: StoreMetadataSnapshot;
+  effectivePractices: readonly EffectivePractice[];
+}
+
+interface MaterializedRow {
+  practice_id: string;
+  content_digest: string;
+  canonical_content: string;
+  title: string;
+  stage: string;
+  tech_stack_json: string;
+  applies_when: string;
+  severity: string;
+  effective_revision: number;
+  pack_name: string;
+  source_path: string;
+  source_digest: string;
+}
+
+function isMaterializedRow(value: unknown): value is MaterializedRow {
+  if (typeof value !== "object" || value === null) return false;
+  const row = value as Record<string, unknown>;
+  return (
+    typeof row.practice_id === "string" &&
+    typeof row.content_digest === "string" &&
+    typeof row.canonical_content === "string" &&
+    typeof row.title === "string" &&
+    typeof row.stage === "string" &&
+    typeof row.tech_stack_json === "string" &&
+    typeof row.applies_when === "string" &&
+    typeof row.severity === "string" &&
+    typeof row.effective_revision === "number" &&
+    typeof row.pack_name === "string" &&
+    typeof row.source_path === "string" &&
+    typeof row.source_digest === "string"
+  );
+}
+
+function effectiveFromRow(row: MaterializedRow): EffectivePractice {
+  let canonicalObject: unknown;
+  try {
+    canonicalObject = JSON.parse(row.canonical_content);
+  } catch (error) {
+    throw new SqliteStateError("effective canonical content is not JSON", error);
+  }
+  const parsedPractice = PracticeSchema.safeParse(canonicalObject);
+  if (!parsedPractice.success) {
+    throw new SqliteStateError("effective canonical content violates Practice schema");
+  }
+  const canonical = canonicalizePractice(parsedPractice.data);
+  if (
+    canonical.canonicalContent !== row.canonical_content ||
+    canonical.contentDigest !== row.content_digest ||
+    canonical.practice.id !== row.practice_id ||
+    canonical.practice.title !== row.title ||
+    canonical.practice.stage !== row.stage ||
+    JSON.stringify(canonical.practice.tech_stack) !== row.tech_stack_json ||
+    canonical.practice.applies_when !== row.applies_when ||
+    canonical.practice.severity !== row.severity
+  ) {
+    throw new SqliteStateError("effective Practice materialization is inconsistent");
+  }
+  return Object.freeze({
+    practiceId: row.practice_id,
+    contentDigest: row.content_digest,
+    canonicalContent: row.canonical_content,
+    practice: canonical.practice,
+    sources: Object.freeze([]),
+  });
+}
+
+function readMetadata(database: Database): StoreMetadataSnapshot {
+  const row = database
+    .prepare(
+      "SELECT schema_version, installed_packs_generation, effective_revision FROM local_store_metadata WHERE singleton = 1",
+    )
+    .get() as Record<string, unknown> | undefined;
+  if (
+    row === undefined ||
+    row.schema_version !== LOCAL_STORE_SCHEMA_VERSION ||
+    typeof row.installed_packs_generation !== "number" ||
+    typeof row.effective_revision !== "number"
+  ) {
+    throw new SqliteStateError("LocalStore metadata row is missing or malformed");
+  }
+  return Object.freeze({
+    schemaVersion: row.schema_version,
+    generation: row.installed_packs_generation,
+    effectiveRevision: row.effective_revision,
+  });
+}
+
+/** Materializes Effective Practices and sources from one deterministically ordered SQL statement. */
+export function readEffectivePracticeSnapshot(database: Database): EffectivePracticeSnapshot {
+  try {
+    return database.transaction(() => {
+      const metadata = readMetadata(database);
+      const rows = database
+        .prepare(
+          "SELECT e.practice_id, e.content_digest, e.canonical_content, e.title, e.stage, e.tech_stack_json, e.applies_when, e.severity, e.effective_revision, s.pack_name, s.source_path, s.content_digest AS source_digest FROM effective_practices e LEFT JOIN practice_sources s ON s.practice_id = e.practice_id ORDER BY e.practice_id ASC, s.pack_name ASC, s.source_path ASC",
+        )
+        .all();
+
+      const practices: EffectivePractice[] = [];
+      let effective: EffectivePractice | undefined;
+      let sources: PracticeSource[] = [];
+      for (const rawRow of rows) {
+        if (!isMaterializedRow(rawRow)) throw new SqliteStateError("materialized row is malformed");
+        if (
+          rawRow.effective_revision !== metadata.effectiveRevision ||
+          !isPracticeSourcePath(rawRow.source_path)
+        ) {
+          throw new SqliteStateError("materialized Practice row is inconsistent with metadata");
+        }
+        if (effective === undefined || effective.practiceId !== rawRow.practice_id) {
+          if (effective !== undefined) {
+            practices.push(Object.freeze({ ...effective, sources: Object.freeze(sources) }));
+          }
+          effective = effectiveFromRow(rawRow);
+          sources = [];
+        }
+        if (effective.contentDigest !== rawRow.source_digest) {
+          throw new SqliteStateError("source digest differs from effective Practice digest");
+        }
+        sources.push(
+          Object.freeze({
+            packName: rawRow.pack_name,
+            practiceId: effective.practiceId,
+            contentDigest: effective.contentDigest,
+            sourcePath: rawRow.source_path,
+            canonicalPractice: canonicalizePractice(effective.practice),
+          }),
+        );
+      }
+      if (effective !== undefined) {
+        practices.push(Object.freeze({ ...effective, sources: Object.freeze(sources) }));
+      }
+      return Object.freeze({ metadata, effectivePractices: Object.freeze(practices) });
+    })();
+  } catch (error) {
+    if (error instanceof SqliteStateError) throw error;
+    throw new SqliteStateError("cannot materialize Effective Practices", error);
+  }
+}

--- a/packages/engine/src/local-store/storage/sqlite/state-writer.test.ts
+++ b/packages/engine/src/local-store/storage/sqlite/state-writer.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { reactPack } from "@lorelum/format";
+
+import { createPackCandidate, reconcileEffectivePractices } from "../../model";
+
+import { migrateDatabase } from "./migrations";
+import { readEffectivePracticeSnapshot } from "./snapshot-reader";
+import { writeDerivedState } from "./state-writer";
+
+function candidate(name: string) {
+  const input = reactPack();
+  input.pack.name = name;
+  return createPackCandidate(input, {
+    "react.api.layered-design": "practices/api/layered-design.md",
+    "react.state.redux": "practices/state/redux.md",
+    "react.auth.guard": "practices/auth/guard.md",
+  }).candidate;
+}
+
+function activePack(packName: string) {
+  return {
+    packName,
+    packVersion: "0.1.0",
+    artifactDigest: packName === "react-core" ? "a".repeat(64) : "b".repeat(64),
+    storageKey: "p-" + packName,
+    installedAt: "2026-07-27T00:00:00.000Z",
+  };
+}
+
+test("writer and reader round-trip derived state with deterministic source ordering", () => {
+  const database = new Database(":memory:");
+  try {
+    migrateDatabase(database);
+    const first = reconcileEffectivePractices([], candidate("react-core"));
+    const reconciled = reconcileEffectivePractices(first.sources, candidate("react-fullstack"));
+    writeDerivedState(database, {
+      generation: 3,
+      effectiveRevision: 7,
+      activePacks: [activePack("react-core"), activePack("react-fullstack")],
+      effectivePractices: reconciled.effectivePractices,
+    });
+
+    const snapshot = readEffectivePracticeSnapshot(database);
+    expect(snapshot.metadata).toEqual({
+      schemaVersion: 1,
+      generation: 3,
+      effectiveRevision: 7,
+    });
+    expect(snapshot.effectivePractices.map((practice) => practice.practiceId)).toEqual([
+      "react.api.layered-design",
+      "react.auth.guard",
+      "react.state.redux",
+    ]);
+    expect(snapshot.effectivePractices[0]?.sources.map((source) => source.packName)).toEqual([
+      "react-core",
+      "react-fullstack",
+    ]);
+  } finally {
+    database.close();
+  }
+});
+
+test("reader rejects an Effective Practice whose stored metadata was tampered", () => {
+  const database = new Database(":memory:");
+  try {
+    migrateDatabase(database);
+    const reconciled = reconcileEffectivePractices([], candidate("react-core"));
+    writeDerivedState(database, {
+      generation: 1,
+      effectiveRevision: 1,
+      activePacks: [activePack("react-core")],
+      effectivePractices: reconciled.effectivePractices,
+    });
+    database
+      .prepare("UPDATE effective_practices SET title = 'tampered' WHERE practice_id = ?")
+      .run("react.api.layered-design");
+
+    expect(() => readEffectivePracticeSnapshot(database)).toThrow(
+      "materialization is inconsistent",
+    );
+  } finally {
+    database.close();
+  }
+});
+
+test("writer rejects an Effective Practice whose source data was tampered", () => {
+  const database = new Database(":memory:");
+  try {
+    migrateDatabase(database);
+    const reconciled = reconcileEffectivePractices([], candidate("react-core"));
+    const effective = reconciled.effectivePractices[0]!;
+    expect(() =>
+      writeDerivedState(database, {
+        generation: 1,
+        effectiveRevision: 1,
+        activePacks: [activePack("react-core")],
+        effectivePractices: [
+          {
+            ...effective,
+            sources: [{ ...effective.sources[0]!, sourcePath: "practices/../escape.md" }],
+          },
+        ],
+      }),
+    ).toThrow("source is inconsistent");
+  } finally {
+    database.close();
+  }
+});

--- a/packages/engine/src/local-store/storage/sqlite/state-writer.ts
+++ b/packages/engine/src/local-store/storage/sqlite/state-writer.ts
@@ -1,0 +1,111 @@
+import type { Database } from "bun:sqlite";
+
+import { canonicalizePractice, isPracticeSourcePath, type EffectivePractice } from "../../model";
+import type { InstalledPackManifestEntry } from "../manifest/manifest-store";
+import { SqliteStateError } from "../errors";
+
+export interface DerivedStoreState {
+  generation: number;
+  effectiveRevision: number;
+  activePacks: readonly InstalledPackManifestEntry[];
+  effectivePractices: readonly EffectivePractice[];
+}
+
+function assertStateIsCoherent(state: DerivedStoreState): void {
+  if (
+    !Number.isSafeInteger(state.generation) ||
+    state.generation < 0 ||
+    !Number.isSafeInteger(state.effectiveRevision) ||
+    state.effectiveRevision < 0
+  ) {
+    throw new SqliteStateError("generation or effective revision is invalid");
+  }
+  const packNames = new Set(state.activePacks.map((pack) => pack.packName));
+  for (const effective of state.effectivePractices) {
+    const canonical = canonicalizePractice(effective.practice);
+    if (
+      effective.sources.length === 0 ||
+      canonical.canonicalContent !== effective.canonicalContent ||
+      canonical.contentDigest !== effective.contentDigest ||
+      canonical.practice.id !== effective.practiceId
+    ) {
+      throw new SqliteStateError("Effective Practice is inconsistent with canonical content");
+    }
+    for (const source of effective.sources) {
+      if (
+        !packNames.has(source.packName) ||
+        source.practiceId !== effective.practiceId ||
+        source.contentDigest !== effective.contentDigest ||
+        source.canonicalPractice.canonicalContent !== effective.canonicalContent ||
+        source.canonicalPractice.contentDigest !== effective.contentDigest ||
+        !isPracticeSourcePath(source.sourcePath)
+      ) {
+        throw new SqliteStateError("Effective Practice source is inconsistent with derived state");
+      }
+    }
+  }
+}
+
+/** Replaces SQLite's fully-derived LocalStore state in one write transaction. */
+export function writeDerivedState(database: Database, state: DerivedStoreState): void {
+  assertStateIsCoherent(state);
+  try {
+    database.transaction(() => {
+      database.exec("DELETE FROM practice_sources");
+      database.exec("DELETE FROM effective_practices");
+      database.exec("DELETE FROM active_packs");
+      database.exec("DELETE FROM local_store_metadata");
+
+      const insertPack = database.prepare(
+        "INSERT INTO active_packs (pack_name, pack_version, artifact_digest, storage_key, installed_at) VALUES (?, ?, ?, ?, ?)",
+      );
+      for (const pack of state.activePacks) {
+        insertPack.run(
+          pack.packName,
+          pack.packVersion,
+          pack.artifactDigest,
+          pack.storageKey,
+          pack.installedAt,
+        );
+      }
+
+      const insertEffective = database.prepare(
+        "INSERT INTO effective_practices (practice_id, content_digest, canonical_content, title, stage, tech_stack_json, applies_when, severity, effective_revision) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      );
+      const insertSource = database.prepare(
+        "INSERT INTO practice_sources (pack_name, practice_id, content_digest, source_path) VALUES (?, ?, ?, ?)",
+      );
+      for (const effective of state.effectivePractices) {
+        const practice = effective.practice;
+        insertEffective.run(
+          effective.practiceId,
+          effective.contentDigest,
+          effective.canonicalContent,
+          practice.title,
+          practice.stage,
+          JSON.stringify(practice.tech_stack),
+          practice.applies_when,
+          practice.severity ?? "warn",
+          state.effectiveRevision,
+        );
+        for (const source of effective.sources) {
+          insertSource.run(
+            source.packName,
+            source.practiceId,
+            source.contentDigest,
+            source.sourcePath,
+          );
+        }
+      }
+
+      database
+        .prepare(
+          "INSERT INTO local_store_metadata (singleton, schema_version, installed_packs_generation, effective_revision) VALUES (1, 1, ?, ?)",
+        )
+        .run(state.generation, state.effectiveRevision);
+    })();
+  } catch (error) {
+    if (error instanceof SqliteStateError) throw error;
+    throw new SqliteStateError("cannot write LocalStore derived state", error);
+  }
+}

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -14,6 +14,10 @@
   "dependencies": {
     "@lorelum/shared": "workspace:*",
     "gray-matter": "4.0.3",
+    "js-yaml": "3.14.2",
     "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "4.0.9"
   }
 }

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@lorelum/shared": "workspace:*",
     "gray-matter": "4.0.3",
-    "js-yaml": "3.14.2",
+    "js-yaml": "4.3.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/packages/format/src/frontmatter/parse.test.ts
+++ b/packages/format/src/frontmatter/parse.test.ts
@@ -91,6 +91,13 @@ describe("parseYaml safety", () => {
     expect(parseYaml(doc)).toEqual({ base: [1], refs: [[1], [1]] });
   });
 
+  test("alias budget boundary: exactly MAX_ALIAS_VISITS re-references pass, one more fails", () => {
+    const refs = (count: number) =>
+      `base: &base [1]\nrefs: [${Array.from({ length: count }, () => "*base").join(", ")}]`;
+    expect(parseYaml(refs(16))).toBeDefined();
+    expect(() => parseYaml(refs(17))).toThrow(RangeError);
+  });
+
   test("rejects custom JS types from DEFAULT_SCHEMA", () => {
     expect(() => parseYaml("fn: !!js/function 'return 1'")).toThrow();
     expect(() => parseYaml("undef: !!js/undefined")).toThrow();

--- a/packages/format/src/frontmatter/parse.test.ts
+++ b/packages/format/src/frontmatter/parse.test.ts
@@ -103,6 +103,20 @@ describe("parseYaml safety", () => {
     expect(() => parseYaml("undef: !!js/undefined")).toThrow();
   });
 
+  test("alias bombs in frontmatter are rejected through parseFrontmatter", () => {
+    const bomb = [
+      "a: &a [1]",
+      "b: &b [*a, *a]",
+      "c: &c [*b, *b]",
+      "d: &d [*c, *c]",
+      "e: &e [*d, *d]",
+      "f: &f [*e, *e]",
+      "g: &g [*f, *f]",
+      "h: &h [*g, *g]",
+    ].join("\n");
+    expect(() => parseFrontmatter(`---\n${bomb}\n---\nbody`)).toThrow(RangeError);
+  });
+
   test("rejects oversized documents", () => {
     const oversized = "key: " + "x".repeat(512 * 1024);
     expect(() => parseYaml(oversized)).toThrow(RangeError);

--- a/packages/format/src/frontmatter/parse.test.ts
+++ b/packages/format/src/frontmatter/parse.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { PracticeSchema } from "../schema";
-import { parseFrontmatter } from "./parse";
+import { parseFrontmatter, parseYaml } from "./parse";
 
 describe("parseFrontmatter", () => {
   test("parses frontmatter and body", () => {
@@ -59,5 +59,12 @@ Guidance body.`;
     const { data } = parseFrontmatter(md);
     const r = PracticeSchema.safeParse(data);
     expect(r.success).toBe(true);
+  });
+});
+
+test("parseYaml parses a standalone YAML document", () => {
+  expect(parseYaml("name: platform\nitems:\n  - one\n")).toEqual({
+    name: "platform",
+    items: ["one"],
   });
 });

--- a/packages/format/src/frontmatter/parse.test.ts
+++ b/packages/format/src/frontmatter/parse.test.ts
@@ -68,3 +68,36 @@ test("parseYaml parses a standalone YAML document", () => {
     items: ["one"],
   });
 });
+
+describe("parseYaml safety", () => {
+  test("rejects nested alias bombs (exponential expansion via shared subtrees)", () => {
+    // Each level doubles the alias references; js-yaml resolves aliases
+    // lazily, so this parses fine and explodes on first traversal. The alias
+    // budget check must reject it before any consumer expands it.
+    const bomb: string[] = ["n0: &n0 [1]"];
+    for (let i = 1; i < 30; i++) {
+      bomb.push(`n${i}: &n${i} [*n${i - 1}, *n${i - 1}]`);
+    }
+    expect(() => parseYaml(bomb.join("\n"))).toThrow();
+  });
+
+  test("rejects flat alias bombs (one subtree referenced many times)", () => {
+    const flat = `base: &base [1, 2, 3]\nitems: [${Array.from({ length: 100 }, () => "*base").join(", ")}]`;
+    expect(() => parseYaml(flat)).toThrow();
+  });
+
+  test("accepts legitimate bounded alias use", () => {
+    const doc = "base: &base [1]\nrefs: [*base, *base]";
+    expect(parseYaml(doc)).toEqual({ base: [1], refs: [[1], [1]] });
+  });
+
+  test("rejects custom JS types from DEFAULT_SCHEMA", () => {
+    expect(() => parseYaml("fn: !!js/function 'return 1'")).toThrow();
+    expect(() => parseYaml("undef: !!js/undefined")).toThrow();
+  });
+
+  test("rejects oversized documents", () => {
+    const oversized = "key: " + "x".repeat(512 * 1024);
+    expect(() => parseYaml(oversized)).toThrow(RangeError);
+  });
+});

--- a/packages/format/src/frontmatter/parse.ts
+++ b/packages/format/src/frontmatter/parse.ts
@@ -2,6 +2,61 @@ import matter from "gray-matter";
 import yaml from "js-yaml";
 
 /**
+ * This module is the workspace's single YAML dependency point. Both
+ * `parseFrontmatter` (via gray-matter) and `parseYaml` run the same js-yaml
+ * engine; switching YAML libraries (per ADR 0002) means changing this one
+ * file and `@lorelum/format`'s declared dependency, nothing else.
+ */
+
+// Pack files are external input. js-yaml 4.x never instantiates custom JS
+// types and bounds merge keys, but it resolves aliases lazily — a bomb
+// document parses fine and only explodes on the first full traversal by a
+// consumer. These guardrails reject both bomb shapes before that happens.
+const MAX_YAML_INPUT_BYTES = 512 * 1024;
+const MAX_ALIAS_VISITS = 16;
+const MAX_STRUCTURE_NODES = 100_000;
+const MAX_STRUCTURE_DEPTH = 64;
+
+function assertInputSize(text: string): void {
+  if (Buffer.byteLength(text, "utf8") > MAX_YAML_INPUT_BYTES) {
+    throw new RangeError(`YAML input exceeds ${MAX_YAML_INPUT_BYTES} bytes`);
+  }
+}
+
+/**
+ * Reject documents whose shared subtrees would expand exponentially on
+ * traversal. Each parsed object may be re-reached via YAML aliases only a
+ * bounded number of times; normal Pack files never share subtrees, so this
+ * only ever trips on alias bombs.
+ */
+function assertAliasBudget(value: unknown): void {
+  const visits = new Map<object, number>();
+  let nodes = 0;
+  function walk(node: unknown, depth: number): void {
+    if (typeof node !== "object" || node === null) return;
+    if (depth > MAX_STRUCTURE_DEPTH) {
+      throw new RangeError("YAML document exceeds the nesting depth budget");
+    }
+    const count = (visits.get(node) ?? 0) + 1;
+    if (count > MAX_ALIAS_VISITS) {
+      throw new RangeError("YAML document exceeds the alias reference budget");
+    }
+    visits.set(node, count);
+    nodes += 1;
+    if (nodes > MAX_STRUCTURE_NODES) {
+      throw new RangeError("YAML document exceeds the structure node budget");
+    }
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item, depth + 1);
+    } else {
+      const record = node as Record<string, unknown>;
+      for (const key of Object.keys(record)) walk(record[key], depth + 1);
+    }
+  }
+  walk(value, 0);
+}
+
+/**
  * Result of parsing a markdown file with YAML frontmatter. Mirrors the two
  * fields consumers need from gray-matter; `.excerpt`/`.orig`/`.matter` are
  * intentionally not surfaced (exposing them leaks the parser choice).
@@ -17,17 +72,28 @@ export interface ParsedFrontmatter {
  * Parse a markdown string with `---` YAML frontmatter.
  *
  * Thin wrapper over gray-matter — this is the single swap point if we move
- * to `front-matter` (same API shape), per ADR 0002.
+ * to `front-matter` (same API shape), per ADR 0002. The YAML engine is
+ * overridden with the same guarded parser `parseYaml` uses, so frontmatter
+ * gets identical safety without depending on gray-matter's internal defaults.
  *
  * Malformed YAML propagates the underlying `YAMLException` — this wrapper
  * does not catch it. Callers (CLI/MCP) translate it into user-facing output.
  */
 export function parseFrontmatter(markdown: string): ParsedFrontmatter {
-  const result = matter(markdown);
+  const result = matter(markdown, {
+    // gray-matter's engine interface types the result as `object`; the
+    // guarded parser returns `unknown` because the input is untrusted.
+    engines: { yaml: { parse: (input: string) => parseYaml(input) as object } },
+  });
   return { data: result.data, content: result.content };
 }
 
 /** Parse a standalone YAML document used by Pack metadata. */
 export function parseYaml(text: string): unknown {
-  return yaml.load(text);
+  assertInputSize(text);
+  // js-yaml 4.x's `load` is safe by default: no JS-type tags, bounded merge
+  // keys, bounded nesting depth. (`safeLoad` was removed in 4.x.)
+  const value = yaml.load(text);
+  assertAliasBudget(value);
+  return value;
 }

--- a/packages/format/src/frontmatter/parse.ts
+++ b/packages/format/src/frontmatter/parse.ts
@@ -1,4 +1,5 @@
 import matter from "gray-matter";
+import yaml from "js-yaml";
 
 /**
  * Result of parsing a markdown file with YAML frontmatter. Mirrors the two
@@ -24,4 +25,9 @@ export interface ParsedFrontmatter {
 export function parseFrontmatter(markdown: string): ParsedFrontmatter {
   const result = matter(markdown);
   return { data: result.data, content: result.content };
+}
+
+/** Parse a standalone YAML document used by Pack metadata. */
+export function parseYaml(text: string): unknown {
+  return yaml.load(text);
 }

--- a/packages/format/src/frontmatter/parse.ts
+++ b/packages/format/src/frontmatter/parse.ts
@@ -13,7 +13,7 @@ import yaml from "js-yaml";
 // document parses fine and only explodes on the first full traversal by a
 // consumer. These guardrails reject both bomb shapes before that happens.
 const MAX_YAML_INPUT_BYTES = 512 * 1024;
-const MAX_ALIAS_VISITS = 16;
+const MAX_ALIAS_REUSES = 16;
 const MAX_STRUCTURE_NODES = 100_000;
 const MAX_STRUCTURE_DEPTH = 64;
 
@@ -25,9 +25,10 @@ function assertInputSize(text: string): void {
 
 /**
  * Reject documents whose shared subtrees would expand exponentially on
- * traversal. Each parsed object may be re-reached via YAML aliases only a
- * bounded number of times; normal Pack files never share subtrees, so this
- * only ever trips on alias bombs.
+ * traversal. A parsed object may be re-reached via YAML aliases at most
+ * `MAX_ALIAS_REUSES` times (its first definition visit does not count);
+ * normal Pack files never share subtrees, so this only ever trips on alias
+ * bombs.
  */
 function assertAliasBudget(value: unknown): void {
   const visits = new Map<object, number>();
@@ -37,11 +38,17 @@ function assertAliasBudget(value: unknown): void {
     if (depth > MAX_STRUCTURE_DEPTH) {
       throw new RangeError("YAML document exceeds the nesting depth budget");
     }
-    const count = (visits.get(node) ?? 0) + 1;
-    if (count > MAX_ALIAS_VISITS) {
-      throw new RangeError("YAML document exceeds the alias reference budget");
+    const previous = visits.get(node);
+    if (previous !== undefined) {
+      // previous counts total visits including the first; reuse budget is
+      // exhausted when the next visit would be the (MAX_ALIAS_REUSES + 1)th.
+      if (previous > MAX_ALIAS_REUSES) {
+        throw new RangeError("YAML document exceeds the alias reference budget");
+      }
+      visits.set(node, previous + 1);
+    } else {
+      visits.set(node, 1);
     }
-    visits.set(node, count);
     nodes += 1;
     if (nodes > MAX_STRUCTURE_NODES) {
       throw new RangeError("YAML document exceeds the structure node budget");

--- a/packages/format/src/frontmatter/parse.ts
+++ b/packages/format/src/frontmatter/parse.ts
@@ -18,7 +18,9 @@ const MAX_STRUCTURE_NODES = 100_000;
 const MAX_STRUCTURE_DEPTH = 64;
 
 function assertInputSize(text: string): void {
-  if (Buffer.byteLength(text, "utf8") > MAX_YAML_INPUT_BYTES) {
+  // TextEncoder is a Web-standard global (available in Bun and Node), so the
+  // format package does not depend on Node-specific globals.
+  if (new TextEncoder().encode(text).length > MAX_YAML_INPUT_BYTES) {
     throw new RangeError(`YAML input exceeds ${MAX_YAML_INPUT_BYTES} bytes`);
   }
 }
@@ -88,9 +90,19 @@ export interface ParsedFrontmatter {
  */
 export function parseFrontmatter(markdown: string): ParsedFrontmatter {
   const result = matter(markdown, {
-    // gray-matter's engine interface types the result as `object`; the
-    // guarded parser returns `unknown` because the input is untrusted.
-    engines: { yaml: { parse: (input: string) => parseYaml(input) as object } },
+    // Override gray-matter's YAML engine with the guarded parser and a
+    // matching serializer. js-yaml 4.x removed safeLoad/safeDump, so the
+    // default engine would throw on either path; ours keeps parse and
+    // stringify consistent and both on the same engine.
+    engines: {
+      yaml: {
+        // gray-matter's engine interface types the parse result as `object`;
+        // the guarded parser returns `unknown` because the input is untrusted.
+        parse: (input: string) => parseYaml(input) as object,
+        // Output path: data is trusted (already validated), so no guardrails.
+        stringify: (data: object) => yaml.dump(data),
+      },
+    },
   });
   return { data: result.data, content: result.content };
 }

--- a/packages/format/src/validate/validate.test.ts
+++ b/packages/format/src/validate/validate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { reactPack } from "../fixtures";
-import { validatePack, validatePractice } from "./validate";
+import { parsePackInput, validatePack, validatePractice } from "./validate";
 
 function findCode(
   report: { errors: { code: string }[]; warnings: { code: string }[]; infos: { code: string }[] },
@@ -199,5 +199,29 @@ describe("validatePractice", () => {
     const issues = validatePractice({ id: "bad", title: "x" });
     expect(issues.length).toBeGreaterThan(0);
     expect(issues.every((i) => i.code === "format")).toBe(true);
+  });
+});
+
+describe("parsePackInput", () => {
+  test("valid input yields typed data", () => {
+    const parsed = parsePackInput(reactPack());
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.value.pack.name).toBe("react-fullstack");
+      expect(parsed.value.practices.length).toBe(reactPack().practices.length);
+    }
+  });
+
+  test("untyped input with a format error yields the report, not data", () => {
+    const parsed = parsePackInput({
+      pack: { version: "1.0.0" }, // missing required name
+      practices: [],
+      decisions: [],
+    });
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.report.valid).toBe(false);
+      expect(parsed.report.errors.some((i) => i.code === "format")).toBe(true);
+    }
   });
 });

--- a/packages/format/src/validate/validate.test.ts
+++ b/packages/format/src/validate/validate.test.ts
@@ -86,6 +86,32 @@ describe("validatePack — reference integrity errors", () => {
     expect(findCode(r, "errors", "dangling-ref")).toBe(true);
   });
 
+  test("branch.next may reference a Decision declared later in the file", () => {
+    const input = reactPack();
+    input.decisions = [
+      {
+        id: "state.first-choice",
+        question: "first",
+        branches: [
+          {
+            when: "always",
+            recommend: ["react.state.redux"],
+            reason: "continue",
+            next: "state.later-choice",
+          },
+        ],
+      },
+      {
+        id: "state.later-choice",
+        question: "later",
+        branches: [{ when: "always", recommend: ["react.auth.guard"], reason: "done" }],
+      },
+    ];
+    const report = validatePack(input);
+    expect(report.valid).toBe(true);
+    expect(findCode(report, "errors", "dangling-ref")).toBe(false);
+  });
+
   test("decision cycle via next edges", () => {
     const input = reactPack();
     // Three decisions in a cycle: choice-a → choice-b → choice-c → choice-a.

--- a/packages/format/src/validate/validate.test.ts
+++ b/packages/format/src/validate/validate.test.ts
@@ -224,4 +224,16 @@ describe("parsePackInput", () => {
       expect(parsed.report.errors.some((i) => i.code === "format")).toBe(true);
     }
   });
+
+  test("non-array practices or decisions yield format errors, not TypeErrors", () => {
+    const parsed = parsePackInput({
+      pack: { name: "p", version: "1.0.0" },
+      practices: null as unknown as unknown[],
+      decisions: {} as unknown as unknown[],
+    });
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.report.errors.map((i) => i.path)).toEqual(["practices", "decisions"]);
+    }
+  });
 });

--- a/packages/format/src/validate/validate.ts
+++ b/packages/format/src/validate/validate.ts
@@ -40,6 +40,11 @@ function toDotPath(path: PropertyKey[]): string {
   return out;
 }
 
+/** Array.isArray, but narrowing to unknown[] instead of any[]. */
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
 /** Convert every zod issue from a failed safeParse into a "format" error issue. */
 function zodIssuesToFormatErrors(
   result: { success: false; error: { issues: { path: PropertyKey[]; message: string }[] } },
@@ -71,6 +76,18 @@ export function parsePackInput(
   if (!packParsed.success) {
     issues.push(...zodIssuesToFormatErrors(packParsed, "pack"));
   }
+  // Untrusted input: shape-check the collections before touching elements,
+  // so a non-array yields a format error instead of a TypeError.
+  if (!isUnknownArray(input.practices)) {
+    issues.push(issue("error", "format", "practices", "practices must be an array"));
+  }
+  if (!isUnknownArray(input.decisions)) {
+    issues.push(issue("error", "format", "decisions", "decisions must be an array"));
+  }
+  if (!packParsed.success || !isUnknownArray(input.practices) || !isUnknownArray(input.decisions)) {
+    return { ok: false, report: buildReport(issues) };
+  }
+
   const practiceResults = input.practices.map((p, i) => {
     const r = PracticeSchema.safeParse(p);
     if (!r.success) issues.push(...zodIssuesToFormatErrors(r, `practices[${i}]`));
@@ -83,13 +100,9 @@ export function parsePackInput(
   });
 
   // Direct narrowing: each parse result is checked individually, so after
-  // this guard `packParsed` is known to be the success branch. Array elements
-  // are re-narrowed inside the flatMap below.
-  if (
-    !packParsed.success ||
-    practiceResults.some((r) => !r.success) ||
-    decisionResults.some((r) => !r.success)
-  ) {
+  // this guard the element arrays are known to be fully parsed. Elements are
+  // re-narrowed inside the flatMap below.
+  if (practiceResults.some((r) => !r.success) || decisionResults.some((r) => !r.success)) {
     return { ok: false, report: buildReport(issues) };
   }
   return {

--- a/packages/format/src/validate/validate.ts
+++ b/packages/format/src/validate/validate.ts
@@ -1,7 +1,7 @@
 /**
  * validatePack / validatePractice — the validation entry points.
  *
- * Pipeline: format check (zod safeParse) → reference integrity → cycle
+ * Pipeline: parsePackInput (zod safeParse) → reference integrity → cycle
  * detection → warning/info rules → buildReport. Each stage pushes issues
  * into a single flat list; buildReport buckets them by level at the end.
  *
@@ -15,7 +15,14 @@ import { DecisionNodeSchema, PackSchema, PracticeSchema } from "../schema";
 import { detectCycles } from "./cycle";
 import { buildReport, issue, type ValidationIssue, type ValidationReport } from "./report";
 
-/** The three sources validate needs: pack.yaml metadata + scanned practices + decisions.yaml. */
+/** The three sources before the zod format gate: pack.yaml metadata + scanned practices + decisions.yaml. */
+export interface UnvalidatedPackInput {
+  pack: unknown;
+  practices: unknown[];
+  decisions: unknown[];
+}
+
+/** The three sources after the format gate passes. */
 export interface PackInput {
   pack: Pack;
   practices: Practice[];
@@ -49,10 +56,14 @@ function zodIssuesToFormatErrors(
 }
 
 /**
- * Validate a full pack. Returns a report bucketed by error/warning/info.
- * Pure: no filesystem, no network, no side effects.
+ * Run the zod format gate over untrusted input. Returns the typed PackInput
+ * on success, or the full report (format errors bucketed) on failure — never
+ * throws. Consumers that need typed data (e.g. the engine's candidate
+ * builder) use this instead of re-parsing after validatePack.
  */
-export function validatePack(input: PackInput): ValidationReport {
+export function parsePackInput(
+  input: UnvalidatedPackInput,
+): { ok: true; value: PackInput } | { ok: false; report: ValidationReport } {
   const issues: ValidationIssue[] = [];
 
   // Stage 1 — format check.
@@ -60,25 +71,52 @@ export function validatePack(input: PackInput): ValidationReport {
   if (!packParsed.success) {
     issues.push(...zodIssuesToFormatErrors(packParsed, "pack"));
   }
-  input.practices.forEach((p, i) => {
+  const practiceResults = input.practices.map((p, i) => {
     const r = PracticeSchema.safeParse(p);
     if (!r.success) issues.push(...zodIssuesToFormatErrors(r, `practices[${i}]`));
+    return r;
   });
-  input.decisions.forEach((d, i) => {
+  const decisionResults = input.decisions.map((d, i) => {
     const r = DecisionNodeSchema.safeParse(d);
     if (!r.success) issues.push(...zodIssuesToFormatErrors(r, `decisions[${i}]`));
+    return r;
   });
 
-  // If anything failed format, stop here — semantic checks would only noise.
-  const hasFormatErrors = issues.some((i) => i.level === "error");
-  if (hasFormatErrors) {
-    return buildReport(issues);
+  // Direct narrowing: each parse result is checked individually, so after
+  // this guard `packParsed` is known to be the success branch. Array elements
+  // are re-narrowed inside the flatMap below.
+  if (
+    !packParsed.success ||
+    practiceResults.some((r) => !r.success) ||
+    decisionResults.some((r) => !r.success)
+  ) {
+    return { ok: false, report: buildReport(issues) };
   }
+  return {
+    ok: true,
+    value: {
+      pack: packParsed.data,
+      // flatMap keeps order and types; the guard above guarantees every parse
+      // succeeded, so no element is dropped.
+      practices: practiceResults.flatMap((r) => (r.success ? [r.data] : [])),
+      decisions: decisionResults.flatMap((r) => (r.success ? [r.data] : [])),
+    },
+  };
+}
+
+/**
+ * Run the semantic stages (reference integrity, cycle detection, warnings,
+ * infos) over an already format-validated pack. Pure: no filesystem, no
+ * network, no side effects.
+ */
+export function validateParsedPack(input: PackInput): ValidationReport {
+  const { pack, practices, decisions } = input;
+  const issues: ValidationIssue[] = [];
 
   // Stage 2 — reference integrity.
   const practiceIds = new Set<string>();
   const decisionIds = new Set<string>();
-  input.practices.forEach((p, i) => {
+  practices.forEach((p, i) => {
     if (practiceIds.has(p.id)) {
       issues.push(
         issue("error", "duplicate-id", `practices[${i}].id`, `duplicate practice id "${p.id}"`),
@@ -87,7 +125,7 @@ export function validatePack(input: PackInput): ValidationReport {
       practiceIds.add(p.id);
     }
   });
-  input.decisions.forEach((d, i) => {
+  decisions.forEach((d, i) => {
     if (decisionIds.has(d.id)) {
       issues.push(
         issue("error", "duplicate-id", `decisions[${i}].id`, `duplicate decision id "${d.id}"`),
@@ -96,7 +134,7 @@ export function validatePack(input: PackInput): ValidationReport {
       decisionIds.add(d.id);
     }
   });
-  input.decisions.forEach((d, i) => {
+  decisions.forEach((d, i) => {
     d.branches.forEach((b, bi) => {
       b.recommend.forEach((rid) => {
         if (!practiceIds.has(rid)) {
@@ -127,7 +165,7 @@ export function validatePack(input: PackInput): ValidationReport {
 
   // Stage 3 — cycle detection over the `next` edges.
   const edges = new Map<string, string[]>();
-  for (const d of input.decisions) {
+  for (const d of decisions) {
     const nexts = d.branches.map((b) => b.next).filter((n): n is string => n !== undefined);
     if (nexts.length > 0) edges.set(d.id, nexts);
   }
@@ -136,7 +174,7 @@ export function validatePack(input: PackInput): ValidationReport {
   }
 
   // Stage 4 — warnings (quality risks).
-  if (input.pack.depends_on !== undefined && input.pack.depends_on.length > 0) {
+  if (pack.depends_on !== undefined && pack.depends_on.length > 0) {
     issues.push(
       issue(
         "warning",
@@ -146,7 +184,7 @@ export function validatePack(input: PackInput): ValidationReport {
       ),
     );
   }
-  input.practices.forEach((p, i) => {
+  practices.forEach((p, i) => {
     if (p.severity === undefined) {
       issues.push(
         issue(
@@ -181,7 +219,7 @@ export function validatePack(input: PackInput): ValidationReport {
 
   // Stage 5 — infos (advisory).
   const titles = new Map<string, number>();
-  input.practices.forEach((p, i) => {
+  practices.forEach((p, i) => {
     const prev = titles.get(p.title);
     if (prev !== undefined) {
       issues.push(
@@ -196,18 +234,28 @@ export function validatePack(input: PackInput): ValidationReport {
       titles.set(p.title, i);
     }
   });
-  if (input.practices.length < 3) {
+  if (practices.length < 3) {
     issues.push(
       issue(
         "info",
         "small-pack",
         "practices",
-        `pack has ${input.practices.length} practice(s); fewer than 3`,
+        `pack has ${practices.length} practice(s); fewer than 3`,
       ),
     );
   }
 
   return buildReport(issues);
+}
+
+/**
+ * Validate a full pack. Returns a report bucketed by error/warning/info.
+ * Pure: no filesystem, no network, no side effects.
+ */
+export function validatePack(input: UnvalidatedPackInput): ValidationReport {
+  const parsed = parsePackInput(input);
+  if (!parsed.ok) return parsed.report;
+  return validateParsedPack(parsed.value);
 }
 
 /**

--- a/packages/format/src/validate/validate.ts
+++ b/packages/format/src/validate/validate.ts
@@ -95,6 +95,8 @@ export function validatePack(input: PackInput): ValidationReport {
     } else {
       decisionIds.add(d.id);
     }
+  });
+  input.decisions.forEach((d, i) => {
     d.branches.forEach((b, bi) => {
       b.recommend.forEach((rid) => {
         if (!practiceIds.has(rid)) {


### PR DESCRIPTION
PR 1 of 2 - LocalStore foundation. It establishes the pure model and storage contracts that the lifecycle PR will orchestrate.

Closes #22

## What

### ADR 0007

Adds the accepted LocalStore contract: authoritative manifest revision, canonical Practice serialization, storage key, artifact digest, SQLite data model, recovery boundaries, and the LocalStore/vector seam.

### Model

- Deterministic canonical Practice JSON and SHA-256 digest.
- Immutable canonical snapshots with LF normalization, expanded severity defaults, and the reserved anti-pattern check excluded.
- Format-gated Pack candidates with safe POSIX source paths.
- Pure source reconciliation: identical sources merge, conflicting content throws, upgrades replace their own sources first, and revision deltas only advance for effective-content changes.

### Storage foundation

- The format package now exposes the thin parseYaml wrapper required for pack.yaml and decisions.yaml.
- SnapshotCodec discovers practices Markdown files, injects Markdown body, enforces the required decisions top-level sequence, and delegates semantic validity to validatePack.
- Immutable artifacts use the ADR path-NUL-bytes-LF SHA-256 algorithm, projection-before-digest sealing, atomic projection publication, safe storage keys, and symbolic-link rejection.
- Active manifest has atomic writes and validates generation, effective revision, Pack identity, digest, ISO timestamp, deterministic ordering, and p-prefix storage keys.
- SQLite migration, atomic full derived-state writer, and one deterministic Effective Practice/source materializer. The materializer re-canonicalizes stored data and rejects tampering, stale revisions, unsafe paths, and orphaned Effective Practices.

## Review fixes

Addressed the review comments on this PR (see thread):

- **YAML safety (blocking)**: js-yaml 3.14.2 → 4.3.1 (v4-legacy, CVE-2025-64718 fixed). `parseYaml` now uses the safe-by-default `load`, bounds input size (512 KiB), and rejects documents whose shared subtrees would exceed the alias reference budget — js-yaml resolves aliases lazily, so a bomb survives parsing and only explodes on a consumer's first full traversal; the budget check stops it before that. `parseFrontmatter` overrides gray-matter's YAML engine so frontmatter gets identical guardrails. Regression tests: nested bomb, flat bomb, legitimate bounded aliases, JS types, oversized document.
- **Typed parse boundary**: `@lorelum/format` now exports `UnvalidatedPackInput`, `parsePackInput` (zod format gate over unknown input) and `validateParsedPack` (semantic stages over typed input); `validatePack` composes them. The engine's `createPackCandidate` consumes these, so SnapshotCodec no longer needs the `as PackInput` cast — format owns validation and narrowing.
- **Storage errors**: paths stay in structured fields (`artifactPath`/`snapshotPath`/`manifestPath`); messages are generic so the CLI/MCP boundary decides what to surface.
- **ADR 0007**: Status `Proposed` pending maintainer review; declared self-contained (wiki docs are background/provenance, not normative); README documents the reserved 0005–0006 planning numbers.
- **assertValidSource**: documented as deliberate defense at the merge boundary (sources may arrive from an untrusted caller), with the relaxation path for the lifecycle layer.
- **Forward-reference decision fix**: retained in this PR per author decision (the fix is already on this branch; a separate issue was opened and closed — see #23). Happy to split it into its own PR if maintainers prefer.

## Boundaries

This PR intentionally does not expose LocalStore from the engine package and does not implement install, upgrade, uninstall, open, reindex, mutation locking, journaling, recovery orchestration, CLI/MCP wiring, or the vector layer. Those are PR 2 responsibilities.

## Security and integrity decisions

- Pack names never become a directory name directly; storage uses a p-prefix.
- Snapshots reject symbolic links and include the generated projection in the artifact digest.
- Projection, manifest, source path, canonical content, SQLite metadata, and materialized retrieval fields are all validated at their trust boundary.
- SQLite writes are parameterized and transactional; no vector tables or external calls are made inside the transaction.
- Pack files (pack.yaml / decisions.yaml / practice frontmatter) are parsed with a safe-by-default YAML engine, an input size cap, and an alias-expansion budget.

## Tests

- Canonicalization defaults, LF normalization, immutability, and reserved field exclusion.
- Candidate validation, path traversal, and reserved Windows name defenses.
- Multi-Pack merge, conflict, upgrade, uninstall, and revision-delta behavior.
- YAML and Markdown snapshot parsing, decisions shape, and duplicate IDs.
- YAML safety: nested and flat alias bombs, bounded legitimate aliases, JS types, oversized documents.
- Artifact digest, promotion, projection integrity, manifest atomic round-trip, migration compatibility, SQLite state round-trip, deterministic source order, and tamper detection.
- parsePackInput typed/error paths.

## Validation

- bun test - 171 pass, 0 fail
- bun run typecheck - 5 packages, 0 errors
- bun run lint - clean
- Scoped oxfmt check - clean
- git diff check - clean

## Follow-up

PR 2 implements the LocalStore lifecycle and recovery protocol against these model and storage contracts.
