### PR TITLE
feat(cli): establish the agent-first CLI JSON protocol

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@lorelum/format": "workspace:*",
         "@lorelum/mcp": "workspace:*",
         "@lorelum/shared": "workspace:*",
+        "commander": "15.0.0",
       },
     },
     "packages/engine": {
@@ -170,6 +171,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 

--- a/docs/adr/0004-agent-first-cli-protocol.md
+++ b/docs/adr/0004-agent-first-cli-protocol.md
@@ -1,0 +1,85 @@
+# ADR 0004: Agent-first CLI protocol
+
+- **Date:** 2026-07-23
+- **Status:** Proposed
+- **Related:** ADR 0002 (Bun + TypeScript toolchain), issue #20 (split from issue #13)
+
+## Context
+
+Lorelum's first CLI consumers are AI coding agents, CI jobs, and editor integrations. A
+human-oriented help screen is not a reliable process contract for those callers: they
+need to discover commands, distinguish a usage error from a completed domain result,
+and recover without parsing prose. The P0 CLI is only a startup stub, so P1 needs to
+establish this boundary before domain commands are introduced.
+
+The protocol must also preserve the package boundary. Commander, process I/O, and exit
+codes are CLI adapter concerns; format, engine, and MCP must not depend on them.
+
+## Decision
+
+The candidate v1 contract is JSON-first. Every normal result is exactly one JSON line on
+stdout, and optional diagnostic logs are written only to stderr. Each response has
+`protocolVersion`, `toolVersion`, `command`, `ok`, and exactly one of `data` or `error`.
+The CLI exports a JSON Schema for this envelope; command definitions provide the schema
+for the contents of `data`.
+
+```json
+{
+  "protocolVersion": 1,
+  "toolVersion": "0.0.0",
+  "command": "describe",
+  "ok": true,
+  "data": { "name": "lore" }
+}
+```
+
+```json
+{
+  "protocolVersion": 1,
+  "toolVersion": "0.0.0",
+  "command": "unknown",
+  "ok": false,
+  "error": { "code": "usage.invalid", "message": "The command invocation is invalid." }
+}
+```
+
+`lore`, `--help`, and `describe [command]` are capability-discovery operations and use
+the same envelope. `--version` returns the protocol and tool versions in the same form.
+Unknown options, missing option values, unknown command paths, and malformed command
+paths are rejected before help or version can respond. Their exit code is `2` and their
+messages must not echo raw arguments.
+
+Exit codes are `0` for a successful call, `1` for a future completed call that reports a
+blocking domain finding, and `2` for usage or runtime failures. The command registry is
+the single source for parser construction, `describe` metadata, result schema, visible
+errors, and exit codes. Independent golden fixtures validate the outer envelope schema;
+built-in command tests validate response data against the result schema in the registry.
+
+Exit code `1` is valid only with a successful (`ok: true`) completed result; failure
+envelopes always use exit code `2`. Each command definition's `errorCodes` is the
+allowlist for errors visible to callers. A handler error not declared by the selected
+command is normalized to `runtime.unexpected`, which every command must declare.
+Handlers return structured data and an optional completion exit code; the CLI adapter is
+the sole owner of validating JSON-safe data and rendering the response, so a completed
+invocation writes one JSON line. Command options model flags, values, defaults, and
+required presence separately; Commander declarations and discovery text are derived from
+that metadata. Framework options additionally declare whether they apply globally or only
+to the root invocation; options that emit a static response also expose its command and
+result schema through discovery. Until local argument inheritance is explicitly modeled,
+a command with child commands cannot declare its own positional arguments or options.
+
+This ADR does not decide whether a future human-readable mode exists. If introduced, it
+must not create a second result semantic or weaken the JSON contract.
+
+## Consequences
+
+**Positive:** callers can use a stable envelope, command discovery is machine-readable,
+and domain packages remain independent of CLI process details.
+
+**Negative / accepted risk:** strict validation is less familiar than conventional CLI
+help behavior, and version 1 will need an explicit compatibility policy before it becomes
+a published promise. The protocol remains Proposed until maintainers accept this ADR
+during review; domain commands are not required for that decision.
+
+**Follow-ups:** separate changes will add deterministic local configuration, validate the
+adapter with `lore validate`, and verify the candidate fixture set on compiled binaries.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,10 +1,10 @@
 # Architecture Decision Records
 
-This directory holds Lorelum's Architecture Decision Records (ADRs) — short documents that capture **why** an architecturally significant choice was made, not just *what* was decided.
+This directory holds Lorelum's Architecture Decision Records (ADRs) — short documents that capture **why** an architecturally significant choice was made, not just _what_ was decided.
 
 ## Why ADRs
 
-Code tells you *how* the system works today. ADRs tell you *why* it works that way — the context, the alternatives considered, and the trade-offs accepted. When someone (human or AI agent) asks "why is X like this?", the answer lives here.
+Code tells you _how_ the system works today. ADRs tell you _why_ it works that way — the context, the alternatives considered, and the trade-offs accepted. When someone (human or AI agent) asks "why is X like this?", the answer lives here.
 
 ## When to write an ADR
 
@@ -24,7 +24,8 @@ docs/adr/
 ├── 0001-record-architecture-decisions.md      # meta-ADR: we use ADRs
 ├── 0002-bun-typescript-toolchain.md           # the first real decision
 ├── 0003-practice-pack-format.md               # Practice/pack format & validation semantics
-├── 0004-...                                   # subsequent decisions
+├── 0004-agent-first-cli-protocol.md            # candidate CLI protocol contract
+├── 0005-...                                   # subsequent decisions
 └── 0000-template.md                           # copy this to start a new ADR
 ```
 
@@ -36,12 +37,12 @@ docs/adr/
 
 Every ADR has a **Status** field at the top:
 
-| Status | Meaning |
-|---|---|
-| `Proposed` | Open for discussion (usually via a PR). Not yet the source of truth. |
-| `Accepted` | The decision is active and in effect. |
-| `Deprecated` | No longer relevant; nothing replaces it directly. |
-| `Superseded by NNNN` | Replaced by a later ADR. The old one stays for history. |
+| Status               | Meaning                                                              |
+| -------------------- | -------------------------------------------------------------------- |
+| `Proposed`           | Open for discussion (usually via a PR). Not yet the source of truth. |
+| `Accepted`           | The decision is active and in effect.                                |
+| `Deprecated`         | No longer relevant; nothing replaces it directly.                    |
+| `Superseded by NNNN` | Replaced by a later ADR. The old one stays for history.              |
 
 ADRs are **immutable history**. To change a decision, write a new ADR that supersedes the old one — don't edit an Accepted ADR to flip its conclusion. The reasoning at the time matters as much as the outcome.
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,18 @@
 {
   "name": "lorelum",
   "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "type": "module",
-  "packageManager": "bun@1.3.8",
-  "workspaces": ["packages/*"],
   "scripts": {
     "test": "bun test",
+    "test:integration": "bun packages/cli/integration/process.integration.ts",
     "lint": "oxlint .",
     "fmt": "oxfmt --write .",
     "fmt:check": "oxfmt --check .",
     "typecheck": "bun run --filter '*' typecheck",
-    "build:cli": "bun build --compile packages/cli/src/index.ts --outfile dist/lore"
+    "build:cli": "bun build --compile packages/cli/src/main.ts --outfile dist/lore"
   },
   "devDependencies": {
     "@types/bun": "1.3.8",
@@ -20,5 +22,6 @@
   },
   "overrides": {
     "js-yaml": "3.14.2"
-  }
+  },
+  "packageManager": "bun@1.3.8"
 }

--- a/packages/cli/integration/process.integration.ts
+++ b/packages/cli/integration/process.integration.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const entrypoint = join(import.meta.dir, "../src/main.ts");
+const bunExecutable = Bun.which("bun");
+const processTimeoutMs = 60_000;
+
+if (bunExecutable === null) {
+  throw new Error("Bun executable is required for CLI integration tests.");
+}
+
+await assert.rejects(
+  runProcess([bunExecutable, "-e", "setInterval(() => undefined, 1_000);"], 100),
+  /Process timed out after 100 ms:/,
+);
+
+const source = await runProcess([bunExecutable, entrypoint, "--version"]);
+assert.equal(source.exitCode, 0);
+assert.deepEqual(selectProtocolFields(source.stdout), { command: "version", ok: true });
+assert.equal(source.stderr, "");
+
+const directory = await mkdtemp(join(tmpdir(), "lorelum-cli-"));
+const executable = join(directory, process.platform === "win32" ? "lore.exe" : "lore");
+
+try {
+  const build = await runProcess([
+    bunExecutable,
+    "build",
+    "--compile",
+    entrypoint,
+    "--outfile",
+    executable,
+  ]);
+  assert.equal(build.exitCode, 0);
+
+  const binary = await runProcess([executable, "--version"]);
+  assert.equal(binary.exitCode, 0);
+  assert.deepEqual(selectProtocolFields(binary.stdout), { command: "version", ok: true });
+  assert.equal(binary.stderr, "");
+
+  const discovery = await runProcess([executable]);
+  assert.equal(discovery.exitCode, 0);
+  assert.deepEqual(selectProtocolFields(discovery.stdout), { command: "describe", ok: true });
+  assert.equal(discovery.stderr, "");
+
+  const invalid = await runProcess([executable, "--private-token"]);
+  assert.equal(invalid.exitCode, 2);
+  assert.deepEqual(selectProtocolFields(invalid.stdout), {
+    command: "unknown",
+    errorCode: "usage.invalid",
+    ok: false,
+  });
+  assert.equal(invalid.stdout.includes("private-token"), false);
+  assert.equal(invalid.stderr, "");
+} finally {
+  await rm(directory, { force: true, recursive: true });
+}
+
+function selectProtocolFields(stdout: string): {
+  command: unknown;
+  errorCode?: unknown;
+  ok: unknown;
+} {
+  const response: unknown = JSON.parse(stdout);
+  assert(isRecord(response));
+
+  const error = response.error;
+  return {
+    command: response.command,
+    ...(isRecord(error) ? { errorCode: error.code } : {}),
+    ok: response.ok,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function runProcess(
+  command: string[],
+  timeoutMs = processTimeoutMs,
+): Promise<{ exitCode: number; stderr: string; stdout: string }> {
+  const child = Bun.spawn({ cmd: command, stderr: "pipe", stdout: "pipe" });
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      const executableName = command[0] ?? "<missing executable>";
+      try {
+        child.kill();
+      } catch (error) {
+        reject(
+          new Error(
+            `Process timed out after ${timeoutMs} ms and could not be terminated: ${executableName}`,
+            { cause: error },
+          ),
+        );
+        return;
+      }
+      reject(new Error(`Process timed out after ${timeoutMs} ms: ${executableName}`));
+    }, timeoutMs);
+  });
+
+  try {
+    const [stdout, stderr, exitCode] = await Promise.race([
+      Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]),
+      timeout,
+    ]);
+    return { exitCode, stderr, stdout };
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,22 +2,23 @@
   "name": "@lorelum/cli",
   "version": "0.0.0",
   "private": true,
+  "bin": {
+    "lore": "./src/main.ts"
+  },
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts"
   },
-  "bin": {
-    "lore": "./src/index.ts"
-  },
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@lorelum/shared": "workspace:*",
-    "@lorelum/format": "workspace:*",
     "@lorelum/engine": "workspace:*",
-    "@lorelum/mcp": "workspace:*"
+    "@lorelum/format": "workspace:*",
+    "@lorelum/mcp": "workspace:*",
+    "@lorelum/shared": "workspace:*",
+    "commander": "15.0.0"
   }
 }

--- a/packages/cli/src/create-program.ts
+++ b/packages/cli/src/create-program.ts
@@ -1,0 +1,215 @@
+import { Argument, Command, Option } from "commander";
+
+import { renderSuccess, type OutputWriter } from "./output/protocol.js";
+import {
+  commandOptionAppliesTo,
+  commandOptionKey,
+  commandOptionDeclaration,
+  commandRegistry,
+  describeCommand,
+  discoveryCommandName,
+  positionalValues,
+  requireCommandDescription,
+  type CommandOption,
+  type CommandDefinition,
+  type DescribeCommand,
+  rootCommand,
+  snapshotCommandDefinitions,
+} from "./registry.js";
+import { invalidInvocationError } from "./runtime/errors.js";
+import { Logger, logLevels, type LogLevel } from "./runtime/logger.js";
+
+export interface CliRuntime {
+  /** Runtime capabilities are constructed before Commander parses an invocation. */
+  readonly logger: Logger;
+}
+
+/** Internal callbacks that let `run` own selected-command and process-exit state. */
+export interface ProgramLifecycle {
+  selectCommand(definition: CommandDefinition): void;
+  setExitCode(code: 1): void;
+}
+
+/** Builds a parser from one complete registry snapshot; `run` owns failure rendering. */
+export function createProgram(
+  runtime: CliRuntime,
+  output: OutputWriter,
+  lifecycle: ProgramLifecycle,
+  registryDefinitions: readonly CommandDefinition[] = commandRegistry,
+): Command {
+  const registry = snapshotCommandDefinitions(registryDefinitions);
+  const describeFromRegistry: DescribeCommand = (command) => describeCommand(command, registry);
+  const program = new Command();
+
+  program
+    .name(rootCommand.name)
+    .description(rootCommand.summary)
+    .helpOption(false)
+    .helpCommand(false)
+    .configureOutput({ writeErr: () => undefined, writeOut: () => undefined })
+    .exitOverride()
+    .hook("preAction", () => {
+      runtime.logger.setLevel(parsedLogLevel(program));
+    })
+    .action(() =>
+      executeCommand(
+        rootCommand,
+        program,
+        [],
+        output,
+        lifecycle,
+        describeFromRegistry,
+        discoveryCommandName,
+      ),
+    );
+
+  for (const option of rootCommand.options) {
+    program.addOption(toCommanderOption(option));
+  }
+
+  const commands = new Map<string, Command>();
+  for (const definition of registry) {
+    const command = commandForDefinition(program, commands, definition);
+    command.description(definition.summary);
+    for (const positional of definition.positionals) {
+      const argument = new Argument(
+        positional.required ? `<${positional.name}>` : `[${positional.name}]`,
+      );
+      const values = positionalValues(definition, positional, registry);
+      if (values !== undefined) argument.choices([...values]);
+      command.addArgument(argument);
+    }
+    for (const option of definition.options) {
+      command.addOption(toCommanderOption(option));
+    }
+    command.action(async (...arguments_: unknown[]) => {
+      const commandInstance = arguments_.at(-1);
+      if (!(commandInstance instanceof Command)) {
+        throw new Error("Commander did not provide the command context.");
+      }
+      await executeCommand(
+        definition,
+        commandInstance,
+        arguments_
+          .slice(0, -1)
+          .filter((argument): argument is string => typeof argument === "string"),
+        output,
+        lifecycle,
+        describeFromRegistry,
+        definition.name,
+      );
+    });
+  }
+
+  return program;
+}
+
+async function executeCommand(
+  definition: CommandDefinition,
+  command: Command,
+  positionals: string[],
+  output: OutputWriter,
+  lifecycle: ProgramLifecycle,
+  describeFromRegistry: DescribeCommand,
+  responseCommand: string,
+): Promise<void> {
+  lifecycle.selectCommand(definition);
+  const helpOption = enabledFrameworkOption(command, definition, "help");
+  const versionOption = enabledFrameworkOption(command, definition, "version");
+
+  if (helpOption !== undefined && versionOption !== undefined) {
+    throw invalidInvocationError();
+  }
+  if (versionOption !== undefined) {
+    const response = versionOption.response;
+    if (response === undefined) throw new Error("The version registry response is missing.");
+    renderSuccess(output, response.command, response.data);
+    return;
+  }
+  if (helpOption !== undefined) {
+    renderSuccess(
+      output,
+      discoveryCommandName,
+      requireCommandDescription(describeFromRegistry, definition.name),
+    );
+    return;
+  }
+  for (const option of definition.options) {
+    if (option.optionRequired && !hasParsedOption(command, option)) {
+      throw invalidInvocationError();
+    }
+  }
+
+  const result = await definition.handler({
+    options: command.optsWithGlobals(),
+    positionals,
+    describeCommand: describeFromRegistry,
+  });
+  const exitCode = result.exitCode ?? 0;
+  if (!definition.exitCodes.includes(exitCode)) {
+    throw new Error(`Command "${definition.name}" returned undeclared exit code ${exitCode}.`);
+  }
+  renderSuccess(output, responseCommand, result.data);
+  if (exitCode === 1) lifecycle.setExitCode(1);
+}
+
+function commandForDefinition(
+  program: Command,
+  commands: Map<string, Command>,
+  definition: CommandDefinition,
+): Command {
+  const segments = definition.name.split(".");
+  if (segments.some((segment) => segment.length === 0)) {
+    throw new Error(`Invalid command name: ${definition.name}`);
+  }
+
+  let parent = program;
+  for (let index = 0; index < segments.length; index += 1) {
+    const path = segments.slice(0, index + 1).join(".");
+    let command = commands.get(path);
+    if (command === undefined) {
+      command = parent.command(segments[index]!).helpOption(false).helpCommand(false);
+      commands.set(path, command);
+    }
+    parent = command;
+  }
+  return parent;
+}
+
+function hasParsedOption(command: Command, option: CommandDefinition["options"][number]): boolean {
+  const key = commandOptionKey(option);
+  return command.optsWithGlobals()[key] !== undefined;
+}
+
+function toCommanderOption(option: CommandDefinition["options"][number]): Option {
+  const commanderOption = new Option(commandOptionDeclaration(option), option.description);
+  if (option.values !== undefined) commanderOption.choices([...option.values]);
+  if (option.defaultValue !== undefined) commanderOption.default(option.defaultValue);
+  return commanderOption;
+}
+
+function frameworkOption(behavior: NonNullable<CommandOption["behavior"]>): CommandOption {
+  const option = rootCommand.options.find((candidate) => candidate.behavior === behavior);
+  if (option === undefined) throw new Error(`The ${behavior} registry option is missing.`);
+  return option;
+}
+
+function enabledFrameworkOption(
+  command: Command,
+  definition: CommandDefinition,
+  behavior: NonNullable<CommandOption["behavior"]>,
+): CommandOption | undefined {
+  const option = frameworkOption(behavior);
+  if (command.optsWithGlobals()[commandOptionKey(option)] !== true) return undefined;
+  if (!commandOptionAppliesTo(option, definition)) throw invalidInvocationError();
+  return option;
+}
+
+function parsedLogLevel(command: Command): LogLevel {
+  const option = frameworkOption("log-level");
+  const value = command.optsWithGlobals()[commandOptionKey(option)];
+  if (typeof value !== "string" || !logLevels.includes(value as LogLevel)) {
+    throw new Error("The log-level registry option is missing or invalid.");
+  }
+  return value as LogLevel;
+}

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,9 +1,25 @@
-import { describe, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 
-import { PACKAGE_NAME } from "./index";
+import {
+  PACKAGE_NAME,
+  protocolResponseSchema,
+  protocolVersion,
+  toolVersion,
+  type ProtocolSuccess,
+} from "@lorelum/cli";
 
-describe("@lorelum/cli", () => {
-  test("exposes its package name", () => {
-    expect(PACKAGE_NAME).toBe("@lorelum/cli");
-  });
+test("exports the CLI package contract", () => {
+  expect(PACKAGE_NAME).toBe("@lorelum/cli");
+  expect(protocolResponseSchema).toHaveProperty("oneOf");
+  expect(protocolVersion).toBe(1);
+  expect(toolVersion).toBe("0.0.0");
+
+  const response: ProtocolSuccess<{ name: string }> = {
+    protocolVersion,
+    toolVersion,
+    command: "describe",
+    ok: true,
+    data: { name: "lore" },
+  };
+  expect(response.data.name).toBe("lore");
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,13 +1,23 @@
-#!/usr/bin/env bun
-/**
- * lore — the Lorelum CLI entry point.
- *
- * P0 scaffold: a stub that confirms the binary runs. Subcommands
- * (install/query/decide/check/learn) land with their owning tasks.
- */
-
 export const PACKAGE_NAME = "@lorelum/cli";
 
-if (import.meta.main) {
-  console.log("lore — Lorelum CLI (scaffold)");
-}
+export { createProgram, type CliRuntime, type ProgramLifecycle } from "./create-program.js";
+export { run, type RunOptions } from "./main.js";
+export {
+  commandRegistry,
+  describeCommand,
+  type CommandDefinition,
+  type CommandInvocation,
+  type CommandOption,
+  type CommandResult,
+  type PositionalArgument,
+} from "./registry.js";
+export {
+  protocolResponseSchema,
+  protocolVersion,
+  toolVersion,
+  type JsonSchema,
+  type JsonValue,
+  type OutputWriter,
+  type ProtocolFailure,
+  type ProtocolSuccess,
+} from "./output/protocol.js";

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -1,0 +1,149 @@
+import { expect, test } from "bun:test";
+
+import { run } from "./main.js";
+import { protocolResponseSchema, toolVersion, type JsonSchema } from "./output/protocol.js";
+import {
+  validateJsonSchema,
+  validateProtocolSchema,
+} from "./output/protocol-schema.test-helper.js";
+import { describeCommand } from "./registry.js";
+
+class MemoryWriter {
+  value = "";
+
+  write(message: string): void {
+    this.value += message;
+  }
+}
+
+test("returns machine-readable root capability discovery", async () => {
+  const stdout = new MemoryWriter();
+  const stderr = new MemoryWriter();
+
+  expect(await run([], { stderr, stdout })).toBe(0);
+  const response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({
+    protocolVersion: 1,
+    toolVersion,
+    command: "describe",
+    ok: true,
+    data: {
+      name: "lore",
+      commands: [{ name: "describe" }],
+    },
+  });
+  expect(stderr.value).toBe("");
+  expect(validateProtocolSchema(response, protocolResponseSchema)).toEqual([]);
+  expect(validateJsonSchema(response.data, resultSchemaFor("lore"))).toEqual([]);
+  expect(
+    validateJsonSchema({ ...response.data, commands: "describe" }, resultSchemaFor("lore")),
+  ).not.toEqual([]);
+});
+
+test("returns command metadata through describe", async () => {
+  const stdout = new MemoryWriter();
+
+  expect(await run(["describe", "describe"], { stdout })).toBe(0);
+  const response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({
+    command: "describe",
+    ok: true,
+    data: {
+      name: "describe",
+      resultSchema: { oneOf: expect.any(Array) },
+      errorCodes: ["usage.invalid", "runtime.unexpected"],
+      exitCodes: [0, 2],
+    },
+  });
+  expect(validateProtocolSchema(response, protocolResponseSchema)).toEqual([]);
+  expect(validateJsonSchema(response.data, resultSchemaFor("describe"))).toEqual([]);
+  expect(
+    validateJsonSchema({ ...response.data, exitCodes: ["0", "2"] }, resultSchemaFor("describe")),
+  ).not.toEqual([]);
+});
+
+function resultSchemaFor(command: string): JsonSchema {
+  const description = describeCommand(command) as { resultSchema?: JsonSchema } | undefined;
+  if (description?.resultSchema === undefined) {
+    throw new Error(`Missing result schema for ${command}`);
+  }
+  return description.resultSchema;
+}
+
+function optionResultSchemaFor(command: string, behavior: string): JsonSchema {
+  const description = describeCommand(command) as
+    | {
+        options?: readonly {
+          behavior?: string;
+          response?: { resultSchema?: JsonSchema };
+        }[];
+      }
+    | undefined;
+  const schema = description?.options?.find((option) => option.behavior === behavior)?.response
+    ?.resultSchema;
+  if (schema === undefined) {
+    throw new Error(`Missing ${behavior} result schema for ${command}`);
+  }
+  return schema;
+}
+
+test("returns structured help and version responses", async () => {
+  const help = new MemoryWriter();
+  const version = new MemoryWriter();
+
+  expect(await run(["describe", "--help"], { stdout: help })).toBe(0);
+  expect(JSON.parse(help.value)).toMatchObject({
+    command: "describe",
+    ok: true,
+    data: { name: "describe" },
+  });
+  expect(validateProtocolSchema(JSON.parse(help.value), protocolResponseSchema)).toEqual([]);
+
+  expect(await run(["--version"], { stdout: version })).toBe(0);
+  const versionResponse = JSON.parse(version.value);
+  expect(versionResponse).toEqual({
+    protocolVersion: 1,
+    toolVersion,
+    command: "version",
+    ok: true,
+    data: { protocolVersion: 1, toolVersion },
+  });
+  expect(validateProtocolSchema(versionResponse, protocolResponseSchema)).toEqual([]);
+  const versionResultSchema = optionResultSchemaFor("lore", "version");
+  expect(validateJsonSchema(versionResponse.data, versionResultSchema)).toEqual([]);
+  expect(validateJsonSchema({ protocolVersion: 1 }, versionResultSchema)).not.toEqual([]);
+});
+
+test("accepts the documented equals form of global options", async () => {
+  const stdout = new MemoryWriter();
+
+  expect(await run(["--log-level=debug"], { stdout })).toBe(0);
+  expect(JSON.parse(stdout.value)).toMatchObject({ command: "describe", ok: true });
+});
+
+test("validates invalid calls before help and version responses", async () => {
+  const invalidCalls = [
+    ["unknown", "--help"],
+    ["describe", "unknown", "--help"],
+    ["unknown", "--version"],
+    ["--help", "--version"],
+    ["describe", "--version"],
+    ["--log-level"],
+    ["--private-token"],
+  ];
+  await Promise.all(
+    invalidCalls.map(async (args) => {
+      const stdout = new MemoryWriter();
+      const stderr = new MemoryWriter();
+
+      expect(await run(args, { stderr, stdout })).toBe(2);
+      expect(JSON.parse(stdout.value)).toMatchObject({
+        ok: false,
+        error: { code: "usage.invalid", message: "The command invocation is invalid." },
+      });
+      expect(stdout.value).not.toContain("private-token");
+      expect(stderr.value).toBe("");
+      expect(validateProtocolSchema(JSON.parse(stdout.value), protocolResponseSchema)).toEqual([]);
+    }),
+  );
+});

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+
+import { createProgram, type CliRuntime } from "./create-program.js";
+import { renderFailure, type OutputWriter } from "./output/protocol.js";
+import { rootCommand, type CommandDefinition, type KnownCommand } from "./registry.js";
+import { toVisibleCliError } from "./runtime/errors.js";
+import { Logger } from "./runtime/logger.js";
+
+export interface RunOptions {
+  /** Complete registry replacement; omit to use the immutable built-in `commandRegistry`. */
+  registry?: readonly CommandDefinition[];
+  /** Prebuilt runtime override; omit to use the process stderr-backed runtime. */
+  runtime?: CliRuntime;
+  stderr?: OutputWriter;
+  stdout?: OutputWriter;
+}
+
+/** Executes one argv invocation and owns its single protocol response and exit code. */
+export async function run(arguments_: string[], options: RunOptions = {}): Promise<number> {
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  let command: KnownCommand | "unknown" = "unknown";
+  let commandExitCode: 0 | 1 = 0;
+  let visibleErrorCodes = rootCommand.errorCodes;
+
+  try {
+    const runtime = options.runtime ?? { logger: new Logger(stderr) };
+    const program = createProgram(
+      runtime,
+      stdout,
+      {
+        selectCommand(definition) {
+          command = definition.name as KnownCommand;
+          visibleErrorCodes = definition.errorCodes;
+        },
+        setExitCode(exitCode) {
+          commandExitCode = exitCode;
+        },
+      },
+      options.registry,
+    );
+    await program.parseAsync(arguments_, { from: "user" });
+    return commandExitCode;
+  } catch (error) {
+    const cliError = toVisibleCliError(error, visibleErrorCodes);
+    renderFailure(stdout, command, cliError.code, cliError.message);
+    return cliError.exitCode;
+  }
+}
+
+if (import.meta.main) {
+  process.exitCode = await run(process.argv.slice(2));
+}

--- a/packages/cli/src/output/protocol-envelope.fixture.json
+++ b/packages/cli/src/output/protocol-envelope.fixture.json
@@ -1,0 +1,19 @@
+[
+  {
+    "protocolVersion": 1,
+    "toolVersion": "0.0.0",
+    "command": "fixture.success",
+    "ok": true,
+    "data": {}
+  },
+  {
+    "protocolVersion": 1,
+    "toolVersion": "0.0.0",
+    "command": "fixture.failure",
+    "ok": false,
+    "error": {
+      "code": "usage.invalid",
+      "message": "The command invocation is invalid."
+    }
+  }
+]

--- a/packages/cli/src/output/protocol-schema.test-helper.ts
+++ b/packages/cli/src/output/protocol-schema.test-helper.ts
@@ -1,0 +1,73 @@
+import type { JsonSchema } from "./protocol.js";
+
+/** Validates the JSON Schema vocabulary used by the v1 protocol contract. */
+export function validateProtocolSchema(value: unknown, schema: JsonSchema): string[] {
+  return validate(value, schema, "response");
+}
+
+/** Validates command data against the JSON Schema subset emitted by capability discovery. */
+export function validateJsonSchema(value: unknown, schema: JsonSchema): string[] {
+  return validate(value, schema, "data");
+}
+
+function validate(value: unknown, schema: JsonSchema, path: string): string[] {
+  if (schema.oneOf !== undefined) {
+    const results = schema.oneOf.map((candidate) => validate(value, candidate, path));
+    const matchingSchemas = results.filter((errors) => errors.length === 0);
+    return matchingSchemas.length === 1 ? [] : [`${path} must match exactly one schema branch`];
+  }
+
+  if (Object.hasOwn(schema, "const") && !Object.is(value, schema.const)) {
+    return [`${path} must equal ${JSON.stringify(schema.const)}`];
+  }
+
+  if (schema.enum !== undefined && !schema.enum.some((candidate) => Object.is(value, candidate))) {
+    return [`${path} must be one of ${JSON.stringify(schema.enum)}`];
+  }
+
+  if (schema.type === "string") {
+    return typeof value === "string" ? [] : [`${path} must be a string`];
+  }
+
+  if (schema.type === "boolean") {
+    return typeof value === "boolean" ? [] : [`${path} must be a boolean`];
+  }
+
+  if (schema.type === "integer") {
+    return Number.isInteger(value) ? [] : [`${path} must be an integer`];
+  }
+
+  if (schema.type === "array") {
+    if (!Array.isArray(value)) return [`${path} must be an array`];
+    return schema.items === undefined
+      ? []
+      : value.flatMap((item, index) => validate(item, schema.items!, `${path}[${index}]`));
+  }
+
+  if (schema.type !== "object") return [];
+  if (!isRecord(value)) return [`${path} must be an object`];
+
+  const errors: string[] = [];
+  for (const property of schema.required ?? []) {
+    if (!Object.hasOwn(value, property)) errors.push(`${path}.${property} is required`);
+  }
+
+  if (schema.additionalProperties === false) {
+    for (const property of Object.keys(value)) {
+      if (schema.properties?.[property] === undefined) {
+        errors.push(`${path}.${property} is not allowed`);
+      }
+    }
+  }
+
+  for (const [property, propertySchema] of Object.entries(schema.properties ?? {})) {
+    if (Object.hasOwn(value, property)) {
+      errors.push(...validate(value[property], propertySchema, `${path}.${property}`));
+    }
+  }
+  return errors;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/cli/src/output/protocol.test.ts
+++ b/packages/cli/src/output/protocol.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test";
+
+import { protocolResponseSchema, renderFailure, renderSuccess, toolVersion } from "./protocol.js";
+import goldenEnvelopes from "./protocol-envelope.fixture.json";
+import { validateProtocolSchema } from "./protocol-schema.test-helper.js";
+
+class MemoryWriter {
+  value = "";
+
+  write(message: string): void {
+    this.value += message;
+  }
+}
+
+test("renders one JSON line for successful protocol responses", () => {
+  const writer = new MemoryWriter();
+
+  renderSuccess(writer, "describe", { name: "lore" });
+
+  expect(writer.value.endsWith("\n")).toBe(true);
+  expect(JSON.parse(writer.value)).toEqual({
+    protocolVersion: 1,
+    toolVersion,
+    command: "describe",
+    ok: true,
+    data: { name: "lore" },
+  });
+  expect(validateProtocolSchema(JSON.parse(writer.value), protocolResponseSchema)).toEqual([]);
+});
+
+test("rejects non-JSON-safe success data before writing", () => {
+  const circular: Record<string, unknown> = {};
+  circular.self = circular;
+  const invalidValues: unknown[] = [
+    undefined,
+    { nested: undefined },
+    Number.NaN,
+    1n,
+    new Date(0),
+    circular,
+  ];
+
+  for (const value of invalidValues) {
+    const writer = new MemoryWriter();
+    expect(() => renderSuccess(writer, "invalid", value as never)).toThrow();
+    expect(writer.value).toBe("");
+  }
+});
+
+test("renders structured protocol failures", () => {
+  const writer = new MemoryWriter();
+
+  renderFailure(writer, "unknown", "usage.invalid", "The command invocation is invalid.");
+
+  expect(JSON.parse(writer.value)).toMatchObject({
+    command: "unknown",
+    ok: false,
+    error: { code: "usage.invalid" },
+  });
+  expect(validateProtocolSchema(JSON.parse(writer.value), protocolResponseSchema)).toEqual([]);
+});
+
+test("validates independent golden envelopes with the exported envelope schema", () => {
+  for (const response of goldenEnvelopes) {
+    expect(response.toolVersion).toBe(toolVersion);
+    expect(response.command).toStartWith("fixture.");
+    expect(validateProtocolSchema(response, protocolResponseSchema)).toEqual([]);
+  }
+});
+
+test("rejects malformed envelopes with the exported JSON Schema", () => {
+  expect(
+    validateProtocolSchema(
+      { protocolVersion: 1, toolVersion, command: "describe", ok: true },
+      protocolResponseSchema,
+    ),
+  ).not.toEqual([]);
+  expect(
+    validateProtocolSchema(
+      {
+        protocolVersion: 1,
+        toolVersion,
+        command: "describe",
+        ok: true,
+        data: {},
+        extra: true,
+      },
+      protocolResponseSchema,
+    ),
+  ).not.toEqual([]);
+});

--- a/packages/cli/src/output/protocol.ts
+++ b/packages/cli/src/output/protocol.ts
@@ -1,0 +1,153 @@
+import packageManifest from "../../package.json";
+
+/** Version of the process-envelope contract. */
+export const protocolVersion = 1;
+/** Version of the CLI implementation emitting the envelope. */
+export const toolVersion = packageManifest.version;
+
+export type JsonSchema = {
+  oneOf?: readonly JsonSchema[];
+  type?: "array" | "boolean" | "integer" | "object" | "string";
+  const?: unknown;
+  enum?: readonly unknown[];
+  additionalProperties?: boolean;
+  required?: readonly string[];
+  properties?: Readonly<Record<string, JsonSchema>>;
+  items?: JsonSchema;
+};
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly JsonValue[]
+  | Readonly<Record<string, unknown>>;
+
+export interface OutputWriter {
+  write(message: string): void;
+}
+
+interface EnvelopeBase {
+  protocolVersion: number;
+  toolVersion: string;
+  command: string;
+}
+
+export interface ProtocolSuccess<T extends JsonValue = JsonValue> extends EnvelopeBase {
+  ok: true;
+  data: T;
+}
+
+export interface ProtocolFailure extends EnvelopeBase {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+/** Validates the outer response only; command `data` uses its registry result schema. */
+export const protocolResponseSchema = {
+  oneOf: [
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["protocolVersion", "toolVersion", "command", "ok", "data"],
+      properties: {
+        protocolVersion: { const: protocolVersion },
+        toolVersion: { type: "string" },
+        command: { type: "string" },
+        ok: { const: true },
+        data: {},
+      },
+    },
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["protocolVersion", "toolVersion", "command", "ok", "error"],
+      properties: {
+        protocolVersion: { const: protocolVersion },
+        toolVersion: { type: "string" },
+        command: { type: "string" },
+        ok: { const: false },
+        error: {
+          type: "object",
+          additionalProperties: false,
+          required: ["code", "message"],
+          properties: {
+            code: { type: "string" },
+            message: { type: "string" },
+          },
+        },
+      },
+    },
+  ],
+} as const satisfies JsonSchema;
+
+export function renderSuccess<T extends JsonValue>(
+  writer: OutputWriter,
+  command: string,
+  data: T,
+): void {
+  assertJsonValue(data);
+  const response: ProtocolSuccess<T> = {
+    protocolVersion,
+    toolVersion,
+    command,
+    ok: true,
+    data,
+  };
+  writer.write(`${JSON.stringify(response)}\n`);
+}
+
+export function renderFailure(
+  writer: OutputWriter,
+  command: string,
+  code: string,
+  message: string,
+): void {
+  const response: ProtocolFailure = {
+    protocolVersion,
+    toolVersion,
+    command,
+    ok: false,
+    error: { code, message },
+  };
+  writer.write(`${JSON.stringify(response)}\n`);
+}
+
+function assertJsonValue(value: unknown, ancestors: WeakSet<object> = new WeakSet()): void {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return;
+  if (typeof value === "number") {
+    if (Number.isFinite(value)) return;
+    throw new TypeError("Protocol data contains a non-finite number.");
+  }
+  if (typeof value !== "object") {
+    throw new TypeError("Protocol data is not JSON-safe.");
+  }
+  if (ancestors.has(value)) {
+    throw new TypeError("Protocol data contains a circular reference.");
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (const item of value) assertJsonValue(item, ancestors);
+      return;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError("Protocol data must contain only plain JSON objects.");
+    }
+    if (Object.getOwnPropertySymbols(value).length > 0) {
+      throw new TypeError("Protocol data contains symbol properties.");
+    }
+    for (const nestedValue of Object.values(value)) {
+      assertJsonValue(nestedValue, ancestors);
+    }
+  } finally {
+    ancestors.delete(value);
+  }
+}

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -1,0 +1,466 @@
+import { expect, test } from "bun:test";
+
+import { createProgram } from "./create-program.js";
+import { run } from "./main.js";
+import {
+  commandRegistry,
+  describeCommand,
+  snapshotCommandDefinitions,
+  type CommandDefinition,
+} from "./registry.js";
+import { CliError, cliErrorCodes, frameworkErrorCodes } from "./runtime/errors.js";
+import { Logger } from "./runtime/logger.js";
+
+class MemoryWriter {
+  value = "";
+
+  write(message: string): void {
+    this.value += message;
+  }
+}
+
+const futureCommand: CommandDefinition = {
+  name: "future",
+  summary: "Temporary registry regression command.",
+  positionals: [],
+  options: [
+    {
+      longFlag: "--future-mode",
+      description: "Exercise command-specific option registration.",
+      value: { name: "mode", required: true },
+      optionRequired: true,
+      values: ["safe"],
+    },
+  ],
+  resultSchema: { type: "object" },
+  errorCodes: frameworkErrorCodes,
+  exitCodes: [0, 2],
+  handler: async (invocation) => {
+    await Promise.resolve();
+    return { data: { mode: invocation.options.futureMode } };
+  },
+};
+
+test("exposes an immutable production command registry", () => {
+  expect(Object.isFrozen(commandRegistry)).toBe(true);
+  expect(Object.isFrozen(commandRegistry[0])).toBe(true);
+  expect(Object.isFrozen(commandRegistry[0]?.positionals)).toBe(true);
+  expect(Object.isFrozen(commandRegistry[0]?.resultSchema)).toBe(true);
+});
+
+test("rejects command metadata that omits framework errors or exit codes", () => {
+  expect(() =>
+    snapshotCommandDefinitions([{ ...futureCommand, errorCodes: [cliErrorCodes.usageInvalid] }]),
+  ).toThrow(cliErrorCodes.runtimeUnexpected);
+  expect(() => snapshotCommandDefinitions([{ ...futureCommand, exitCodes: [0] }])).toThrow(
+    "exit code 2",
+  );
+});
+
+test("rejects registry definitions that would make parser metadata ambiguous", () => {
+  expect(() => snapshotCommandDefinitions([futureCommand, futureCommand])).toThrow(
+    'Command name "future" is declared more than once.',
+  );
+  expect(() =>
+    snapshotCommandDefinitions([
+      futureCommand,
+      {
+        ...futureCommand,
+        name: "nested",
+        positionals: [{ name: "target", required: false }],
+        options: [],
+      },
+      { ...futureCommand, name: "nested.child", options: [] },
+    ]),
+  ).toThrow("cannot combine local arguments with child commands");
+  expect(() =>
+    snapshotCommandDefinitions([
+      {
+        ...futureCommand,
+        name: "conflicting-option",
+        options: [
+          {
+            longFlag: "--log-level",
+            description: "Conflict.",
+            value: { name: "level", required: true },
+            optionRequired: false,
+          },
+        ],
+      },
+    ]),
+  ).toThrow('conflicting option "--log-level"');
+  expect(() =>
+    snapshotCommandDefinitions([
+      {
+        ...futureCommand,
+        name: "conflicting-short-option",
+        options: [
+          {
+            longFlag: "--local-help",
+            shortFlag: "-h",
+            description: "Conflict.",
+            optionRequired: false,
+          },
+        ],
+      },
+    ]),
+  ).toThrow('conflicting option "-h"');
+  expect(() =>
+    snapshotCommandDefinitions([
+      {
+        ...futureCommand,
+        name: "reserved-behavior",
+        options: [
+          {
+            longFlag: "--local-help",
+            description: "Invalid framework behavior.",
+            optionRequired: false,
+            behavior: "help",
+          },
+        ],
+      },
+    ]),
+  ).toThrow("cannot declare framework option behavior");
+  expect(() =>
+    snapshotCommandDefinitions([
+      {
+        ...futureCommand,
+        name: "required-default",
+        options: [
+          {
+            longFlag: "--mode",
+            description: "Contradictory option.",
+            value: { name: "mode", required: true },
+            optionRequired: true,
+            defaultValue: "safe",
+          },
+        ],
+      },
+    ]),
+  ).toThrow("cannot default a required option");
+  expect(() =>
+    snapshotCommandDefinitions([
+      {
+        ...futureCommand,
+        name: "invalid-default",
+        options: [
+          {
+            longFlag: "--mode",
+            description: "Invalid default.",
+            value: { name: "mode", required: true },
+            optionRequired: false,
+            defaultValue: "unsafe",
+            values: ["safe"],
+          },
+        ],
+      },
+    ]),
+  ).toThrow("option default must be one of its choices");
+  expect(() =>
+    snapshotCommandDefinitions([
+      {
+        ...futureCommand,
+        name: "parent",
+        options: [
+          {
+            longFlag: "--mode",
+            description: "Parent mode.",
+            value: { name: "mode", required: true },
+            optionRequired: false,
+          },
+        ],
+      },
+      {
+        ...futureCommand,
+        name: "parent.child",
+        options: [],
+      },
+    ]),
+  ).toThrow('Command "parent" cannot combine local arguments with child commands');
+});
+
+test("describes registered commands from a single registry", () => {
+  expect(describeCommand()).toMatchObject({
+    name: "lore",
+    options: [
+      { behavior: "help", name: "-h, --help", scope: "global" },
+      {
+        behavior: "version",
+        name: "-V, --version",
+        scope: "root",
+        response: {
+          command: "version",
+          resultSchema: {
+            required: ["protocolVersion", "toolVersion"],
+            type: "object",
+          },
+        },
+      },
+      {
+        behavior: "log-level",
+        defaultValue: "error",
+        name: "--log-level <level>",
+        scope: "global",
+      },
+    ],
+    commands: [
+      {
+        name: "describe",
+        positionals: [{ name: "command", values: ["describe"] }],
+      },
+    ],
+  });
+  expect(describeCommand("describe")).toMatchObject({
+    options: [
+      { behavior: "help", scope: "global" },
+      { behavior: "log-level", scope: "global" },
+    ],
+  });
+});
+
+test("registers every command definition with an executable handler", () => {
+  for (const command of commandRegistry) {
+    const description = describeCommand(command.name) as { name: string; usage: string };
+    expect(description.name).toBe(command.name);
+    expect(description.usage).toContain(command.name.replaceAll(".", " "));
+    expect(command.handler).toBeInstanceOf(Function);
+  }
+});
+
+test("derives parser options and describe metadata from registered commands", async () => {
+  const definitions = [...commandRegistry, futureCommand];
+  expect(describeCommand("future", definitions)).toMatchObject({
+    name: "future",
+    options: [
+      { behavior: "help", scope: "global" },
+      { behavior: "log-level", scope: "global" },
+      { name: "--future-mode <mode>", scope: "command" },
+    ],
+  });
+  expect(describeCommand("describe", definitions)).toMatchObject({
+    positionals: [{ name: "command", values: ["describe", "future"] }],
+  });
+
+  const stdout = new MemoryWriter();
+  expect(await run(["future", "--future-mode", "safe"], { registry: definitions, stdout })).toBe(0);
+  expect(JSON.parse(stdout.value)).toMatchObject({ command: "future", data: { mode: "safe" } });
+
+  const missingRequiredOption = new MemoryWriter();
+  expect(await run(["future"], { registry: definitions, stdout: missingRequiredOption })).toBe(2);
+
+  const unsupportedOptionValue = new MemoryWriter();
+  expect(
+    await run(["future", "--future-mode", "unsafe"], {
+      registry: definitions,
+      stdout: unsupportedOptionValue,
+    }),
+  ).toBe(2);
+
+  const help = new MemoryWriter();
+  expect(await run(["future", "--help"], { registry: definitions, stdout: help })).toBe(0);
+  expect(JSON.parse(help.value)).toMatchObject({ command: "describe", data: { name: "future" } });
+});
+
+test("keeps parser and describe on the same immutable program snapshot", async () => {
+  const definitions: CommandDefinition[] = [...commandRegistry, futureCommand];
+  const stdout = new MemoryWriter();
+  const stderr = new MemoryWriter();
+  const program = createProgram(
+    { logger: new Logger(stderr) },
+    stdout,
+    { selectCommand() {}, setExitCode() {} },
+    definitions,
+  );
+
+  definitions.pop();
+  await program.parseAsync(["future", "--help"], { from: "user" });
+
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "describe",
+    data: { name: "future" },
+  });
+});
+
+test("returns exit code 1 with a successful blocking domain result", async () => {
+  const blockingCommand: CommandDefinition = {
+    name: "future-domain",
+    summary: "Report a completed blocking domain finding.",
+    positionals: [],
+    options: [],
+    resultSchema: { type: "object" },
+    errorCodes: frameworkErrorCodes,
+    exitCodes: [0, 1, 2],
+    handler: () => ({ data: { blocking: true }, exitCode: 1 }),
+  };
+  const stdout = new MemoryWriter();
+
+  expect(
+    await run(["future-domain"], {
+      registry: [...commandRegistry, blockingCommand],
+      stdout,
+    }),
+  ).toBe(1);
+  expect(stdout.value.trimEnd().split("\n")).toHaveLength(1);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "future-domain",
+    data: { blocking: true },
+    ok: true,
+  });
+});
+
+test("renders one failure when a handler returns an undeclared completion", async () => {
+  const command: CommandDefinition = {
+    name: "future-undeclared-exit",
+    summary: "Exercise centralized completion validation.",
+    positionals: [],
+    options: [],
+    resultSchema: { type: "object" },
+    errorCodes: frameworkErrorCodes,
+    exitCodes: [0, 2],
+    handler: () => ({ data: { blocking: true }, exitCode: 1 }),
+  };
+  const stdout = new MemoryWriter();
+
+  expect(await run([command.name], { registry: [...commandRegistry, command], stdout })).toBe(2);
+  expect(stdout.value.trimEnd().split("\n")).toHaveLength(1);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: command.name,
+    error: { code: cliErrorCodes.runtimeUnexpected },
+    ok: false,
+  });
+});
+
+test("normalizes non-JSON-safe handler data before any success is written", async () => {
+  const command: CommandDefinition = {
+    name: "future-invalid-data",
+    summary: "Exercise the JSON-safe process boundary.",
+    positionals: [],
+    options: [],
+    resultSchema: { type: "object" },
+    errorCodes: frameworkErrorCodes,
+    exitCodes: [0, 2],
+    handler: () => ({ data: undefined as never }),
+  };
+  const stdout = new MemoryWriter();
+
+  expect(await run([command.name], { registry: [...commandRegistry, command], stdout })).toBe(2);
+  expect(stdout.value.trimEnd().split("\n")).toHaveLength(1);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: command.name,
+    error: { code: cliErrorCodes.runtimeUnexpected },
+    ok: false,
+  });
+});
+
+test("normalizes handler errors that are not visible in command metadata", async () => {
+  const command: CommandDefinition = {
+    name: "future-failure",
+    summary: "Exercise the visible error allowlist.",
+    positionals: [],
+    options: [],
+    resultSchema: { type: "object" },
+    errorCodes: frameworkErrorCodes,
+    exitCodes: [0, 2],
+    handler: () => {
+      throw new CliError("domain.private", "Private handler detail.");
+    },
+  };
+  const stdout = new MemoryWriter();
+
+  expect(
+    await run(["future-failure"], {
+      registry: [...commandRegistry, command],
+      stdout,
+    }),
+  ).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "future-failure",
+    error: {
+      code: cliErrorCodes.runtimeUnexpected,
+      message: "The command could not be completed.",
+    },
+    ok: false,
+  });
+  expect(stdout.value).not.toContain("domain.private");
+  expect(stdout.value).not.toContain("Private handler detail");
+});
+
+test("preserves handler errors declared in command metadata", async () => {
+  const command: CommandDefinition = {
+    name: "future-visible-failure",
+    summary: "Exercise a declared domain error.",
+    positionals: [],
+    options: [],
+    resultSchema: { type: "object" },
+    errorCodes: [...frameworkErrorCodes, "domain.visible"],
+    exitCodes: [0, 2],
+    handler: () => {
+      throw new CliError("domain.visible", "The domain call could not be completed.");
+    },
+  };
+  const stdout = new MemoryWriter();
+
+  expect(
+    await run(["future-visible-failure"], {
+      registry: [...commandRegistry, command],
+      stdout,
+    }),
+  ).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "future-visible-failure",
+    error: {
+      code: "domain.visible",
+      message: "The domain call could not be completed.",
+    },
+    ok: false,
+  });
+});
+
+test("registers parent and nested commands from dotted command names", async () => {
+  const definitions: readonly CommandDefinition[] = [
+    ...commandRegistry,
+    {
+      name: "config",
+      summary: "Return configuration capabilities.",
+      positionals: [],
+      options: [],
+      resultSchema: { type: "object" },
+      errorCodes: frameworkErrorCodes,
+      exitCodes: [0, 2],
+      handler: () => ({ data: { kind: "root" } }),
+    },
+    {
+      name: "config.path",
+      summary: "Return the selected configuration path.",
+      positionals: [],
+      options: [],
+      resultSchema: { type: "object" },
+      errorCodes: frameworkErrorCodes,
+      exitCodes: [0, 2],
+      handler: () => ({ data: { kind: "nested" } }),
+    },
+  ];
+
+  const root = new MemoryWriter();
+  expect(await run(["config"], { registry: definitions, stdout: root })).toBe(0);
+  expect(JSON.parse(root.value)).toMatchObject({ command: "config", data: { kind: "root" } });
+
+  const nested = new MemoryWriter();
+  expect(await run(["config", "path"], { registry: definitions, stdout: nested })).toBe(0);
+  expect(JSON.parse(nested.value)).toMatchObject({
+    command: "config.path",
+    data: { kind: "nested" },
+  });
+
+  const description = new MemoryWriter();
+  expect(
+    await run(["describe", "config.path"], {
+      registry: definitions,
+      stdout: description,
+    }),
+  ).toBe(0);
+  expect(JSON.parse(description.value)).toMatchObject({
+    command: "describe",
+    data: { name: "config.path", usage: "config path" },
+  });
+});

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -1,0 +1,509 @@
+import {
+  protocolVersion,
+  toolVersion,
+  type JsonSchema,
+  type JsonValue,
+} from "./output/protocol.js";
+import { frameworkErrorCodes, invalidInvocationError } from "./runtime/errors.js";
+import { logLevels } from "./runtime/logger.js";
+
+export interface CommandOption {
+  readonly longFlag: string;
+  readonly shortFlag?: string;
+  readonly description: string;
+  /** Value syntax when the option is present; `required` selects `<value>` over `[value]`. */
+  readonly value?: Readonly<{ name: string; required: boolean }>;
+  /** Requires callers to provide the option; defaults are therefore not allowed. */
+  readonly optionRequired: boolean;
+  /** Reserved for framework-owned global options on the root command. */
+  readonly behavior?: "help" | "log-level" | "version";
+  /** Framework option availability; local command options omit this field. */
+  readonly scope?: "global" | "root";
+  /** Static framework response metadata, including its discoverable data contract. */
+  readonly response?: Readonly<{
+    command: string;
+    data: JsonValue;
+    resultSchema: JsonSchema;
+  }>;
+  readonly defaultValue?: string;
+  readonly values?: readonly string[];
+}
+
+export interface PositionalArgument {
+  readonly name: string;
+  readonly required: boolean;
+  readonly values?: readonly string[];
+}
+
+export interface CommandDefinition {
+  /** Stable dotted command id; dots become nested Commander paths. */
+  readonly name: string;
+  readonly summary: string;
+  readonly positionals: readonly PositionalArgument[];
+  readonly options: readonly CommandOption[];
+  /** Validates response `data`; the protocol envelope has its own exported schema. */
+  readonly resultSchema: JsonSchema;
+  /** Handler errors outside this allowlist are exposed as `runtime.unexpected`. */
+  readonly errorCodes: readonly string[];
+  /** Must contain framework exits 0 and 2; domain commands may additionally declare 1. */
+  readonly exitCodes: readonly number[];
+  readonly handler: CommandHandler;
+}
+
+export interface CommandInvocation {
+  readonly options: Readonly<Record<string, unknown>>;
+  readonly positionals: readonly string[];
+  readonly describeCommand: DescribeCommand;
+}
+
+export type DescribeCommand = (command?: string) => JsonValue | undefined;
+
+/** Domain result returned to the adapter, which performs the single stdout write. */
+export interface CommandResult<T extends JsonValue = JsonValue> {
+  readonly data: T;
+  /** Defaults to 0. Exit 1 is valid only when declared by the command. */
+  readonly exitCode?: 0 | 1;
+}
+
+export type CommandHandler = (
+  invocation: CommandInvocation,
+) => CommandResult | Promise<CommandResult>;
+
+const frameworkExitCodes = [0, 2] as const;
+export const discoveryCommandName = "describe";
+const stringSchema: JsonSchema = { type: "string" };
+const versionResultSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["protocolVersion", "toolVersion"],
+  properties: {
+    protocolVersion: { const: protocolVersion },
+    toolVersion: stringSchema,
+  },
+};
+
+const globalOptions: readonly CommandOption[] = [
+  {
+    longFlag: "--help",
+    shortFlag: "-h",
+    description: "Return machine-readable command capabilities.",
+    optionRequired: false,
+    behavior: "help",
+    scope: "global",
+  },
+  {
+    longFlag: "--version",
+    shortFlag: "-V",
+    description: "Return protocol and tool versions.",
+    optionRequired: false,
+    behavior: "version",
+    scope: "root",
+    response: {
+      command: "version",
+      data: { protocolVersion, toolVersion },
+      resultSchema: versionResultSchema,
+    },
+  },
+  {
+    longFlag: "--log-level",
+    description: "Set stderr log verbosity.",
+    value: { name: "level", required: true },
+    optionRequired: false,
+    behavior: "log-level",
+    scope: "global",
+    defaultValue: "error",
+    values: logLevels,
+  },
+] as const satisfies readonly CommandOption[];
+
+const positionalDescriptionSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name", "required"],
+  properties: {
+    name: stringSchema,
+    required: { type: "boolean" },
+    values: { type: "array", items: stringSchema },
+  },
+};
+const optionResponseDescriptionSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["command", "resultSchema"],
+  properties: {
+    command: stringSchema,
+    resultSchema: { type: "object" },
+  },
+};
+const optionDescriptionSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name", "description", "required", "scope"],
+  properties: {
+    name: stringSchema,
+    description: stringSchema,
+    required: { type: "boolean" },
+    scope: { enum: ["command", "global", "root"] },
+    behavior: { enum: ["help", "log-level", "version"] },
+    response: optionResponseDescriptionSchema,
+    defaultValue: stringSchema,
+    values: { type: "array", items: stringSchema },
+  },
+};
+const commandCapabilityProperties: Readonly<Record<string, JsonSchema>> = {
+  usage: stringSchema,
+  name: stringSchema,
+  summary: stringSchema,
+  positionals: { type: "array", items: positionalDescriptionSchema },
+  options: { type: "array", items: optionDescriptionSchema },
+  resultSchema: { type: "object" },
+  errorCodes: { type: "array", items: stringSchema },
+  exitCodes: { type: "array", items: { type: "integer" } },
+};
+const commandCapabilityRequired = [
+  "usage",
+  "name",
+  "summary",
+  "positionals",
+  "options",
+  "resultSchema",
+  "errorCodes",
+  "exitCodes",
+] as const;
+const commandCapabilitySchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: commandCapabilityRequired,
+  properties: commandCapabilityProperties,
+};
+const rootCapabilitySchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [...commandCapabilityRequired, "commands"],
+  properties: {
+    ...commandCapabilityProperties,
+    commands: { type: "array", items: commandCapabilitySchema },
+  },
+};
+const discoveryResultSchema: JsonSchema = {
+  oneOf: [rootCapabilitySchema, commandCapabilitySchema],
+};
+
+const builtInCommandDefinitions = [
+  {
+    name: discoveryCommandName,
+    summary: "Return machine-readable command capabilities.",
+    positionals: [{ name: "command", required: false }],
+    options: [],
+    resultSchema: discoveryResultSchema,
+    errorCodes: frameworkErrorCodes,
+    exitCodes: [0, 2],
+    handler: (invocation) => ({
+      data: requireCommandDescription(invocation.describeCommand, invocation.positionals[0]),
+    }),
+  },
+] satisfies readonly CommandDefinition[];
+
+/** Root parser metadata is separate because it is not an invokable child command. */
+export const rootCommand = snapshotCommandDefinition({
+  name: "lore",
+  summary: "Engineering knowledge tooling for AI coding agents.",
+  positionals: [],
+  options: globalOptions,
+  resultSchema: rootCapabilitySchema,
+  errorCodes: frameworkErrorCodes,
+  exitCodes: [0, 2],
+  handler: (invocation) => ({ data: requireCommandDescription(invocation.describeCommand) }),
+});
+
+/** Immutable child-command registry used unless a complete replacement is supplied. */
+export const commandRegistry = snapshotCommandDefinitions(builtInCommandDefinitions);
+
+export type KnownCommand = "lore" | (typeof commandRegistry)[number]["name"];
+
+export function describeCommand(
+  command?: string,
+  definitions: readonly CommandDefinition[] = commandRegistry,
+): JsonValue | undefined {
+  if (command === "lore" || command === undefined) {
+    return {
+      ...materializeCommandDefinition(rootCommand, definitions),
+      commands: definitions.map((definition) =>
+        materializeCommandDefinition(definition, definitions),
+      ),
+    };
+  }
+
+  const definition = definitions.find((candidate) => candidate.name === command);
+  return definition === undefined
+    ? undefined
+    : materializeCommandDefinition(definition, definitions);
+}
+
+export function positionalValues(
+  definition: CommandDefinition,
+  positional: PositionalArgument,
+  definitions: readonly CommandDefinition[] = commandRegistry,
+): readonly string[] | undefined {
+  return definition.name === discoveryCommandName && positional.name === "command"
+    ? definitions.map((candidate) => candidate.name)
+    : positional.values;
+}
+
+export function requireCommandDescription(describe: DescribeCommand, command?: string): JsonValue {
+  const description = describe(command);
+  if (description === undefined) throw invalidInvocationError();
+  return description;
+}
+
+interface CommandOptionDescription {
+  readonly name: string;
+  readonly description: string;
+  readonly required: boolean;
+  readonly scope: "command" | "global" | "root";
+  readonly behavior?: CommandOption["behavior"];
+  readonly response?: Readonly<{ command: string; resultSchema: JsonSchema }>;
+  readonly defaultValue?: string;
+  readonly values?: readonly string[];
+}
+
+type CommandDescription = Omit<CommandDefinition, "handler" | "options"> & {
+  usage: string;
+  options: readonly CommandOptionDescription[];
+};
+
+function materializeCommandDefinition(
+  definition: CommandDefinition,
+  definitions: readonly CommandDefinition[],
+): CommandDescription {
+  const options =
+    definition === rootCommand
+      ? definition.options
+      : [
+          ...rootCommand.options.filter((option) => commandOptionAppliesTo(option, definition)),
+          ...definition.options,
+        ];
+  return {
+    usage: commandUsage(definition),
+    name: definition.name,
+    summary: definition.summary,
+    positionals: definition.positionals.map((positional) => {
+      const values = positionalValues(definition, positional, definitions);
+      return { ...positional, ...(values === undefined ? {} : { values }) };
+    }),
+    options: options.map((option) => ({
+      name: commandOptionDeclaration(option),
+      description: option.description,
+      required: option.optionRequired,
+      scope: option.scope ?? "command",
+      ...(option.behavior === undefined ? {} : { behavior: option.behavior }),
+      ...(option.response === undefined
+        ? {}
+        : {
+            response: {
+              command: option.response.command,
+              resultSchema: option.response.resultSchema,
+            },
+          }),
+      ...(option.defaultValue === undefined ? {} : { defaultValue: option.defaultValue }),
+      ...(option.values === undefined ? {} : { values: [...option.values] }),
+    })),
+    resultSchema: definition.resultSchema,
+    errorCodes: [...definition.errorCodes],
+    exitCodes: [...definition.exitCodes],
+  };
+}
+
+export function snapshotCommandDefinitions(
+  definitions: readonly CommandDefinition[],
+): readonly CommandDefinition[] {
+  assertRegistryMetadata(definitions);
+  return Object.freeze(definitions.map(snapshotCommandDefinition));
+}
+
+export function commandOptionKey(option: CommandOption): string {
+  const longName = option.longFlag.slice(2);
+  return longName.replace(/-([a-z0-9])/g, (_, character: string) => character.toUpperCase());
+}
+
+export function commandOptionDeclaration(option: CommandOption): string {
+  const flags =
+    option.shortFlag === undefined ? option.longFlag : `${option.shortFlag}, ${option.longFlag}`;
+  if (option.value === undefined) return flags;
+  const value = option.value.required ? `<${option.value.name}>` : `[${option.value.name}]`;
+  return `${flags} ${value}`;
+}
+
+export function commandOptionAppliesTo(
+  option: CommandOption,
+  definition: CommandDefinition,
+): boolean {
+  return option.scope !== "root" || definition === rootCommand;
+}
+
+function snapshotCommandDefinition(definition: CommandDefinition): CommandDefinition {
+  assertFrameworkMetadata(definition);
+  return Object.freeze({
+    ...definition,
+    positionals: Object.freeze(
+      definition.positionals.map((positional) =>
+        Object.freeze({
+          ...positional,
+          ...(positional.values === undefined
+            ? {}
+            : { values: Object.freeze([...positional.values]) }),
+        }),
+      ),
+    ),
+    options: Object.freeze(
+      definition.options.map((option) =>
+        Object.freeze({
+          ...option,
+          ...(option.value === undefined ? {} : { value: Object.freeze({ ...option.value }) }),
+          ...(option.response === undefined
+            ? {}
+            : { response: deepFreeze(structuredClone(option.response)) }),
+          ...(option.values === undefined ? {} : { values: Object.freeze([...option.values]) }),
+        }),
+      ),
+    ),
+    resultSchema: deepFreeze(structuredClone(definition.resultSchema)),
+    errorCodes: Object.freeze([...definition.errorCodes]),
+    exitCodes: Object.freeze([...definition.exitCodes]),
+  });
+}
+
+function assertFrameworkMetadata(definition: CommandDefinition): void {
+  if (!/^[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)*$/.test(definition.name)) {
+    throw new Error(`Command name "${definition.name}" must be a dotted kebab-case id.`);
+  }
+  if (new Set(definition.errorCodes).size !== definition.errorCodes.length) {
+    throw new Error(`Command "${definition.name}" declares duplicate error codes.`);
+  }
+  if (new Set(definition.exitCodes).size !== definition.exitCodes.length) {
+    throw new Error(`Command "${definition.name}" declares duplicate exit codes.`);
+  }
+  if (definition.exitCodes.some((exitCode) => exitCode !== 0 && exitCode !== 1 && exitCode !== 2)) {
+    throw new Error(`Command "${definition.name}" declares an unsupported exit code.`);
+  }
+  if (
+    new Set(definition.positionals.map((positional) => positional.name)).size !==
+    definition.positionals.length
+  ) {
+    throw new Error(`Command "${definition.name}" declares duplicate positional names.`);
+  }
+  for (const option of definition.options) {
+    if (!/^--[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/.test(option.longFlag)) {
+      throw new Error(`Command "${definition.name}" declares invalid long option flag.`);
+    }
+    if (option.shortFlag !== undefined && !/^-[A-Za-z0-9]$/.test(option.shortFlag)) {
+      throw new Error(`Command "${definition.name}" declares invalid short option flag.`);
+    }
+    if (option.value !== undefined && !/^[a-z][a-z0-9-]*$/.test(option.value.name)) {
+      throw new Error(`Command "${definition.name}" declares an invalid option value name.`);
+    }
+    if (
+      option.behavior === undefined &&
+      (option.scope !== undefined || option.response !== undefined)
+    ) {
+      throw new Error(`Command "${definition.name}" option scope and response require a behavior.`);
+    }
+    if (option.behavior !== undefined && option.scope === undefined) {
+      throw new Error(`Command "${definition.name}" framework options must declare a scope.`);
+    }
+    if ((option.behavior === "version") !== (option.response !== undefined)) {
+      throw new Error(
+        `Command "${definition.name}" version behavior requires exactly one response.`,
+      );
+    }
+    if (option.optionRequired && option.defaultValue !== undefined) {
+      throw new Error(`Command "${definition.name}" cannot default a required option.`);
+    }
+    if (
+      (option.defaultValue !== undefined || option.values !== undefined) &&
+      option.value === undefined
+    ) {
+      throw new Error(`Command "${definition.name}" option values require a value declaration.`);
+    }
+    if (option.values !== undefined && option.values.length === 0) {
+      throw new Error(`Command "${definition.name}" option choices must not be empty.`);
+    }
+    if (
+      option.defaultValue !== undefined &&
+      option.values !== undefined &&
+      !option.values.includes(option.defaultValue)
+    ) {
+      throw new Error(`Command "${definition.name}" option default must be one of its choices.`);
+    }
+  }
+  for (const errorCode of frameworkErrorCodes) {
+    if (!definition.errorCodes.includes(errorCode)) {
+      throw new Error(`Command "${definition.name}" must declare error code "${errorCode}".`);
+    }
+  }
+  for (const exitCode of frameworkExitCodes) {
+    if (!definition.exitCodes.includes(exitCode)) {
+      throw new Error(`Command "${definition.name}" must declare exit code ${exitCode}.`);
+    }
+  }
+}
+
+function assertRegistryMetadata(definitions: readonly CommandDefinition[]): void {
+  const names = new Set<string>();
+  const globalOptionFlags = new Set(rootCommand.options.flatMap(commandOptionFlags));
+
+  for (const definition of definitions) {
+    if (definition.name === rootCommand.name) {
+      throw new Error(`Command name "${definition.name}" is reserved for the root command.`);
+    }
+    if (names.has(definition.name)) {
+      throw new Error(`Command name "${definition.name}" is declared more than once.`);
+    }
+    names.add(definition.name);
+
+    const localOptionFlags = new Set<string>();
+    for (const option of definition.options) {
+      if (option.behavior !== undefined) {
+        throw new Error(`Command "${definition.name}" cannot declare framework option behavior.`);
+      }
+      for (const flag of commandOptionFlags(option)) {
+        if (globalOptionFlags.has(flag) || localOptionFlags.has(flag)) {
+          throw new Error(`Command "${definition.name}" declares conflicting option "${flag}".`);
+        }
+        localOptionFlags.add(flag);
+      }
+    }
+  }
+
+  for (const definition of definitions) {
+    const hasChild = definitions.some((candidate) =>
+      candidate.name.startsWith(`${definition.name}.`),
+    );
+    if (hasChild && (definition.positionals.length > 0 || definition.options.length > 0)) {
+      throw new Error(
+        `Command "${definition.name}" cannot combine local arguments with child commands.`,
+      );
+    }
+  }
+}
+
+function commandOptionFlags(option: CommandOption): string[] {
+  return option.shortFlag === undefined ? [option.longFlag] : [option.shortFlag, option.longFlag];
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
+
+  for (const nestedValue of Object.values(value)) {
+    deepFreeze(nestedValue);
+  }
+  return Object.freeze(value);
+}
+
+function commandUsage(definition: CommandDefinition): string {
+  const command = definition.name.replaceAll(".", " ");
+  const positionals = definition.positionals.map((positional) =>
+    positional.required ? `<${positional.name}>` : `[${positional.name}]`,
+  );
+  return [command, ...positionals].join(" ");
+}

--- a/packages/cli/src/runtime/errors.ts
+++ b/packages/cli/src/runtime/errors.ts
@@ -1,0 +1,57 @@
+export const cliErrorCodes = Object.freeze({
+  runtimeUnexpected: "runtime.unexpected",
+  usageInvalid: "usage.invalid",
+});
+
+export const frameworkErrorCodes = Object.freeze([
+  cliErrorCodes.usageInvalid,
+  cliErrorCodes.runtimeUnexpected,
+]);
+
+export class CliError extends Error {
+  readonly exitCode = 2 as const;
+
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "CliError";
+  }
+}
+
+export function invalidInvocationError(): CliError {
+  return new CliError(cliErrorCodes.usageInvalid, "The command invocation is invalid.");
+}
+
+/** Preserves only errors declared by the selected command's public allowlist. */
+export function toVisibleCliError(error: unknown, visibleErrorCodes: readonly string[]): CliError {
+  const cliError = toCliError(error);
+  return visibleErrorCodes.includes(cliError.code) ? cliError : unexpectedRuntimeError();
+}
+
+function toCliError(error: unknown): CliError {
+  if (error instanceof CliError) {
+    return error;
+  }
+
+  if (isCommanderError(error)) {
+    return invalidInvocationError();
+  }
+
+  return unexpectedRuntimeError();
+}
+
+function unexpectedRuntimeError(): CliError {
+  return new CliError(cliErrorCodes.runtimeUnexpected, "The command could not be completed.");
+}
+
+function isCommanderError(error: unknown): error is { code: string } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    error.code.startsWith("commander.")
+  );
+}

--- a/packages/cli/src/runtime/logger.test.ts
+++ b/packages/cli/src/runtime/logger.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+
+import { Logger } from "./logger.js";
+
+class MemoryWriter {
+  value = "";
+
+  write(message: string): void {
+    this.value += message;
+  }
+}
+
+test("filters logs by the configured level", () => {
+  const writer = new MemoryWriter();
+  const logger = new Logger(writer);
+  logger.setLevel("warn");
+
+  logger.log("info", "hidden");
+  logger.log("warn", "visible");
+
+  expect(writer.value).toBe("[warn] visible\n");
+});

--- a/packages/cli/src/runtime/logger.ts
+++ b/packages/cli/src/runtime/logger.ts
@@ -1,0 +1,28 @@
+import type { OutputWriter } from "../output/protocol.js";
+
+export const logLevels = ["error", "warn", "info", "debug"] as const;
+
+export type LogLevel = (typeof logLevels)[number];
+
+const priorities: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+};
+
+export class Logger {
+  private level: LogLevel = "error";
+
+  constructor(private readonly writer: OutputWriter) {}
+
+  setLevel(level: LogLevel): void {
+    this.level = level;
+  }
+
+  log(level: LogLevel, message: string): void {
+    if (priorities[level] <= priorities[this.level]) {
+      this.writer.write(`[${level}] ${message}\n`);
+    }
+  }
+}


### PR DESCRIPTION
## 关联

- Closes #20
- Parent context: #13
- Supersedes the closed, over-scoped PR #14
- Candidate design: `docs/adr/0004-agent-first-cli-protocol.md`
- Split rationale: PR #14 maintainer Request Changes review

## 背景

PR #14 将 CLI 协议、配置、pack loader、format 行为、CI 和仓库文档绑在一起，无法按
one-issue-per-PR 独立审核。本 PR 只收住 agent-first CLI 的 JSON 进程协议和命令注册
边界，让后续配置、领域命令和 loader 可以在不重新发明 parser、输出或错误语义的前提下
分别演进。

ADR 0004 保持 `Proposed`：本 PR 提供可执行实现和验证证据，但协议是否成为长期真源仍由
维护者 review 决定。

## 改动

### CLI 协议边界

- 增加单行 JSON success/failure envelope、协议版本、工具版本和公共 JSON Schema。
- 从 `@lorelum/cli` 公共入口导出 envelope schema、协议类型、`run` 和 program factory。
- 将 `lore`、`--help`、`--version`、`describe [command]` 和非法调用统一到同一 envelope。
- 非法参数返回稳定 exit code `2` 和泛化错误，不回显原始参数。

### Command registry

- 用命令定义驱动 Commander parser、capability discovery、result schema、error codes 和
  exit codes。
- 生产 registry 深冻结；每个 program 使用创建时的不可变快照，避免 parser 与
  `describe` 因生命周期发生漂移。
- command handler 返回结构化 `data` 和可选 exit code；中心 renderer 唯一写入 stdout。
  exit code `1` 表示 `ok: true` 的已完成阻塞结果，failure envelope 只能返回 `2`。
- success data 在写 stdout 前执行 JSON-safe 递归校验；`undefined`、BigInt、非有限数字、
  循环引用和非普通对象统一转为单行 `runtime.unexpected`。
- `errorCodes` 作为运行时可见错误白名单：未登记 handler 错误统一降级为
  `runtime.unexpected`，并校验每个命令都声明框架基础错误和 `[0, 2]`。
- registry snapshot 拒绝重复命令名、root 保留名、全局 option 冲突和有歧义的层级定义，
  并禁止未建模的父级本地参数继承，避免 `describe` metadata 与 Commander 实际 handler
  漂移。
- option 将长短 flag、value 和 option-required 结构化建模，统一拒绝 alias 冲突、
  required/default 冲突和不属于 choices 的 default。
- framework option 用同一 metadata 声明 global/root scope；root-only 的 `--version` 不再
  出现在子命令 discovery 中，其响应 command、data 和 result schema 也由同一处定义。

### 验证边界

- 覆盖 envelope schema、root/describe result schema、非法调用、registry 冻结与快照、
  exit code `1`、错误白名单和嵌套命令。
- 将真实 Bun 进程与 compiled binary 冒烟测试放入独立 `test:integration` target，避免
  混入 `bun test` 单元测试套件。
- integration 子进程统一使用 60 秒上限，超时后主动终止；短超时回归用例覆盖异常路径。

## 验证

- `bun test`：124 pass、0 fail、266 assertions。
- `bun run typecheck`：5 个 workspace 全部通过。
- `bun run lint`：通过。
- `bun run test:integration`：源码入口、compiled binary、discovery 和非法参数冒烟通过。
- 对 19 个 PR 文本文件运行 `oxfmt --check`：通过。
- `git diff --cached --check upstream/main`：通过。
- 敏感信息模式扫描：未发现 private key、GitHub token、OpenAI key、AWS key 或密码赋值。
- Commander `15.0.0`：MIT license。

## 风险与未验证项

- **result schema 运行期校验（后续领域命令风险）：** 独立 envelope fixture 只验证外层
  协议；当前内置 root/describe 输出由测试对 registry result schema 做一致性校验。任意注入
  的未来 handler 数据尚不在生产运行期执行 JSON Schema 校验；首个领域命令应继续补同类
  契约测试，若需要运行期拒绝 schema 漂移，应单独选择标准 JSON Schema validator。
- **全仓格式基线（非本任务）：** `bun run fmt:check` 会在 57 个与本 PR 无关、且内容与
  `upstream/main` 一致的既有文件上失败；当前 CI 将该步骤设为 `continue-on-error`。本 PR
  不重新格式化 README、AGENTS、format/engine 或其他无关文件。
- **依赖审计基线（非本任务）：** `bun audit` 报告 4 个既有传递依赖漏洞（2 high、
  2 moderate）：`@modelcontextprotocol/sdk` 链路中的 `@hono/node-server` / `fast-uri`，以及
  `gray-matter` 链路中的 `js-yaml`。本 PR 新增的 Commander 不在报告中；依赖升级应单独
  issue/PR 处理，避免扩大协议 PR 范围。
- 本地仅运行当前 Windows 环境的 compiled binary integration；本 PR 不修改 CI workflow，
  因此不声明新增 Linux/macOS binary matrix 证据。

## Review Notes

- 建议按 ADR 0004 → output protocol/schema → registry → create-program/main → tests 的顺序审核。
- 本 PR 明确不包含 config、`lore validate`、pack loader、format YAML/frontmatter/validation
  行为、AGENTS/README/SECURITY 或 GitHub Actions 信任链改动。
- Commander、process I/O、stdout/stderr 和 exit code 只存在于 `packages/cli`；engine、
  format、MCP 和 shared 均未增加对 CLI 的依赖。
- Package 仍是 `private`、版本 `0.0.0`，本 PR 不发布 package 或 binary，也不承诺最终的
  human-readable mode 或 v1 compatibility policy。
