### PR TITLE
[feat] 新增确定性本地 lore decide 命令（结构化决策图求值器，v1）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Test
         run: bun test
 
+      # Process-level integration tests compile the real CLI binary and spawn
+      # it, so they are gated separately from the unit suite (ADR 0004).
+      - name: Integration test
+        run: bun run test:integration
+
       # oxfmt is still alpha (ADR 0002). Run as a non-blocking signal for now;
       # promote to blocking once it stabilizes.
       - name: Format check

--- a/docs/adr/0008-decide-evaluation-contract.md
+++ b/docs/adr/0008-decide-evaluation-contract.md
@@ -1,0 +1,99 @@
+# ADR 0008: Decide evaluation contract
+
+- **Date:** 2026-08-10
+- **Status:** Proposed
+- **Related:** ADR 0003 (`decisions.yaml` Decision Node schema), ADR 0004 (agent-first CLI protocol), ADR 0007 (engine LocalStore). Reference implementation: fork PR `SmallParamecium/lorelum#18` (MERGED) and its F1 boundary fix `SmallParamecium/lorelum#20` (carried into this change).
+
+## Context
+
+ADR 0003 freezes the `decisions.yaml` schema and Decision Node fields, and the P5 roadmap calls for a "decision graph evaluator," but the official `main` has no runtime command that executes a decision tree. The official CLI (ADR 0004, PR #21) is an agent-first protocol framework with no domain commands yet, so agents cannot map a structured project context to a deterministic decision path or obtain an auditable recommendation trace.
+
+The fork (`SmallParamecium/lorelum`) implemented `lore decide` on a Commander-based CLI that diverged from the official framework after common ancestor `03761a3`: its handler protocol is `async (output, invocation)` and its runtime owns a pack loader, so its CLI layer cannot be reused directly. The engine/decide evaluator and `parseDecisionDocument` are pure logic that port cleanly. A stack-overflow defect (F1) in the when-condition parser — a flat binary-operator chain within the 256KiB input budget recursed through evaluation — was fixed in fork PR #20 with a regression test and must land with the port.
+
+Scope decisions made before this ADR:
+
+- **D0:** This issue is the structured decision-graph evaluator (P5 "decision graph evaluator" local v1), not the README natural-language `lore decide` (P0–P2 retrieval/LLM). They are complementary; the natural-language form is out of scope.
+- **D1:** `decide <pack-path>` reads `<pack-path>/decisions.yaml` with a 256KiB cap. The full v1 directory-layout loader and its threat model (not accepted upstream) are a separate future task.
+- **D2:** `--human` is not ported; the official protocol is a single JSON envelope (ADR 0004). Human rendering is deferred as a protocol extension.
+- **D4:** ADR number 0008 — 0005–0006 are reserved for in-flight planning, 0007 is engine-local-store.
+
+## Decision
+
+### 1. Command surface and layering
+
+`lore decide <pack-path> --decision <id> --context <json>` is registered on the official ADR 0004 framework:
+
+- `@lorelum/engine` exposes a pure `evaluateDecisions` function (no filesystem or process I/O) plus the when-condition parser; the CLI and future MCP adapters share the same semantics.
+- `@lorelum/format` adds `parseDecisionDocument` + `DecisionDocumentError`, reusing the existing `DecisionNodeSchema` unchanged.
+- The CLI package owns argument parsing and the lightweight pack read (`readDecisionsDocument`), because the official `CliRuntime` deliberately exposes only a logger and the framework has no loader.
+
+### 2. When-condition language (frozen)
+
+Supported: dotted field paths (`state.client`) whose segments match `[A-Za-z_][A-Za-z0-9_]*` (hyphens are not valid in when paths, unlike Decision Node ids), string/boolean/number literals, `==`, `!=`, `&&`, `||`, `!`, parentheses. Explicitly not supported: JS execution, function calls, regular expressions, collection quantifiers. Bounds: parentheses + unary nesting ≤ 128; logical binary operators (`&&` / `||`) per condition ≤ 1024; deeper or longer conditions are rejected as `decide.invalid_condition` (exit 2). This is the F1 fix: a flat `&&` chain under the input budget previously overflowed the stack during evaluation.
+
+### 3. Null safety and no-match
+
+Missing context fields and type-incompatible comparisons evaluate to `false` — never an error. When no branch in the entry node (or after a `next` chain) matches, the command returns `status: "no_match"` with `noMatchReason` and exit 0. An empty decisions document is an empty decision list → `no_match` ("pack has no decisions"); the entry id is not validated when the list is empty.
+
+### 4. Determinism and cycles
+
+- Branches are evaluated in declaration order; the first matching branch wins.
+- A matched branch may chain via `next` to another Decision Node id.
+- Recommendations deduplicate by practice id on first occurrence; reasons from each matched branch append in match order.
+- A runtime cycle along a `next` path is rejected as `decide.cycle` (exit 2). Duplicate decision ids are rejected up front as `decide.duplicate_decision`.
+
+### 5. Audit trace
+
+Every evaluation returns a full trace of visited nodes: `decisionId`, `question`, `matchedWhen` (the matched branch's when expression, or null), `nextDecision` (next node id, or null).
+
+### 6. Result contract
+
+Success envelope data:
+
+```text
+{ status: "matched" | "no_match",
+  entryDecision: <id>,
+  recommendations: [{ practiceId, reasons: string[] }],
+  trace: [{ decisionId, question, matchedWhen, nextDecision }] }
+```
+
+`no_match` adds `noMatchReason`. Exit codes: `matched`/`no_match` = 0; every error = 2. Error codes enter the ADR 0004 allowlist mechanism and are surfaced verbatim: `pack.path_invalid`, `pack.unreadable`, `pack.parse_error`, `decide.unknown_decision`, `decide.invalid_condition`, `decide.duplicate_decision`, `decide.cycle`. This differs from `validate`'s exit-1-on-issues convention because decide reports runtime evaluation errors (usage/input/evaluation), not validation issues.
+
+### 7. Pack input limits
+
+`decide <pack-path>` requires `<pack-path>` to be a readable directory (`pack.path_invalid` otherwise), reads `<pack-path>/decisions.yaml` (`pack.unreadable` when missing or unreadable), enforces a 256KiB byte cap matching the fork's `v1PackInputLimits.maxDecisionBytes` (`pack.unreadable` when exceeded), and parses through `@lorelum/format`'s guarded `parseYaml` (`pack.parse_error`). A parsed non-list document is `pack.parse_error` ("The decisions document is not a list of decision nodes.").
+
+### 8. Out of scope
+
+Not part of this change: `--human` rendering, the `config` command, the full v1 directory-layout loader (ADR 0006 counterpart, not accepted upstream), when-syntax checks in `lore validate` (ADR 0003/0007 follow-up), natural-language decide, `lore query/get/check`, MCP tool wiring, and any change to pack.yaml / Decision Node / Practice public fields.
+
+## Consequences
+
+**Positive:**
+
+- Deterministic, auditable, offline decision evaluation with a stable machine contract for agents.
+- The pure engine evaluator is reusable by future MCP adapters without duplicating semantics.
+- No new dependencies and no public schema changes; the F1 stack-overflow defect is fixed in-repo with regression coverage.
+
+**Negative / accepted risk:**
+
+- Human-readable rendering is deferred, so human users see only the JSON envelope until a future protocol extension.
+- The loader only understands `decisions.yaml`; packs relying on the full v1 directory layout or `pack.yaml` metadata are not validated here — a missing `decisions.yaml` is `pack.unreadable`, not a "no decisions" pack. This matches D1 and is revisited when the official loader task lands.
+- The when language is intentionally small; conditions needing functions, regex, or richer types require a superseding ADR.
+- ADR numbering leaves 0005–0006 unused (reserved for in-flight planning); 0008 follows 0007 per the repo convention.
+
+**Follow-ups:**
+
+- Official loader task: replace `readDecisionsDocument` with the full v1 directory-layout loader and its threat model.
+- `--human` / protocol presentation extension discussion (D2).
+- `lore validate` when-syntax checking as part of ADR 0003/0007 follow-ups.
+- Natural-language `lore decide` (P0–P2 retrieval/LLM) as a separate issue.
+
+## References
+
+- ADR 0003 — `decisions.yaml` schema and Decision Node fields consumed by this command.
+- ADR 0004 — agent-first JSON-envelope CLI protocol this command is registered on.
+- ADR 0007 — engine LocalStore; its validation follow-ups include when-syntax checks.
+- Fork reference implementation: `SmallParamecium/lorelum#18` (MERGED; source for engine/decide and format `parseDecisionDocument`).
+- F1 fix: `SmallParamecium/lorelum#20` (binary-operator bound + regression tests).
+- Issue: lorelum/lorelum#24 — this change.

--- a/docs/adr/0008-decide-evaluation-contract.md
+++ b/docs/adr/0008-decide-evaluation-contract.md
@@ -33,11 +33,18 @@ Supported: dotted field paths (`state.client`) whose segments match `[A-Za-z_][A
 
 ### 3. Null safety and no-match
 
-Missing context fields and type-incompatible comparisons evaluate to `false` — never an error. When no branch in the entry node (or after a `next` chain) matches, the command returns `status: "no_match"` with `noMatchReason` and exit 0. An empty decisions document is an empty decision list → `no_match` ("pack has no decisions"); the entry id is not validated when the list is empty.
+Missing context fields and type-incompatible comparisons never raise an error. A missing value propagates through the expression as unknown and resolves to `false` at the condition boundary, with these concrete rules:
+
+- A bare missing path (`feature.enabled`) and its negation (`!feature.enabled`) both evaluate to `false`.
+- `&&` / `||` treat a missing operand as `false`, so a determined other side wins: `missing || true` → `true`, `missing || false` → `false`, `missing && true` → `false`.
+- `==` and `!=` involving a missing operand evaluate to `false`, so `missing == missing` and `missing != "x"` are both `false`.
+
+When no branch in the entry node (or after a `next` chain) matches, the command returns `status: "no_match"` with `noMatchReason` and exit 0. An empty decisions document is an empty decision list → `no_match` ("pack has no decisions"); the entry id is not validated when the list is empty.
 
 ### 4. Determinism and cycles
 
 - Branches are evaluated in declaration order; the first matching branch wins.
+- All when conditions in a node are parsed before any is evaluated; a syntax error in any branch is `decide.invalid_condition` even when an earlier branch would have matched.
 - A matched branch may chain via `next` to another Decision Node id.
 - Recommendations deduplicate by practice id on first occurrence; reasons from each matched branch append in match order.
 - A runtime cycle along a `next` path is rejected as `decide.cycle` (exit 2). Duplicate decision ids are rejected up front as `decide.duplicate_decision`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ docs/adr/
 ├── 0004-agent-first-cli-protocol.md            # candidate CLI protocol contract
 ├── 0005-0006                                   # reserved for in-flight planning numbers; 0007 is numbered to match planning docs, not the strict next-free sequence
 ├── 0007-engine-local-store.md                 # @lorelum/engine LocalStore storage & lifecycle contract
+├── 0008-decide-evaluation-contract.md        # lore decide evaluation contract (engine/format/CLI)
 └── 0000-template.md                           # copy this to start a new ADR
 ```
 

--- a/packages/cli/integration/process.integration.ts
+++ b/packages/cli/integration/process.integration.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+import { clientVsServerYaml } from "../src/decide/fixtures.js";
 
 const entrypoint = join(import.meta.dir, "../src/main.ts");
 const bunExecutable = Bun.which("bun");
@@ -54,6 +56,22 @@ try {
   });
   assert.equal(invalid.stdout.includes("private-token"), false);
   assert.equal(invalid.stderr, "");
+
+  const packDirectory = join(directory, "pack");
+  await mkdir(packDirectory, { recursive: true });
+  await writeFile(join(packDirectory, "decisions.yaml"), clientVsServerYaml);
+  const decide = await runProcess([
+    executable,
+    "decide",
+    packDirectory,
+    "--decision",
+    "state.client-vs-server",
+    "--context",
+    '{"state":{"client":"heavy"}}',
+  ]);
+  assert.equal(decide.exitCode, 0);
+  assert.deepEqual(selectProtocolFields(decide.stdout), { command: "decide", ok: true });
+  assert.equal(decide.stderr, "");
 } finally {
   await rm(directory, { force: true, recursive: true });
 }

--- a/packages/cli/src/decide.test.ts
+++ b/packages/cli/src/decide.test.ts
@@ -1,0 +1,530 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { clientVsServerYaml } from "./decide/fixtures.js";
+import { run } from "./main.js";
+import { protocolResponseSchema, type JsonSchema } from "./output/protocol.js";
+import {
+  validateJsonSchema,
+  validateProtocolSchema,
+} from "./output/protocol-schema.test-helper.js";
+import { describeCommand } from "./registry.js";
+
+class MemoryWriter {
+  value = "";
+
+  write(message: string): void {
+    this.value += message;
+  }
+}
+
+async function withPackDirectory(
+  decisionsYaml: string,
+  runWithDirectory: (directory: string) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-decide-"));
+  try {
+    await writeFile(join(directory, "decisions.yaml"), decisionsYaml);
+    await runWithDirectory(directory);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+}
+
+function decisionResultSchema(): JsonSchema {
+  const description = describeCommand("decide") as { resultSchema?: JsonSchema } | undefined;
+  if (description?.resultSchema === undefined) {
+    throw new Error("Missing result schema for decide");
+  }
+  return description.resultSchema;
+}
+
+test("exposes decide through capability discovery", async () => {
+  const stdout = new MemoryWriter();
+  const stderr = new MemoryWriter();
+
+  expect(await run(["describe", "decide"], { stderr, stdout })).toBe(0);
+  const response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({
+    command: "describe",
+    ok: true,
+    data: {
+      name: "decide",
+      usage: "decide <pack-path>",
+      positionals: [{ name: "pack-path", required: true }],
+      options: [
+        { name: "-h, --help", required: false },
+        { name: "--log-level <level>", required: false },
+        { name: "--decision <id>", required: true },
+        { name: "--context <json>", required: true },
+      ],
+      errorCodes: [
+        "usage.invalid",
+        "runtime.unexpected",
+        "pack.path_invalid",
+        "pack.unreadable",
+        "pack.parse_error",
+        "decide.unknown_decision",
+        "decide.invalid_condition",
+        "decide.duplicate_decision",
+        "decide.cycle",
+      ],
+      exitCodes: [0, 2],
+    },
+  });
+  expect(validateProtocolSchema(response, protocolResponseSchema)).toEqual([]);
+  const discoverySchema = (describeCommand("describe") as { resultSchema?: JsonSchema } | undefined)
+    ?.resultSchema;
+  if (discoverySchema === undefined) throw new Error("Missing describe result schema");
+  expect(validateJsonSchema(response.data, discoverySchema)).toEqual([]);
+});
+
+test("evaluates a matching decision through the CLI protocol", async () => {
+  const stdout = new MemoryWriter();
+  const stderr = new MemoryWriter();
+
+  await withPackDirectory(clientVsServerYaml, async (directory) => {
+    expect(
+      await run(
+        [
+          "decide",
+          directory,
+          "--decision",
+          "state.client-vs-server",
+          "--context",
+          '{"state":{"client":"heavy"}}',
+        ],
+        { stderr, stdout },
+      ),
+    ).toBe(0);
+  });
+  const response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({
+    command: "decide",
+    ok: true,
+    data: {
+      status: "matched",
+      entryDecision: "state.client-vs-server",
+      recommendations: [{ practiceId: "react.state.redux", reasons: ["Redux scales"] }],
+      trace: [
+        {
+          decisionId: "state.client-vs-server",
+          matchedWhen: 'state.client == "heavy"',
+          nextDecision: null,
+          question: "How much client state?",
+        },
+      ],
+    },
+  });
+  expect(stderr.value).toBe("");
+  expect(validateProtocolSchema(response, protocolResponseSchema)).toEqual([]);
+  expect(validateJsonSchema(response.data, decisionResultSchema())).toEqual([]);
+});
+
+test("returns no_match when no branch matches the provided context", async () => {
+  const stdout = new MemoryWriter();
+  const stderr = new MemoryWriter();
+
+  await withPackDirectory(clientVsServerYaml, async (directory) => {
+    expect(
+      await run(
+        [
+          "decide",
+          directory,
+          "--decision",
+          "state.client-vs-server",
+          "--context",
+          '{"state":{"client":"light"}}',
+        ],
+        { stderr, stdout },
+      ),
+    ).toBe(0);
+  });
+  const response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({
+    command: "decide",
+    ok: true,
+    data: {
+      status: "no_match",
+      entryDecision: "state.client-vs-server",
+      noMatchReason: "no branch matched the provided context",
+      recommendations: [],
+      trace: [{ decisionId: "state.client-vs-server", matchedWhen: null, nextDecision: null }],
+    },
+  });
+  expect(validateJsonSchema(response.data, decisionResultSchema())).toEqual([]);
+});
+
+test("validates a chained match with non-null next edges against the result schema", async () => {
+  const stdout = new MemoryWriter();
+  const stderr = new MemoryWriter();
+  const chainedYaml = [
+    "- id: state.entry",
+    "  question: Start?",
+    "  branches:",
+    "    - when: 'state.client == \"heavy\"'",
+    "      recommend: [react.state.redux]",
+    "      reason: Redux scales",
+    "      next: state.fallback",
+    "- id: state.fallback",
+    "  question: Fallback?",
+    "  branches:",
+    "    - when: 'state.mode == \"offline\"'",
+    "      recommend: []",
+    "      reason: Nothing extra",
+    "",
+  ].join("\n");
+
+  await withPackDirectory(chainedYaml, async (directory) => {
+    expect(
+      await run(
+        [
+          "decide",
+          directory,
+          "--decision",
+          "state.entry",
+          "--context",
+          '{"state":{"client":"heavy","mode":"offline"}}',
+        ],
+        { stderr, stdout },
+      ),
+    ).toBe(0);
+  });
+  const response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({
+    command: "decide",
+    ok: true,
+    data: {
+      status: "matched",
+      entryDecision: "state.entry",
+      recommendations: [{ practiceId: "react.state.redux", reasons: ["Redux scales"] }],
+      trace: [
+        { decisionId: "state.entry", nextDecision: "state.fallback" },
+        { decisionId: "state.fallback", nextDecision: null },
+      ],
+    },
+  });
+  expect(validateProtocolSchema(response, protocolResponseSchema)).toEqual([]);
+  expect(validateJsonSchema(response.data, decisionResultSchema())).toEqual([]);
+});
+
+test("validates a matched result with empty recommendations against the result schema", async () => {
+  const stdout = new MemoryWriter();
+  const stderr = new MemoryWriter();
+  const emptyRecommendYaml = [
+    "- id: state.entry",
+    "  question: What now?",
+    "  branches:",
+    "    - when: 'enabled'",
+    "      recommend: []",
+    "      reason: No practice applies",
+    "",
+  ].join("\n");
+
+  await withPackDirectory(emptyRecommendYaml, async (directory) => {
+    expect(
+      await run(
+        ["decide", directory, "--decision", "state.entry", "--context", '{"enabled":true}'],
+        { stderr, stdout },
+      ),
+    ).toBe(0);
+  });
+  const response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({
+    command: "decide",
+    ok: true,
+    data: { status: "matched", entryDecision: "state.entry", recommendations: [] },
+  });
+  expect(validateJsonSchema(response.data, decisionResultSchema())).toEqual([]);
+});
+
+test("treats an empty decisions document as no_match", async () => {
+  const stdout = new MemoryWriter();
+  const stderr = new MemoryWriter();
+
+  await withPackDirectory("", async (directory) => {
+    expect(
+      await run(["decide", directory, "--decision", "state.entry", "--context", "{}"], {
+        stderr,
+        stdout,
+      }),
+    ).toBe(0);
+  });
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "decide",
+    ok: true,
+    data: {
+      noMatchReason: "pack has no decisions",
+      recommendations: [],
+      status: "no_match",
+    },
+  });
+});
+
+test("maps invalid pack paths and missing documents to pack errors", async () => {
+  const missingDirectory = new MemoryWriter();
+  const missingDirectoryStderr = new MemoryWriter();
+  const absentPath = join(tmpdir(), "lorelum-decide-missing-pack");
+
+  expect(
+    await run(["decide", absentPath, "--decision", "state.entry", "--context", "{}"], {
+      stderr: missingDirectoryStderr,
+      stdout: missingDirectory,
+    }),
+  ).toBe(2);
+  expect(JSON.parse(missingDirectory.value)).toMatchObject({
+    command: "decide",
+    error: { code: "pack.path_invalid" },
+    ok: false,
+  });
+
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-decide-"));
+  try {
+    const stdout = new MemoryWriter();
+    const stderr = new MemoryWriter();
+    expect(
+      await run(["decide", directory, "--decision", "state.entry", "--context", "{}"], {
+        stderr,
+        stdout,
+      }),
+    ).toBe(2);
+    expect(JSON.parse(stdout.value)).toMatchObject({
+      command: "decide",
+      error: { code: "pack.unreadable" },
+      ok: false,
+    });
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("maps malformed and non-list decisions documents to pack.parse_error", async () => {
+  const malformed = new MemoryWriter();
+  const malformedStderr = new MemoryWriter();
+  await withPackDirectory("- id: [unclosed", async (directory) => {
+    expect(
+      await run(["decide", directory, "--decision", "state.entry", "--context", "{}"], {
+        stderr: malformedStderr,
+        stdout: malformed,
+      }),
+    ).toBe(2);
+  });
+  expect(JSON.parse(malformed.value)).toMatchObject({
+    command: "decide",
+    error: { code: "pack.parse_error" },
+    ok: false,
+  });
+
+  const notAList = new MemoryWriter();
+  const notAListStderr = new MemoryWriter();
+  await withPackDirectory("id: state.entry", async (directory) => {
+    expect(
+      await run(["decide", directory, "--decision", "state.entry", "--context", "{}"], {
+        stderr: notAListStderr,
+        stdout: notAList,
+      }),
+    ).toBe(2);
+  });
+  expect(JSON.parse(notAList.value)).toMatchObject({
+    command: "decide",
+    error: {
+      code: "pack.parse_error",
+      message: "The decisions document is not a list of decision nodes.",
+    },
+    ok: false,
+  });
+});
+
+test("rejects invalid context and missing required options as usage errors", async () => {
+  await withPackDirectory(clientVsServerYaml, async (directory) => {
+    const badContext = new MemoryWriter();
+    const badContextStderr = new MemoryWriter();
+    expect(
+      await run(
+        ["decide", directory, "--decision", "state.client-vs-server", "--context", "not-json"],
+        { stderr: badContextStderr, stdout: badContext },
+      ),
+    ).toBe(2);
+    expect(JSON.parse(badContext.value)).toMatchObject({
+      command: "decide",
+      error: { code: "usage.invalid" },
+      ok: false,
+    });
+
+    const missingContext = new MemoryWriter();
+    const missingContextStderr = new MemoryWriter();
+    expect(
+      await run(["decide", directory, "--decision", "state.client-vs-server"], {
+        stderr: missingContextStderr,
+        stdout: missingContext,
+      }),
+    ).toBe(2);
+    expect(JSON.parse(missingContext.value)).toMatchObject({
+      command: "decide",
+      error: { code: "usage.invalid" },
+      ok: false,
+    });
+
+    const missingDecision = new MemoryWriter();
+    const missingDecisionStderr = new MemoryWriter();
+    expect(
+      await run(["decide", directory, "--context", "{}"], {
+        stderr: missingDecisionStderr,
+        stdout: missingDecision,
+      }),
+    ).toBe(2);
+    expect(JSON.parse(missingDecision.value)).toMatchObject({
+      command: "decide",
+      error: { code: "usage.invalid" },
+      ok: false,
+    });
+  });
+});
+
+test("maps evaluator failures to their declared protocol errors", async () => {
+  const unknown = new MemoryWriter();
+  const unknownStderr = new MemoryWriter();
+  await withPackDirectory(clientVsServerYaml, async (directory) => {
+    expect(
+      await run(["decide", directory, "--decision", "state.missing", "--context", "{}"], {
+        stderr: unknownStderr,
+        stdout: unknown,
+      }),
+    ).toBe(2);
+  });
+  expect(JSON.parse(unknown.value)).toMatchObject({
+    command: "decide",
+    error: { code: "decide.unknown_decision" },
+    ok: false,
+  });
+
+  const duplicate = new MemoryWriter();
+  const duplicateStderr = new MemoryWriter();
+  const duplicateYaml = [
+    "- id: state.entry",
+    "  question: What now?",
+    "  branches: []",
+    "- id: state.entry",
+    "  question: Ambiguous duplicate?",
+    "  branches: []",
+    "",
+  ].join("\n");
+  await withPackDirectory(duplicateYaml, async (directory) => {
+    expect(
+      await run(["decide", directory, "--decision", "state.entry", "--context", "{}"], {
+        stderr: duplicateStderr,
+        stdout: duplicate,
+      }),
+    ).toBe(2);
+  });
+  expect(JSON.parse(duplicate.value)).toMatchObject({
+    command: "decide",
+    error: { code: "decide.duplicate_decision" },
+    ok: false,
+  });
+
+  const cycle = new MemoryWriter();
+  const cycleStderr = new MemoryWriter();
+  const cycleYaml = [
+    "- id: state.entry",
+    "  question: Start?",
+    "  branches:",
+    "    - when: 'enabled'",
+    "      recommend: []",
+    "      reason: Loop",
+    "      next: state.entry",
+    "",
+  ].join("\n");
+  await withPackDirectory(cycleYaml, async (directory) => {
+    expect(
+      await run(
+        ["decide", directory, "--decision", "state.entry", "--context", '{"enabled":true}'],
+        { stderr: cycleStderr, stdout: cycle },
+      ),
+    ).toBe(2);
+  });
+  expect(JSON.parse(cycle.value)).toMatchObject({
+    command: "decide",
+    error: { code: "decide.cycle" },
+    ok: false,
+  });
+
+  const invalidCondition = new MemoryWriter();
+  const invalidConditionStderr = new MemoryWriter();
+  const invalidConditionYaml = [
+    "- id: state.entry",
+    "  question: What now?",
+    "  branches:",
+    "    - when: 'state.client = \"heavy\"'",
+    "      recommend: []",
+    "      reason: Invalid",
+    "",
+  ].join("\n");
+  await withPackDirectory(invalidConditionYaml, async (directory) => {
+    expect(
+      await run(["decide", directory, "--decision", "state.entry", "--context", "{}"], {
+        stderr: invalidConditionStderr,
+        stdout: invalidCondition,
+      }),
+    ).toBe(2);
+  });
+  expect(JSON.parse(invalidCondition.value)).toMatchObject({
+    command: "decide",
+    error: { code: "decide.invalid_condition" },
+    ok: false,
+  });
+});
+
+test("rejects an oversized decisions document as pack.unreadable", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-decide-"));
+  try {
+    const oversized = "# " + "a".repeat(300 * 1024) + "\n";
+    await writeFile(join(directory, "decisions.yaml"), oversized);
+    const stdout = new MemoryWriter();
+    const stderr = new MemoryWriter();
+    expect(
+      await run(["decide", directory, "--decision", "state.entry", "--context", "{}"], {
+        stderr,
+        stdout,
+      }),
+    ).toBe(2);
+    expect(JSON.parse(stdout.value)).toMatchObject({
+      command: "decide",
+      error: { code: "pack.unreadable" },
+      ok: false,
+    });
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("rejects a flat condition beyond the binary operator limit", async () => {
+  const condition = Array.from({ length: 1026 }, () => "true").join(" && ");
+  const stdout = new MemoryWriter();
+  const stderr = new MemoryWriter();
+  const boundedYaml = [
+    "- id: state.entry",
+    "  question: Bound?",
+    "  branches:",
+    "    - when: '" + condition + "'",
+    "      recommend: []",
+    "      reason: Bound",
+    "",
+  ].join("\n");
+
+  await withPackDirectory(boundedYaml, async (directory) => {
+    expect(
+      await run(["decide", directory, "--decision", "state.entry", "--context", "{}"], {
+        stderr,
+        stdout,
+      }),
+    ).toBe(2);
+  });
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "decide",
+    error: { code: "decide.invalid_condition" },
+    ok: false,
+  });
+});

--- a/packages/cli/src/decide/command.ts
+++ b/packages/cli/src/decide/command.ts
@@ -2,9 +2,8 @@
  * `lore decide` command: owns argument parsing and pack loading only;
  * evaluation is the pure engine call (ADR 0008 §1).
  */
-import { evaluateDecisions } from "@lorelum/engine";
+import { decisionResultSchema, evaluateDecisions } from "@lorelum/engine";
 
-import type { JsonSchema } from "../output/protocol.js";
 import type { CommandDefinition, CommandOption } from "../registry.js";
 import { cliErrorCodes, frameworkErrorCodes, invalidInvocationError } from "../runtime/errors.js";
 import { readDecisionsDocument } from "./load.js";
@@ -24,58 +23,6 @@ const decideOptions: readonly CommandOption[] = [
     optionRequired: true,
   },
 ];
-
-/** Trace entry schema, mirroring the engine DecisionTraceEntry shape. */
-const decisionTraceSchema: JsonSchema = {
-  type: "object",
-  additionalProperties: false,
-  required: ["decisionId", "question", "matchedWhen", "nextDecision"],
-  properties: {
-    decisionId: { type: "string" },
-    question: { type: "string" },
-    matchedWhen: { oneOf: [{ type: "string" }, { const: null }] },
-    nextDecision: { oneOf: [{ type: "string" }, { const: null }] },
-  },
-};
-/** Recommendation schema, mirroring the engine DecisionRecommendation shape. */
-const decisionRecommendationSchema: JsonSchema = {
-  type: "object",
-  additionalProperties: false,
-  required: ["practiceId", "reasons"],
-  properties: {
-    practiceId: { type: "string" },
-    reasons: { type: "array", items: { type: "string" } },
-  },
-};
-// Mirrors the engine DecideResult contract (ADR 0008 §6): no_match adds
-// noMatchReason; trace entries expose the matched when and next edge.
-const decisionResultSchema: JsonSchema = {
-  oneOf: [
-    {
-      type: "object",
-      additionalProperties: false,
-      required: ["status", "entryDecision", "recommendations", "trace"],
-      properties: {
-        status: { const: "matched" },
-        entryDecision: { type: "string" },
-        recommendations: { type: "array", items: decisionRecommendationSchema },
-        trace: { type: "array", items: decisionTraceSchema },
-      },
-    },
-    {
-      type: "object",
-      additionalProperties: false,
-      required: ["status", "entryDecision", "recommendations", "trace", "noMatchReason"],
-      properties: {
-        status: { const: "no_match" },
-        entryDecision: { type: "string" },
-        recommendations: { type: "array" },
-        trace: { type: "array", items: decisionTraceSchema },
-        noMatchReason: { type: "string" },
-      },
-    },
-  ],
-};
 
 /**
  * Evaluate a local pack's decisions.yaml along one deterministic path. The

--- a/packages/cli/src/decide/command.ts
+++ b/packages/cli/src/decide/command.ts
@@ -1,0 +1,142 @@
+/**
+ * `lore decide` command: owns argument parsing and pack loading only;
+ * evaluation is the pure engine call (ADR 0008 §1).
+ */
+import { evaluateDecisions } from "@lorelum/engine";
+
+import type { JsonSchema } from "../output/protocol.js";
+import type { CommandDefinition, CommandOption } from "../registry.js";
+import { cliErrorCodes, frameworkErrorCodes, invalidInvocationError } from "../runtime/errors.js";
+import { readDecisionsDocument } from "./load.js";
+
+/** Required options for one decide invocation: entry decision id and structured context JSON. */
+const decideOptions: readonly CommandOption[] = [
+  {
+    longFlag: "--decision",
+    description: "Decision node id at which evaluation starts.",
+    value: { name: "id", required: true },
+    optionRequired: true,
+  },
+  {
+    longFlag: "--context",
+    description: "Structured JSON object used to evaluate conditions.",
+    value: { name: "json", required: true },
+    optionRequired: true,
+  },
+];
+
+/** Trace entry schema, mirroring the engine DecisionTraceEntry shape. */
+const decisionTraceSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["decisionId", "question", "matchedWhen", "nextDecision"],
+  properties: {
+    decisionId: { type: "string" },
+    question: { type: "string" },
+    matchedWhen: { oneOf: [{ type: "string" }, { const: null }] },
+    nextDecision: { oneOf: [{ type: "string" }, { const: null }] },
+  },
+};
+/** Recommendation schema, mirroring the engine DecisionRecommendation shape. */
+const decisionRecommendationSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["practiceId", "reasons"],
+  properties: {
+    practiceId: { type: "string" },
+    reasons: { type: "array", items: { type: "string" } },
+  },
+};
+// Mirrors the engine DecideResult contract (ADR 0008 §6): no_match adds
+// noMatchReason; trace entries expose the matched when and next edge.
+const decisionResultSchema: JsonSchema = {
+  oneOf: [
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["status", "entryDecision", "recommendations", "trace"],
+      properties: {
+        status: { const: "matched" },
+        entryDecision: { type: "string" },
+        recommendations: { type: "array", items: decisionRecommendationSchema },
+        trace: { type: "array", items: decisionTraceSchema },
+      },
+    },
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["status", "entryDecision", "recommendations", "trace", "noMatchReason"],
+      properties: {
+        status: { const: "no_match" },
+        entryDecision: { type: "string" },
+        recommendations: { type: "array" },
+        trace: { type: "array", items: decisionTraceSchema },
+        noMatchReason: { type: "string" },
+      },
+    },
+  ],
+};
+
+/**
+ * Evaluate a local pack's decisions.yaml along one deterministic path. The
+ * engine evaluator is pure; this handler owns only argument parsing and pack
+ * loading (ADR 0008).
+ */
+export const decideCommand: CommandDefinition = {
+  name: "decide",
+  summary: "Evaluate a local knowledge pack decision tree for a structured context.",
+  positionals: [{ name: "pack-path", required: true }],
+  options: decideOptions,
+  resultSchema: decisionResultSchema,
+  errorCodes: [
+    ...frameworkErrorCodes,
+    cliErrorCodes.packPathInvalid,
+    cliErrorCodes.packUnreadable,
+    cliErrorCodes.packParseError,
+    cliErrorCodes.decideUnknownDecision,
+    cliErrorCodes.decideInvalidCondition,
+    cliErrorCodes.decideDuplicateDecision,
+    cliErrorCodes.decideCycle,
+  ],
+  exitCodes: [0, 2],
+  handler: async (invocation) => {
+    // The handler owns only argument parsing and pack loading; evaluation is
+    // the pure engine call below (ADR 0008 §1).
+    const entryDecision = requiredStringOption(invocation.options, "decision");
+    const context = parseDecisionContext(requiredStringOption(invocation.options, "context"));
+    const packPath = invocation.positionals[0];
+    // `pack-path` is a Commander-required positional; the guard keeps TS
+    // narrowing under noUncheckedIndexedAccess and defends the invocation
+    // contract against a framework regression.
+    if (packPath === undefined) throw invalidInvocationError();
+    const decisions = await readDecisionsDocument(packPath);
+    return { data: evaluateDecisions({ context, decisions, entryDecision }) };
+  },
+};
+
+/** Read a required string option; a missing or empty value is a usage error. */
+function requiredStringOption(options: Readonly<Record<string, unknown>>, name: string): string {
+  const value = options[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw invalidInvocationError();
+  }
+  return value;
+}
+
+/**
+ * Parse the JSON object passed via --context. Only a JSON object is valid:
+ * dotted when-paths resolve fields off it, so arrays, scalars, and null are
+ * usage errors instead of silently evaluating to no_match.
+ */
+function parseDecisionContext(source: string): Readonly<Record<string, unknown>> {
+  let value: unknown;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    throw invalidInvocationError();
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw invalidInvocationError();
+  }
+  return value as Readonly<Record<string, unknown>>;
+}

--- a/packages/cli/src/decide/command.ts
+++ b/packages/cli/src/decide/command.ts
@@ -2,10 +2,15 @@
  * `lore decide` command: owns argument parsing and pack loading only;
  * evaluation is the pure engine call (ADR 0008 §1).
  */
-import { decisionResultSchema, evaluateDecisions } from "@lorelum/engine";
+import { DecisionEvaluationError, decisionResultSchema, evaluateDecisions } from "@lorelum/engine";
 
 import type { CommandDefinition, CommandOption } from "../registry.js";
-import { cliErrorCodes, frameworkErrorCodes, invalidInvocationError } from "../runtime/errors.js";
+import {
+  CliError,
+  cliErrorCodes,
+  frameworkErrorCodes,
+  invalidInvocationError,
+} from "../runtime/errors.js";
 import { readDecisionsDocument } from "./load.js";
 
 /** Required options for one decide invocation: entry decision id and structured context JSON. */
@@ -57,7 +62,17 @@ export const decideCommand: CommandDefinition = {
     // contract against a framework regression.
     if (packPath === undefined) throw invalidInvocationError();
     const decisions = await readDecisionsDocument(packPath);
-    return { data: evaluateDecisions({ context, decisions, entryDecision }) };
+    try {
+      return { data: evaluateDecisions({ context, decisions, entryDecision }) };
+    } catch (error) {
+      // The decide command owns its domain errors: engine evaluation failures
+      // become CliError here, keeping the framework mapper free of engine
+      // error classes (ADR 0004).
+      if (error instanceof DecisionEvaluationError) {
+        throw new CliError(error.code, error.message);
+      }
+      throw error;
+    }
   },
 };
 

--- a/packages/cli/src/decide/fixtures.ts
+++ b/packages/cli/src/decide/fixtures.ts
@@ -1,0 +1,10 @@
+/** Minimal decisions.yaml fixture: one Decision Node with a heavy-client branch. */
+export const clientVsServerYaml = [
+  "- id: state.client-vs-server",
+  "  question: How much client state?",
+  "  branches:",
+  "    - when: 'state.client == \"heavy\"'",
+  "      recommend: [react.state.redux]",
+  "      reason: Redux scales",
+  "",
+].join("\n");

--- a/packages/cli/src/decide/load.ts
+++ b/packages/cli/src/decide/load.ts
@@ -6,7 +6,12 @@
 import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 
-import { parseDecisionDocument, parseYaml, type DecisionNode } from "@lorelum/format";
+import {
+  DecisionDocumentError,
+  parseDecisionDocument,
+  parseYaml,
+  type DecisionNode,
+} from "@lorelum/format";
 
 import { CliError, cliErrorCodes } from "../runtime/errors.js";
 
@@ -22,17 +27,24 @@ const maxDecisionsBytes = 256 * 1024;
  * path must be a readable directory; a missing document, an oversized
  * document, or unparseable YAML is a pack error, not a runtime failure.
  *
- * Every failure here is thrown as a CliError with a pack code; the format
- * layer's DecisionDocumentError is deliberately left for the central
- * toCliError so its code and message stay single-sourced (runtime/errors.ts).
+ * Every failure here is thrown as a CliError with a pack code, including the
+ * format layer's DecisionDocumentError, so the framework error mapper never
+ * needs to know format error classes.
  */
 export async function readDecisionsDocument(packPath: string): Promise<DecisionNode[]> {
   await requireReadableDirectory(packPath);
   const content = await readDecisionsFile(join(packPath, "decisions.yaml"));
   // An empty YAML document is an empty decision list, matching the fork
-  // reference behavior (ADR 0008 §decisions). DecisionDocumentError is mapped
-  // to pack.parse_error by the central toCliError (runtime/errors.ts).
-  return parseDecisionDocument(parsePackYaml(content));
+  // reference behavior (ADR 0008 §decisions). A non-list document is mapped
+  // to pack.parse_error here, at the CLI boundary (ADR 0008 §7).
+  try {
+    return parseDecisionDocument(parsePackYaml(content));
+  } catch (error) {
+    if (error instanceof DecisionDocumentError) {
+      throw new CliError(cliErrorCodes.packParseError, error.message);
+    }
+    throw error;
+  }
 }
 
 /** Require <pack-path> to be a readable directory; otherwise pack.path_invalid. */
@@ -55,11 +67,18 @@ async function readDecisionsFile(decisionsPath: string): Promise<string> {
     throw packUnreadable();
   }
   if (metadata.size > maxDecisionsBytes) throw packUnreadable();
+  let content: string;
   try {
-    return await readFile(decisionsPath, "utf8");
+    content = await readFile(decisionsPath, "utf8");
   } catch {
     throw packUnreadable();
   }
+  // Re-check the byte length after reading: a file replaced between stat and
+  // read can bypass the pre-read cap, and string length counts UTF-16 code
+  // units rather than bytes. Keep the enforced cap on the actual content
+  // (ADR 0008 §7).
+  if (Buffer.byteLength(content, "utf8") > maxDecisionsBytes) throw packUnreadable();
+  return content;
 }
 
 /** Parse guarded YAML; malformed input is a pack parse error. */
@@ -67,8 +86,13 @@ function parsePackYaml(content: string): unknown {
   try {
     return parseYaml(content);
   } catch {
-    throw new CliError(cliErrorCodes.packParseError, "The decisions document could not be parsed.");
+    throw packParseError();
   }
+}
+
+/** The decisions document could not be parsed or is not a list of decision nodes. */
+function packParseError(message = "The decisions document could not be parsed."): CliError {
+  return new CliError(cliErrorCodes.packParseError, message);
 }
 
 /** The pack path is not a readable directory. */

--- a/packages/cli/src/decide/load.ts
+++ b/packages/cli/src/decide/load.ts
@@ -1,0 +1,82 @@
+/**
+ * Pack input loading for `lore decide`: validates the pack directory, enforces
+ * the 256KiB decisions.yaml cap, and parses through @lorelum/format with
+ * failures mapped to pack.* codes (ADR 0008 §7).
+ */
+import { readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { parseDecisionDocument, parseYaml, type DecisionNode } from "@lorelum/format";
+
+import { CliError, cliErrorCodes } from "../runtime/errors.js";
+
+/**
+ * Max bytes for the decisions document. Matches the fork reference
+ * implementation's v1PackInputLimits.maxDecisionBytes so oversized pack input
+ * is rejected before the guarded YAML parser runs (ADR 0008 §decisions).
+ */
+const maxDecisionsBytes = 256 * 1024;
+
+/**
+ * Read and parse <pack-path>/decisions.yaml for the decide command. The pack
+ * path must be a readable directory; a missing document, an oversized
+ * document, or unparseable YAML is a pack error, not a runtime failure.
+ *
+ * Every failure here is thrown as a CliError with a pack code; the format
+ * layer's DecisionDocumentError is deliberately left for the central
+ * toCliError so its code and message stay single-sourced (runtime/errors.ts).
+ */
+export async function readDecisionsDocument(packPath: string): Promise<DecisionNode[]> {
+  await requireReadableDirectory(packPath);
+  const content = await readDecisionsFile(join(packPath, "decisions.yaml"));
+  // An empty YAML document is an empty decision list, matching the fork
+  // reference behavior (ADR 0008 §decisions). DecisionDocumentError is mapped
+  // to pack.parse_error by the central toCliError (runtime/errors.ts).
+  return parseDecisionDocument(parsePackYaml(content));
+}
+
+/** Require <pack-path> to be a readable directory; otherwise pack.path_invalid. */
+async function requireReadableDirectory(packPath: string): Promise<void> {
+  let metadata;
+  try {
+    metadata = await stat(packPath);
+  } catch {
+    throw packPathInvalid();
+  }
+  if (!metadata.isDirectory()) throw packPathInvalid();
+}
+
+/** Read decisions.yaml with a pre-read byte cap; missing or oversized is pack.unreadable. */
+async function readDecisionsFile(decisionsPath: string): Promise<string> {
+  let metadata;
+  try {
+    metadata = await stat(decisionsPath);
+  } catch {
+    throw packUnreadable();
+  }
+  if (metadata.size > maxDecisionsBytes) throw packUnreadable();
+  try {
+    return await readFile(decisionsPath, "utf8");
+  } catch {
+    throw packUnreadable();
+  }
+}
+
+/** Parse guarded YAML; malformed input is a pack parse error. */
+function parsePackYaml(content: string): unknown {
+  try {
+    return parseYaml(content);
+  } catch {
+    throw new CliError(cliErrorCodes.packParseError, "The decisions document could not be parsed.");
+  }
+}
+
+/** The pack path is not a readable directory. */
+function packPathInvalid(): CliError {
+  return new CliError(cliErrorCodes.packPathInvalid, "The pack path must be a readable directory.");
+}
+
+/** The decisions document is missing, unreadable, or oversized. */
+function packUnreadable(): CliError {
+  return new CliError(cliErrorCodes.packUnreadable, "The decisions document could not be read.");
+}

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -29,7 +29,7 @@ test("returns machine-readable root capability discovery", async () => {
     ok: true,
     data: {
       name: "lore",
-      commands: [{ name: "describe" }],
+      commands: [{ name: "describe" }, { name: "decide" }],
     },
   });
   expect(stderr.value).toBe("");

--- a/packages/cli/src/output/protocol.ts
+++ b/packages/cli/src/output/protocol.ts
@@ -1,20 +1,13 @@
 import packageManifest from "../../package.json";
 
+import type { JsonSchema } from "@lorelum/shared";
+
 /** Version of the process-envelope contract. */
 export const protocolVersion = 1;
 /** Version of the CLI implementation emitting the envelope. */
 export const toolVersion = packageManifest.version;
 
-export type JsonSchema = {
-  oneOf?: readonly JsonSchema[];
-  type?: "array" | "boolean" | "integer" | "object" | "string";
-  const?: unknown;
-  enum?: readonly unknown[];
-  additionalProperties?: boolean;
-  required?: readonly string[];
-  properties?: Readonly<Record<string, JsonSchema>>;
-  items?: JsonSchema;
-};
+export type { JsonSchema };
 
 export type JsonValue =
   | null

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -206,7 +206,11 @@ test("describes registered commands from a single registry", () => {
     commands: [
       {
         name: "describe",
-        positionals: [{ name: "command", values: ["describe"] }],
+        positionals: [{ name: "command", values: ["describe", "decide"] }],
+      },
+      {
+        name: "decide",
+        positionals: [{ name: "pack-path", required: true }],
       },
     ],
   });
@@ -238,7 +242,7 @@ test("derives parser options and describe metadata from registered commands", as
     ],
   });
   expect(describeCommand("describe", definitions)).toMatchObject({
-    positionals: [{ name: "command", values: ["describe", "future"] }],
+    positionals: [{ name: "command", values: ["describe", "decide", "future"] }],
   });
 
   const stdout = new MemoryWriter();

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -4,6 +4,7 @@ import {
   type JsonSchema,
   type JsonValue,
 } from "./output/protocol.js";
+import { decideCommand } from "./decide/command.js";
 import { frameworkErrorCodes, invalidInvocationError } from "./runtime/errors.js";
 import { logLevels } from "./runtime/logger.js";
 
@@ -202,6 +203,7 @@ const builtInCommandDefinitions = [
       data: requireCommandDescription(invocation.describeCommand, invocation.positionals[0]),
     }),
   },
+  decideCommand,
 ] satisfies readonly CommandDefinition[];
 
 /** Root parser metadata is separate because it is not an invokable child command. */

--- a/packages/cli/src/runtime/errors.ts
+++ b/packages/cli/src/runtime/errors.ts
@@ -1,13 +1,34 @@
+import { DecisionEvaluationError, decisionErrorCodes } from "@lorelum/engine";
+import { DecisionDocumentError } from "@lorelum/format";
+
+/**
+ * CLI error model (ADR 0004): every command failure is one JSON envelope with
+ * a stable dotted `code`. Command code throws `CliError` directly; domain
+ * errors from engine/format are mapped here once. `toVisibleCliError` masks
+ * any code outside the selected command's declared `errorCodes` allowlist as
+ * `runtime.unexpected`, so command authors opt in to what agents may rely on.
+ * Decide codes are sourced from `@lorelum/engine` to keep the strings in one
+ * place.
+ */
 export const cliErrorCodes = Object.freeze({
   runtimeUnexpected: "runtime.unexpected",
   usageInvalid: "usage.invalid",
+  packPathInvalid: "pack.path_invalid",
+  packUnreadable: "pack.unreadable",
+  packParseError: "pack.parse_error",
+  decideUnknownDecision: decisionErrorCodes.unknownDecision,
+  decideInvalidCondition: decisionErrorCodes.invalidCondition,
+  decideDuplicateDecision: decisionErrorCodes.duplicateDecision,
+  decideCycle: decisionErrorCodes.cycle,
 });
 
+/** Error codes every command must declare; used as the framework masking baseline. */
 export const frameworkErrorCodes = Object.freeze([
   cliErrorCodes.usageInvalid,
   cliErrorCodes.runtimeUnexpected,
 ]);
 
+/** Typed CLI failure carrying a stable dotted protocol code and exit code 2. */
 export class CliError extends Error {
   readonly exitCode = 2 as const;
 
@@ -20,6 +41,7 @@ export class CliError extends Error {
   }
 }
 
+/** Standard usage error for an invalid command invocation. */
 export function invalidInvocationError(): CliError {
   return new CliError(cliErrorCodes.usageInvalid, "The command invocation is invalid.");
 }
@@ -30,9 +52,18 @@ export function toVisibleCliError(error: unknown, visibleErrorCodes: readonly st
   return visibleErrorCodes.includes(cliError.code) ? cliError : unexpectedRuntimeError();
 }
 
+/** Translate any thrown value into a CliError; domain errors are mapped here once. */
 function toCliError(error: unknown): CliError {
   if (error instanceof CliError) {
     return error;
+  }
+
+  if (error instanceof DecisionEvaluationError) {
+    return new CliError(error.code, error.message);
+  }
+
+  if (error instanceof DecisionDocumentError) {
+    return new CliError(cliErrorCodes.packParseError, error.message);
   }
 
   if (isCommanderError(error)) {
@@ -42,10 +73,12 @@ function toCliError(error: unknown): CliError {
   return unexpectedRuntimeError();
 }
 
+/** Fallback error masking anything the selected command did not declare. */
 function unexpectedRuntimeError(): CliError {
   return new CliError(cliErrorCodes.runtimeUnexpected, "The command could not be completed.");
 }
 
+/** Commander parse failures are invocation errors, not domain failures. */
 function isCommanderError(error: unknown): error is { code: string } {
   return (
     typeof error === "object" &&

--- a/packages/cli/src/runtime/errors.ts
+++ b/packages/cli/src/runtime/errors.ts
@@ -1,11 +1,11 @@
-import { DecisionEvaluationError, decisionErrorCodes } from "@lorelum/engine";
-import { DecisionDocumentError } from "@lorelum/format";
+import { decisionErrorCodes } from "@lorelum/engine";
 
 /**
  * CLI error model (ADR 0004): every command failure is one JSON envelope with
- * a stable dotted `code`. Command code throws `CliError` directly; domain
- * errors from engine/format are mapped here once. `toVisibleCliError` masks
- * any code outside the selected command's declared `errorCodes` allowlist as
+ * a stable dotted `code`. Commands throw `CliError` directly; domain errors
+ * from engine/format are mapped to `CliError` by the owning command, so the
+ * framework stays free of domain error classes. `toVisibleCliError` masks any
+ * code outside the selected command's declared `errorCodes` allowlist as
  * `runtime.unexpected`, so command authors opt in to what agents may rely on.
  * Decide codes are sourced from `@lorelum/engine` to keep the strings in one
  * place.
@@ -52,18 +52,10 @@ export function toVisibleCliError(error: unknown, visibleErrorCodes: readonly st
   return visibleErrorCodes.includes(cliError.code) ? cliError : unexpectedRuntimeError();
 }
 
-/** Translate any thrown value into a CliError; domain errors are mapped here once. */
+/** Translate any thrown value into a CliError; domain errors arrive already mapped by their command. */
 function toCliError(error: unknown): CliError {
   if (error instanceof CliError) {
     return error;
-  }
-
-  if (error instanceof DecisionEvaluationError) {
-    return new CliError(error.code, error.message);
-  }
-
-  if (error instanceof DecisionDocumentError) {
-    return new CliError(cliErrorCodes.packParseError, error.message);
   }
 
   if (isCommanderError(error)) {

--- a/packages/engine/src/decide/evaluate.test.ts
+++ b/packages/engine/src/decide/evaluate.test.ts
@@ -1,0 +1,256 @@
+import { expect, test } from "bun:test";
+
+import { evaluateDecisions } from "./evaluate.js";
+
+test("uses the first matching branch in declaration order", () => {
+  const result = evaluateDecisions({
+    context: { state: { client: "heavy" } },
+    decisions: [
+      {
+        branches: [
+          {
+            reason: "The specific branch wins",
+            recommend: ["test.specific"],
+            when: 'state.client == "heavy"',
+          },
+          {
+            reason: "This is never reached",
+            recommend: ["test.fallback"],
+            when: 'state.client == "heavy"',
+          },
+        ],
+        id: "test.entry",
+        question: "Which recommendation applies?",
+      },
+    ],
+    entryDecision: "test.entry",
+  });
+
+  expect(result).toEqual({
+    entryDecision: "test.entry",
+    recommendations: [{ practiceId: "test.specific", reasons: ["The specific branch wins"] }],
+    status: "matched",
+    trace: [
+      {
+        decisionId: "test.entry",
+        matchedWhen: 'state.client == "heavy"',
+        nextDecision: null,
+        question: "Which recommendation applies?",
+      },
+    ],
+  });
+});
+
+test("accumulates chain recommendations while preserving first occurrence order and reasons", () => {
+  const result = evaluateDecisions({
+    context: { state: { client: "heavy", persistence: true } },
+    decisions: [
+      {
+        branches: [
+          {
+            next: "test.persistence",
+            reason: "Complex client state needs a predictable store",
+            recommend: ["test.store"],
+            when: 'state.client == "heavy"',
+          },
+        ],
+        id: "test.entry",
+        question: "How much client state?",
+      },
+      {
+        branches: [
+          {
+            reason: "Persisted state needs a recovery policy",
+            recommend: ["test.store", "test.persistence"],
+            when: "state.persistence == true",
+          },
+        ],
+        id: "test.persistence",
+        question: "Does state persist?",
+      },
+    ],
+    entryDecision: "test.entry",
+  });
+
+  expect(result).toEqual({
+    entryDecision: "test.entry",
+    recommendations: [
+      {
+        practiceId: "test.store",
+        reasons: [
+          "Complex client state needs a predictable store",
+          "Persisted state needs a recovery policy",
+        ],
+      },
+      { practiceId: "test.persistence", reasons: ["Persisted state needs a recovery policy"] },
+    ],
+    status: "matched",
+    trace: [
+      {
+        decisionId: "test.entry",
+        matchedWhen: 'state.client == "heavy"',
+        nextDecision: "test.persistence",
+        question: "How much client state?",
+      },
+      {
+        decisionId: "test.persistence",
+        matchedWhen: "state.persistence == true",
+        nextDecision: null,
+        question: "Does state persist?",
+      },
+    ],
+  });
+});
+
+test("returns no_match with the final decision trace for an unmatched or missing context", () => {
+  const input = {
+    decisions: [
+      {
+        branches: [
+          { reason: "Heavy state", recommend: ["test.store"], when: 'state.client == "heavy"' },
+        ],
+        id: "test.entry",
+        question: "How much client state?",
+      },
+    ],
+    entryDecision: "test.entry",
+  };
+
+  expect(evaluateDecisions({ ...input, context: { state: { client: "light" } } })).toMatchObject({
+    noMatchReason: "no branch matched the provided context",
+    recommendations: [],
+    status: "no_match",
+    trace: [expect.objectContaining({ matchedWhen: null, nextDecision: null })],
+  });
+  expect(evaluateDecisions({ ...input, context: {} }).status).toBe("no_match");
+});
+
+test("returns no_match when the pack has no decisions", () => {
+  expect(evaluateDecisions({ context: {}, decisions: [], entryDecision: "test.entry" })).toEqual({
+    entryDecision: "test.entry",
+    noMatchReason: "pack has no decisions",
+    recommendations: [],
+    status: "no_match",
+    trace: [],
+  });
+});
+
+test("deduplicates repeated recommendations within one branch", () => {
+  const result = evaluateDecisions({
+    context: { enabled: true },
+    decisions: [
+      {
+        branches: [
+          {
+            reason: "One reason",
+            recommend: ["test.store", "test.store"],
+            when: "enabled",
+          },
+        ],
+        id: "test.entry",
+        question: "What now?",
+      },
+    ],
+    entryDecision: "test.entry",
+  });
+
+  expect(result).toMatchObject({
+    recommendations: [{ practiceId: "test.store", reasons: ["One reason"] }],
+    status: "matched",
+  });
+});
+
+test("returns typed errors for an unknown entry, malformed condition, and a runtime cycle", () => {
+  expect(() =>
+    evaluateDecisions({
+      context: {},
+      decisions: [{ branches: [], id: "test.other", question: "What now?" }],
+      entryDecision: "test.entry",
+    }),
+  ).toThrow(expect.objectContaining({ code: "decide.unknown_decision" }));
+  expect(() =>
+    evaluateDecisions({
+      context: {},
+      decisions: [
+        {
+          branches: [{ reason: "Invalid", recommend: [], when: "state.client = heavy" }],
+          id: "test.entry",
+          question: "What now?",
+        },
+      ],
+      entryDecision: "test.entry",
+    }),
+  ).toThrow(expect.objectContaining({ code: "decide.invalid_condition" }));
+  expect(() =>
+    evaluateDecisions({
+      context: { enabled: true },
+      decisions: [
+        {
+          branches: [{ next: "test.loop", reason: "Loop", recommend: [], when: "enabled" }],
+          id: "test.entry",
+          question: "Start?",
+        },
+        {
+          branches: [{ next: "test.entry", reason: "Loop", recommend: [], when: "enabled" }],
+          id: "test.loop",
+          question: "Continue?",
+        },
+      ],
+      entryDecision: "test.entry",
+    }),
+  ).toThrow(expect.objectContaining({ code: "decide.cycle" }));
+});
+
+test("rejects an invalid condition in a later branch even when an earlier branch matches", () => {
+  expect(() =>
+    evaluateDecisions({
+      context: { enabled: true },
+      decisions: [
+        {
+          branches: [
+            { reason: "First branch matches", recommend: [], when: "enabled" },
+            { reason: "Invalid syntax", recommend: [], when: "state.client = heavy" },
+          ],
+          id: "test.entry",
+          question: "What now?",
+        },
+      ],
+      entryDecision: "test.entry",
+    }),
+  ).toThrow(expect.objectContaining({ code: "decide.invalid_condition" }));
+});
+
+test("rejects duplicate decision ids before evaluation", () => {
+  expect(() =>
+    evaluateDecisions({
+      context: {},
+      decisions: [
+        { branches: [], id: "test.entry", question: "What now?" },
+        { branches: [], id: "test.entry", question: "Ambiguous duplicate?" },
+      ],
+      entryDecision: "test.entry",
+    }),
+  ).toThrow(expect.objectContaining({ code: "decide.duplicate_decision" }));
+});
+
+test("maps an over-deep condition to a typed invalid-condition error", () => {
+  expect(() =>
+    evaluateDecisions({
+      context: {},
+      decisions: [
+        {
+          branches: [
+            {
+              reason: "Too deep",
+              recommend: [],
+              when: "(".repeat(129) + "true" + ")".repeat(129),
+            },
+          ],
+          id: "test.entry",
+          question: "What now?",
+        },
+      ],
+      entryDecision: "test.entry",
+    }),
+  ).toThrow(expect.objectContaining({ code: "decide.invalid_condition" }));
+});

--- a/packages/engine/src/decide/evaluate.ts
+++ b/packages/engine/src/decide/evaluate.ts
@@ -1,0 +1,148 @@
+import type { DecisionBranch, DecisionNode } from "@lorelum/format";
+
+import {
+  ConditionSyntaxError,
+  evaluateParsedCondition,
+  parseCondition,
+  type Expression,
+} from "./when.js";
+import {
+  DecisionEvaluationError,
+  decisionErrorCodes,
+  type DecideResult,
+  type DecisionEvaluationInput,
+  type DecisionRecommendation,
+  type DecisionTraceEntry,
+} from "./types.js";
+
+/**
+ * Pure decision-graph evaluator (ADR 0008). `evaluateDecisions` walks one
+ * deterministic path from the entry node: the first matching branch wins,
+ * `next` chains continue to other Decision Nodes, cycles and unknown ids are
+ * typed errors, and every step is recorded in the returned trace. The module
+ * touches no filesystem or process I/O so the CLI and future MCP adapters
+ * share exactly these semantics.
+ */
+
+/**
+ * Evaluate one decision path in declaration order. The evaluator stays pure,
+ * so the CLI and future MCP adapters share the same decision semantics.
+ */
+export function evaluateDecisions(input: DecisionEvaluationInput): DecideResult {
+  // An empty decision list is a normal no_match (spec §2.2), not an error.
+  if (input.decisions.length === 0) {
+    return {
+      entryDecision: input.entryDecision,
+      noMatchReason: "pack has no decisions",
+      recommendations: [],
+      status: "no_match",
+      trace: [],
+    };
+  }
+
+  const decisionsById = new Map<string, DecisionNode>();
+  // Build the id → node lookup table first; duplicate ids are rejected before evaluation for deterministic paths.
+  for (const decision of input.decisions) {
+    if (decisionsById.has(decision.id)) {
+      throw new DecisionEvaluationError(
+        decisionErrorCodes.duplicateDecision,
+        "The decision graph contains duplicate decision ids.",
+      );
+    }
+    decisionsById.set(decision.id, decision);
+  }
+  // Runtime state for one evaluation path: merged recommendations, audit trace, cycle-safe visited set.
+  const recommendations = new Map<string, DecisionRecommendation>();
+  const trace: DecisionTraceEntry[] = [];
+  const visited = new Set<string>();
+  let currentDecisionId = input.entryDecision;
+
+  while (true) {
+    // Defensive cycle detection: next edges only move forward, never back to a visited node.
+    if (visited.has(currentDecisionId)) {
+      throw new DecisionEvaluationError(
+        decisionErrorCodes.cycle,
+        "The decision path contains a cycle.",
+      );
+    }
+    visited.add(currentDecisionId);
+
+    // A missing node means entryDecision or some next references an unknown id.
+    const decision = decisionsById.get(currentDecisionId);
+    if (decision === undefined) {
+      throw new DecisionEvaluationError(
+        decisionErrorCodes.unknownDecision,
+        "The requested decision could not be found.",
+      );
+    }
+
+    const branch = findMatchingBranch(decision, input.context);
+    trace.push({
+      decisionId: decision.id,
+      matchedWhen: branch?.when ?? null,
+      nextDecision: branch?.next ?? null,
+      question: decision.question,
+    });
+    if (branch === undefined) {
+      return {
+        entryDecision: input.entryDecision,
+        noMatchReason: "no branch matched the provided context",
+        recommendations: [],
+        status: "no_match",
+        trace,
+      };
+    }
+
+    // Deduplicate by Practice id while merging reasons from each matched branch.
+    for (const practiceId of new Set(branch.recommend)) {
+      const existing = recommendations.get(practiceId);
+      if (existing === undefined) {
+        recommendations.set(practiceId, { practiceId, reasons: [branch.reason] });
+      } else {
+        existing.reasons.push(branch.reason);
+      }
+    }
+
+    if (branch.next === undefined) {
+      return {
+        entryDecision: input.entryDecision,
+        recommendations: [...recommendations.values()],
+        status: "matched",
+        trace,
+      };
+    }
+    currentDecisionId = branch.next;
+  }
+}
+
+/**
+ * Return the first branch whose condition is true, in declaration order, or
+ * undefined when none match. All when conditions in a node are parsed before
+ * any is evaluated, so a later syntax error cannot be masked by an earlier
+ * match (ADR 0008).
+ */
+function findMatchingBranch(
+  decision: DecisionNode,
+  context: DecisionEvaluationInput["context"],
+): DecisionBranch | undefined {
+  const parsedBranches: Array<{ branch: DecisionBranch; condition: Expression }> = [];
+  try {
+    for (const branch of decision.branches) {
+      parsedBranches.push({ branch, condition: parseCondition(branch.when) });
+    }
+  } catch (error) {
+    if (error instanceof ConditionSyntaxError) {
+      throw new DecisionEvaluationError(
+        decisionErrorCodes.invalidCondition,
+        "A decision condition is invalid.",
+      );
+    }
+    throw error;
+  }
+
+  // Syntax was validated up front; take the first matching branch in declaration order.
+  for (const { branch, condition } of parsedBranches) {
+    if (evaluateParsedCondition(condition, context)) return branch;
+  }
+  return undefined;
+}

--- a/packages/engine/src/decide/index.ts
+++ b/packages/engine/src/decide/index.ts
@@ -5,6 +5,7 @@
  */
 export { evaluateDecisions } from "./evaluate.js";
 export { ConditionSyntaxError, evaluateCondition } from "./when.js";
+export * from "./schema.js";
 export {
   DecisionEvaluationError,
   decisionErrorCodes,

--- a/packages/engine/src/decide/index.ts
+++ b/packages/engine/src/decide/index.ts
@@ -1,0 +1,17 @@
+/**
+ * lore decide engine: pure, deterministic evaluation of a knowledge pack's
+ * decisions.yaml Decision Nodes. This module touches no filesystem or
+ * process I/O.
+ */
+export { evaluateDecisions } from "./evaluate.js";
+export { ConditionSyntaxError, evaluateCondition } from "./when.js";
+export {
+  DecisionEvaluationError,
+  decisionErrorCodes,
+  type DecideResult,
+  type DecisionContext,
+  type DecisionErrorCode,
+  type DecisionEvaluationInput,
+  type DecisionRecommendation,
+  type DecisionTraceEntry,
+} from "./types.js";

--- a/packages/engine/src/decide/schema.ts
+++ b/packages/engine/src/decide/schema.ts
@@ -1,0 +1,62 @@
+/**
+ * Canonical JSON Schemas for the decide result contract (single source).
+ * The CLI `describe` metadata and future MCP adapters reference these instead
+ * of re-declaring the engine contract (ADR 0008 §6).
+ */
+
+import type { JsonSchema } from "@lorelum/shared";
+
+const stringSchema: JsonSchema = { type: "string" };
+
+/** Trace entry schema; mirrors the DecisionTraceEntry shape. */
+export const decisionTraceSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["decisionId", "question", "matchedWhen", "nextDecision"],
+  properties: {
+    decisionId: stringSchema,
+    question: stringSchema,
+    matchedWhen: { oneOf: [stringSchema, { const: null }] },
+    nextDecision: { oneOf: [stringSchema, { const: null }] },
+  },
+};
+
+/** Recommendation schema; mirrors the DecisionRecommendation shape. */
+export const decisionRecommendationSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["practiceId", "reasons"],
+  properties: {
+    practiceId: stringSchema,
+    reasons: { type: "array", items: stringSchema },
+  },
+};
+
+/** Result envelope: matched or no_match (no_match adds noMatchReason). */
+export const decisionResultSchema: JsonSchema = {
+  oneOf: [
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["status", "entryDecision", "recommendations", "trace"],
+      properties: {
+        status: { const: "matched" },
+        entryDecision: stringSchema,
+        recommendations: { type: "array", items: decisionRecommendationSchema },
+        trace: { type: "array", items: decisionTraceSchema },
+      },
+    },
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["status", "entryDecision", "recommendations", "trace", "noMatchReason"],
+      properties: {
+        status: { const: "no_match" },
+        entryDecision: stringSchema,
+        recommendations: { type: "array" },
+        trace: { type: "array", items: decisionTraceSchema },
+        noMatchReason: stringSchema,
+      },
+    },
+  ],
+};

--- a/packages/engine/src/decide/schema.ts
+++ b/packages/engine/src/decide/schema.ts
@@ -32,6 +32,18 @@ export const decisionRecommendationSchema: JsonSchema = {
   },
 };
 
+/** Recommendations list shared by both result branches (always empty under no_match). */
+const decisionRecommendationsSchema: JsonSchema = {
+  type: "array",
+  items: decisionRecommendationSchema,
+};
+
+/** Ordered trace list shared by both result branches. */
+const decisionTraceListSchema: JsonSchema = {
+  type: "array",
+  items: decisionTraceSchema,
+};
+
 /** Result envelope: matched or no_match (no_match adds noMatchReason). */
 export const decisionResultSchema: JsonSchema = {
   oneOf: [
@@ -42,8 +54,8 @@ export const decisionResultSchema: JsonSchema = {
       properties: {
         status: { const: "matched" },
         entryDecision: stringSchema,
-        recommendations: { type: "array", items: decisionRecommendationSchema },
-        trace: { type: "array", items: decisionTraceSchema },
+        recommendations: decisionRecommendationsSchema,
+        trace: decisionTraceListSchema,
       },
     },
     {
@@ -53,8 +65,8 @@ export const decisionResultSchema: JsonSchema = {
       properties: {
         status: { const: "no_match" },
         entryDecision: stringSchema,
-        recommendations: { type: "array" },
-        trace: { type: "array", items: decisionTraceSchema },
+        recommendations: decisionRecommendationsSchema,
+        trace: decisionTraceListSchema,
         noMatchReason: stringSchema,
       },
     },

--- a/packages/engine/src/decide/types.ts
+++ b/packages/engine/src/decide/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Decide evaluation contract: context shape, result envelopes, audit trace
+ * entries, and the stable error codes shared by engine, CLI, and protocol
+ * (ADR 0008).
+ */
+import type { DecisionNode } from "@lorelum/format";
+
+/** Structured project context passed to the evaluator; dotted-path condition fields resolve from here. */
+export type DecisionContext = Readonly<Record<string, unknown>>;
+
+/** Aggregated result for one recommended Practice: the matched id plus all matched reasons. */
+export type DecisionRecommendation = {
+  /** Practice id referenced by the matched branch. */
+  practiceId: string;
+  /** Reasons given by each matched branch that recommends this Practice; merged across branches. */
+  reasons: string[];
+};
+
+/** A single Decision Node visited along the evaluation path, for an auditable trace. */
+export type DecisionTraceEntry = {
+  /** id of the evaluated Decision Node. */
+  decisionId: string;
+  /** The node's question text. */
+  question: string;
+  /** The matched branch's when expression; null when no branch matched. */
+  matchedWhen: string | null;
+  /** Next Decision Node id chained by the matched branch; null at the end of the path. */
+  nextDecision: string | null;
+};
+
+/** Successful result: at least one branch matched (recommendations may be empty; spec §2.2: not an error). */
+export type MatchedDecisionResult = {
+  /** Stable status marker distinguishing matched / no_match. */
+  status: "matched";
+  /** Entry Decision Node id passed by the caller. */
+  entryDecision: string;
+  /** Deduplicated, merged recommendation list along the path. */
+  recommendations: DecisionRecommendation[];
+  /** Full evaluation trace for audit and debugging. */
+  trace: DecisionTraceEntry[];
+};
+
+/** Normal (non-error) termination: no branch matched the given context. */
+export type NoMatchDecisionResult = {
+  /** Stable status marker distinguishing matched / no_match. */
+  status: "no_match";
+  /** Entry Decision Node id passed by the caller. */
+  entryDecision: string;
+  /** Always empty under no_match. */
+  recommendations: [];
+  /** Evaluation trace up to the first unmatched node. */
+  trace: DecisionTraceEntry[];
+  /** Human-readable reason for no match, surfaced by the CLI. */
+  noMatchReason: string;
+};
+
+/** Stable external result contract shared by the CLI and future MCP adapters. */
+export type DecideResult = MatchedDecisionResult | NoMatchDecisionResult;
+
+/** Input for a pure evaluation; no filesystem or process I/O, reusable by CLI and MCP. */
+export interface DecisionEvaluationInput {
+  /** Context snapshot used to evaluate when conditions. */
+  context: DecisionContext;
+  /** Decision Nodes to evaluate, usually from decisions.yaml. */
+  decisions: readonly DecisionNode[];
+  /** Decision Node id where evaluation starts. */
+  entryDecision: string;
+}
+
+/**
+ * Single source of truth for decide evaluation error codes (ADR 0008 §6).
+ * The evaluator's typed failures, the CLI allowlist, and the protocol output
+ * all reference these dotted strings so they cannot drift apart.
+ */
+export const decisionErrorCodes = Object.freeze({
+  cycle: "decide.cycle",
+  duplicateDecision: "decide.duplicate_decision",
+  invalidCondition: "decide.invalid_condition",
+  unknownDecision: "decide.unknown_decision",
+} as const);
+
+export type DecisionErrorCode = (typeof decisionErrorCodes)[keyof typeof decisionErrorCodes];
+
+/** Typed evaluation failure; code is a stable protocol value mapped to CLI errorCodes. */
+export class DecisionEvaluationError extends Error {
+  constructor(
+    readonly code: DecisionErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DecisionEvaluationError";
+  }
+}

--- a/packages/engine/src/decide/when.test.ts
+++ b/packages/engine/src/decide/when.test.ts
@@ -30,6 +30,18 @@ test("treats missing paths and incompatible comparisons as false", () => {
   expect(evaluateCondition("state.client == 1", context)).toBe(false);
 });
 
+// Anchors the ADR 0008 §3 missing-value rules: a determined logical side wins,
+// and comparisons involving a missing operand are false.
+test("resolves missing operands from the determined side of logical operations", () => {
+  expect(evaluateCondition("missing.x || true", {})).toBe(true);
+  expect(evaluateCondition("true || missing.x", {})).toBe(true);
+  expect(evaluateCondition("missing.x || false", {})).toBe(false);
+  expect(evaluateCondition("missing.x && true", {})).toBe(false);
+  expect(evaluateCondition("missing.x && false", {})).toBe(false);
+  expect(evaluateCondition("missing.x != 'x'", {})).toBe(false);
+  expect(evaluateCondition("missing.x == missing.y", {})).toBe(false);
+});
+
 test("rejects syntax outside the v1 condition language", () => {
   expect(() => evaluateCondition('state.client = "heavy"', {})).toThrow(ConditionSyntaxError);
   expect(() => evaluateCondition("state.client()", {})).toThrow(ConditionSyntaxError);

--- a/packages/engine/src/decide/when.test.ts
+++ b/packages/engine/src/decide/when.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+
+import { ConditionSyntaxError, evaluateCondition } from "./when.js";
+
+test("evaluates supported literals, comparison, boolean operators, and parentheses", () => {
+  const context = {
+    featureFlags: { experimental: false },
+    state: { client: "heavy", retries: 3 },
+  };
+
+  expect(
+    evaluateCondition(
+      'state.client == "heavy" && (state.retries != 2 || !featureFlags.experimental)',
+      context,
+    ),
+  ).toBe(true);
+  expect(evaluateCondition("state.retries == 3 && true", context)).toBe(true);
+  expect(evaluateCondition("state.retries == 3.5", context)).toBe(false);
+});
+
+test("uses ordinary numeric equality semantics", () => {
+  expect(evaluateCondition("state.value == 0", { state: { value: -0 } })).toBe(true);
+});
+
+test("treats missing paths and incompatible comparisons as false", () => {
+  const context = { state: { client: "heavy" } };
+
+  expect(evaluateCondition('state.server == "heavy"', context)).toBe(false);
+  expect(evaluateCondition("!featureFlags.experimental", context)).toBe(false);
+  expect(evaluateCondition("state.client == 1", context)).toBe(false);
+});
+
+test("rejects syntax outside the v1 condition language", () => {
+  expect(() => evaluateCondition('state.client = "heavy"', {})).toThrow(ConditionSyntaxError);
+  expect(() => evaluateCondition("state.client()", {})).toThrow(ConditionSyntaxError);
+  expect(() => evaluateCondition("(state.client == 'heavy'", {})).toThrow(ConditionSyntaxError);
+});
+
+test("rejects conditions beyond the nesting limit", () => {
+  const source = "(".repeat(129) + "true" + ")".repeat(129);
+  expect(() => evaluateCondition(source, {})).toThrow(ConditionSyntaxError);
+});
+
+test("rejects flat logical chains beyond the binary operator limit", () => {
+  // 1025 operators exceeds the 1024 cap; parsing must reject it as a syntax
+  // error instead of overflowing the call stack during evaluation.
+  const source = Array.from({ length: 1026 }, () => "true").join(" && ");
+  expect(() => evaluateCondition(source, {})).toThrow(ConditionSyntaxError);
+});
+
+test("rejects long || chains beyond the binary operator limit", () => {
+  const source = Array.from({ length: 1026 }, () => "false").join(" || ");
+  expect(() => evaluateCondition(source, {})).toThrow(ConditionSyntaxError);
+});
+
+test("accepts flat logical chains within the binary operator limit", () => {
+  const source = Array.from({ length: 1025 }, () => "true").join(" && ");
+  expect(evaluateCondition(source, {})).toBe(true);
+});

--- a/packages/engine/src/decide/when.ts
+++ b/packages/engine/src/decide/when.ts
@@ -69,8 +69,9 @@ export function parseCondition(source: string): Expression {
 
 /** Evaluate an already-parsed v1 condition; missing fields resolve to false. */
 export function evaluateParsedCondition(expression: Expression, context: DecisionContext): boolean {
-  const result = evaluateExpression(expression, context);
-  return result === missing ? false : result;
+  // Single missing→false boundary; `toBoolean` is also how && / || resolve
+  // missing operands, so the two paths cannot drift (ADR 0008 §3).
+  return toBoolean(evaluateExpression(expression, context));
 }
 
 /** Parse and evaluate a v1 condition; parsing never executes pack-provided code. */

--- a/packages/engine/src/decide/when.ts
+++ b/packages/engine/src/decide/when.ts
@@ -1,0 +1,414 @@
+import type { DecisionContext } from "./types.js";
+
+/**
+ * v1 when-condition language (ADR 0008 §2): a small, total, side-effect-free
+ * boolean expression language evaluated against a structured context. It is
+ * deliberately not JavaScript — no function calls, regex, or collection
+ * quantifiers — so pack text can never execute code or drive unbounded work.
+ * Missing context values resolve to `false` instead of throwing, so evaluation
+ * is deterministic and always terminates.
+ */
+
+/** Literal types supported by the v1 condition language. */
+type Literal = boolean | number | string;
+
+/** Parsed condition AST: only comparisons, boolean logic, and value terminal nodes. */
+export type Expression =
+  | { type: "comparison"; left: ValueExpression; operator: "!=" | "=="; right: ValueExpression }
+  | { type: "logical"; left: Expression; operator: "&&" | "||"; right: Expression }
+  | { type: "not"; operand: Expression }
+  | { type: "value"; value: ValueExpression };
+
+/** Token stream produced by the lexer and consumed by the recursive-descent parser. */
+type Token =
+  | { type: "boolean"; value: boolean }
+  | { type: "end" }
+  | { type: "identifier"; value: string[] }
+  | { type: "number"; value: number }
+  | { type: "operator"; value: "!" | "!=" | "&&" | "==" | "||" }
+  | { type: "parenthesis"; value: "(" | ")" }
+  | { type: "string"; value: string };
+
+/** Comparable operand: an inline literal or a dotted-path context value. */
+type ValueExpression = { type: "literal"; value: Literal } | { type: "path"; value: string[] };
+
+/** Internal sentinel for a missing or type-incompatible context value; surfaced as null-safe false. */
+const missing = Symbol("missing decision context value");
+
+/** Expression evaluation result; missing propagates through the tree to keep evaluation null-safe. */
+type EvaluationResult = boolean | typeof missing;
+
+/** Resolved operand value: a literal, an explicit null, or missing. */
+type ResolvedValue = Literal | null | typeof missing;
+
+/**
+ * Bounds expression nesting (parentheses and unary operators) so pack text
+ * cannot overflow the call stack during parsing or evaluation.
+ */
+const maxConditionDepth = 128;
+
+/**
+ * Bounds the total number of logical binary operators (`&&` / `||`) in one condition. Left-associative
+ * && / || chains evaluate recursively along the chain, so a flat cap keeps
+ * evaluation depth bounded even when the chain itself is not nested.
+ */
+const maxBinaryOperators = 1024;
+
+/** Syntax failure thrown by the condition parser; the evaluator maps it to decide.invalid_condition. */
+export class ConditionSyntaxError extends Error {
+  constructor() {
+    super("The decision condition is invalid.");
+    this.name = "ConditionSyntaxError";
+  }
+}
+
+/** Parse the v1 condition language; parsing never executes pack-provided code. */
+export function parseCondition(source: string): Expression {
+  return new Parser(source).parse();
+}
+
+/** Evaluate an already-parsed v1 condition; missing fields resolve to false. */
+export function evaluateParsedCondition(expression: Expression, context: DecisionContext): boolean {
+  const result = evaluateExpression(expression, context);
+  return result === missing ? false : result;
+}
+
+/** Parse and evaluate a v1 condition; parsing never executes pack-provided code. */
+export function evaluateCondition(source: string, context: DecisionContext): boolean {
+  return evaluateParsedCondition(parseCondition(source), context);
+}
+
+/**
+ * Recursive-descent parser for the v1 condition language. Grammar:
+ * or → and → unary → primary → value. It never executes pack-provided
+ * code and supports no function calls, regular expressions, or quantifiers.
+ */
+class Parser {
+  #index = 0;
+  #lookahead: Token | undefined;
+  #depth = 0;
+  #binaryOperators = 0;
+
+  constructor(readonly source: string) {}
+
+  /** Parse the full input through EOF; trailing garbage triggers a syntax error. */
+  parse(): Expression {
+    const expression = this.parseOr();
+    if (this.read().type !== "end") throw new ConditionSyntaxError();
+    return expression;
+  }
+
+  // Lowest precedence: || is left-associative over and expressions.
+  private parseOr(): Expression {
+    let expression = this.parseAnd();
+    while (this.consumeLogicalOperator("||")) {
+      expression = { left: expression, operator: "||", right: this.parseAnd(), type: "logical" };
+    }
+    return expression;
+  }
+
+  // && is left-associative over unary expressions.
+  private parseAnd(): Expression {
+    let expression = this.parseUnary();
+    while (this.consumeLogicalOperator("&&")) {
+      expression = { left: expression, operator: "&&", right: this.parseUnary(), type: "logical" };
+    }
+    return expression;
+  }
+
+  // Prefix ! applies to a unary operand, so !!x and !(...) are both valid.
+  private parseUnary(): Expression {
+    if (this.matchOperator("!")) {
+      return this.withinDepth(() => ({ operand: this.parseUnary(), type: "not" }));
+    }
+    return this.parsePrimary();
+  }
+
+  // A parenthesized subexpression, or a value with an optional == / != comparison.
+  private parsePrimary(): Expression {
+    if (this.matchParenthesis("(")) {
+      return this.withinDepth(() => {
+        const expression = this.parseOr();
+        if (!this.matchParenthesis(")")) throw new ConditionSyntaxError();
+        return expression;
+      });
+    }
+
+    const left = this.parseValue();
+    const token = this.peek();
+    if (token.type !== "operator" || (token.value !== "==" && token.value !== "!=")) {
+      return { type: "value", value: left };
+    }
+
+    this.read();
+    return { left, operator: token.value, right: this.parseValue(), type: "comparison" };
+  }
+
+  // A value is either a literal or a dotted-path identifier.
+  private parseValue(): ValueExpression {
+    const token = this.read();
+    switch (token.type) {
+      case "boolean":
+      case "number":
+      case "string":
+        return { type: "literal", value: token.value };
+      case "identifier":
+        return { type: "path", value: token.value };
+      default:
+        throw new ConditionSyntaxError();
+    }
+  }
+
+  /** Match a logical operator and count it toward the per-condition bound; a flat chain cannot grow unbounded. */
+  private consumeLogicalOperator(value: "&&" | "||"): boolean {
+    if (!this.matchOperator(value)) return false;
+    this.#binaryOperators += 1;
+    if (this.#binaryOperators > maxBinaryOperators) throw new ConditionSyntaxError();
+    return true;
+  }
+
+  private matchOperator(value: Extract<Token, { type: "operator" }>["value"]): boolean {
+    const token = this.peek();
+    if (token.type !== "operator" || token.value !== value) return false;
+    this.read();
+    return true;
+  }
+
+  private matchParenthesis(value: "(" | ")"): boolean {
+    const token = this.peek();
+    if (token.type !== "parenthesis" || token.value !== value) return false;
+    this.read();
+    return true;
+  }
+
+  private peek(): Token {
+    this.#lookahead ??= this.nextToken();
+    return this.#lookahead;
+  }
+
+  private read(): Token {
+    const token = this.peek();
+    this.#lookahead = undefined;
+    return token;
+  }
+
+  // Dispatch on the first character: parenthesis / string / identifier / number, else operator.
+  private nextToken(): Token {
+    this.skipWhitespace();
+    const character = this.source[this.#index];
+    if (character === undefined) return { type: "end" };
+
+    if (character === "(" || character === ")") {
+      this.#index += 1;
+      return { type: "parenthesis", value: character };
+    }
+    if (character === '"' || character === "'") return { type: "string", value: this.readString() };
+    if (isIdentifierStart(character)) return this.readIdentifier();
+    if (isNumberStart(character, this.source[this.#index + 1])) return this.readNumber();
+    return this.readOperator();
+  }
+
+  // Parse a dotted path like a.b.c; a lone true/false is a boolean literal.
+  private readIdentifier(): Token {
+    const path: string[] = [];
+    while (isIdentifierStart(this.source[this.#index])) {
+      const start = this.#index;
+      this.#index += 1;
+      while (isIdentifierPart(this.source[this.#index])) this.#index += 1;
+      path.push(this.source.slice(start, this.#index));
+      if (this.source[this.#index] !== ".") break;
+      this.#index += 1;
+      if (!isIdentifierStart(this.source[this.#index])) throw new ConditionSyntaxError();
+    }
+
+    if (path.length === 1 && path[0] === "true") return { type: "boolean", value: true };
+    if (path.length === 1 && path[0] === "false") return { type: "boolean", value: false };
+    return { type: "identifier", value: path };
+  }
+
+  // JSON-style number: optional sign, fraction, and exponent parts.
+  private readNumber(): Token {
+    const start = this.#index;
+    if (this.source[this.#index] === "-") this.#index += 1;
+    this.consumeDigits();
+    if (this.source[this.#index] === ".") {
+      this.#index += 1;
+      if (!isDigit(this.source[this.#index])) throw new ConditionSyntaxError();
+      this.consumeDigits();
+    }
+    if (this.source[this.#index] === "e" || this.source[this.#index] === "E") {
+      this.#index += 1;
+      if (this.source[this.#index] === "+" || this.source[this.#index] === "-") this.#index += 1;
+      if (!isDigit(this.source[this.#index])) throw new ConditionSyntaxError();
+      this.consumeDigits();
+    }
+    return { type: "number", value: Number(this.source.slice(start, this.#index)) };
+  }
+
+  private consumeDigits(): void {
+    while (isDigit(this.source[this.#index])) this.#index += 1;
+  }
+
+  // JSON-style string: simple escapes plus \uXXXX code points.
+  private readString(): string {
+    const quote = this.source[this.#index]!;
+    let value = "";
+    this.#index += 1;
+
+    for (;;) {
+      const character = this.source[this.#index];
+      if (character === undefined) throw new ConditionSyntaxError();
+      this.#index += 1;
+      if (character === quote) return value;
+      if (character !== "\\") {
+        value += character;
+        continue;
+      }
+
+      const escaped = this.source[this.#index];
+      if (escaped === undefined) throw new ConditionSyntaxError();
+      this.#index += 1;
+      const simpleEscape = simpleEscapes[escaped];
+      if (simpleEscape !== undefined) {
+        value += simpleEscape;
+        continue;
+      }
+      if (escaped !== "u") throw new ConditionSyntaxError();
+      const codePoint = this.source.slice(this.#index, this.#index + 4);
+      if (!/^[0-9a-fA-F]{4}$/.test(codePoint)) throw new ConditionSyntaxError();
+      value += String.fromCharCode(Number.parseInt(codePoint, 16));
+      this.#index += 4;
+    }
+  }
+
+  // Prefer two-character operators (&& || == !=), then a single !.
+  private readOperator(): Token {
+    const operator = this.source.slice(this.#index, this.#index + 2);
+    if (operator === "&&" || operator === "||" || operator === "==" || operator === "!=") {
+      this.#index += 2;
+      return { type: "operator", value: operator };
+    }
+    if (this.source[this.#index] === "!") {
+      this.#index += 1;
+      return { type: "operator", value: "!" };
+    }
+    throw new ConditionSyntaxError();
+  }
+
+  private skipWhitespace(): void {
+    while (/\s/.test(this.source[this.#index] ?? "")) this.#index += 1;
+  }
+
+  private withinDepth<T>(parse: () => T): T {
+    // Count nesting from parentheses and unary operations; restore on exit so siblings share the budget.
+    this.#depth += 1;
+    if (this.#depth > maxConditionDepth) {
+      this.#depth -= 1;
+      throw new ConditionSyntaxError();
+    }
+    try {
+      return parse();
+    } finally {
+      this.#depth -= 1;
+    }
+  }
+}
+
+/** Simple escape table shared by single- and double-quoted strings. */
+const simpleEscapes: Readonly<Record<string, string>> = {
+  '"': '"',
+  "'": "'",
+  "/": "/",
+  "\\": "\\",
+  b: "\b",
+  f: "\f",
+  n: "\n",
+  r: "\r",
+  t: "\t",
+};
+
+/** Evaluate an AST node; missing propagates and evaluateParsedCondition resolves it to false. */
+function evaluateExpression(expression: Expression, context: DecisionContext): EvaluationResult {
+  switch (expression.type) {
+    case "comparison":
+      return evaluateComparison(expression, context);
+    case "logical": {
+      // Both operands are always evaluated: && / || intentionally do not
+      // short-circuit, matching the fork reference implementation and keeping
+      // evaluation total (a missing operand resolves to false on either side).
+      const left = toBoolean(evaluateExpression(expression.left, context));
+      const right = toBoolean(evaluateExpression(expression.right, context));
+      return expression.operator === "&&" ? left && right : left || right;
+    }
+    case "not": {
+      const operand = evaluateExpression(expression.operand, context);
+      return operand === missing ? missing : !operand;
+    }
+    case "value": {
+      const value = resolveValue(expression.value, context);
+      return typeof value === "boolean" ? value : missing;
+    }
+  }
+}
+
+/** Compare resolved operands for == / !=; missing or null operands never match. */
+function evaluateComparison(
+  expression: Extract<Expression, { type: "comparison" }>,
+  context: DecisionContext,
+): boolean {
+  const left = resolveValue(expression.left, context);
+  const right = resolveValue(expression.right, context);
+  if (left === missing || right === missing || left === null || right === null) return false;
+  if (typeof left !== typeof right) return false;
+  const equal = left === right;
+  return expression.operator === "==" ? equal : !equal;
+}
+
+/** Resolve a dotted path against the context; a missing segment or unsupported type yields missing. */
+function resolveValue(value: ValueExpression, context: DecisionContext): ResolvedValue {
+  if (value.type === "literal") return value.value;
+
+  let current: unknown = context;
+  for (const segment of value.value) {
+    if (!isRecord(current) || !Object.hasOwn(current, segment)) return missing;
+    current = current[segment];
+  }
+  return typeof current === "boolean" || typeof current === "number" || typeof current === "string"
+    ? current
+    : current === null
+      ? null
+      : missing;
+}
+
+/** Convert a possibly-missing evaluation result to a boolean (missing → false). */
+function toBoolean(value: EvaluationResult): boolean {
+  return value === missing ? false : value;
+}
+
+/** Whether a character is an ASCII digit (0-9). */
+function isDigit(value: string | undefined): boolean {
+  return value !== undefined && value >= "0" && value <= "9";
+}
+
+/** Whether a character is a valid identifier continuation (letter, digit, or underscore). */
+function isIdentifierPart(value: string | undefined): boolean {
+  return value !== undefined && (isIdentifierStart(value) || isDigit(value));
+}
+
+/** Whether a character starts an identifier ([A-Za-z_]). */
+function isIdentifierStart(value: string | undefined): boolean {
+  return (
+    value !== undefined &&
+    ((value >= "a" && value <= "z") || (value >= "A" && value <= "Z") || value === "_")
+  );
+}
+
+/** Whether a character starts a JSON-style number (digit, or '-' followed by a digit). */
+function isNumberStart(value: string, next: string | undefined): boolean {
+  return isDigit(value) || (value === "-" && isDigit(next));
+}
+
+/** Whether a value is a plain non-array object usable for dotted-path traversal. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -6,3 +6,5 @@
  */
 
 export const PACKAGE_NAME = "@lorelum/engine";
+
+export * from "./decide";

--- a/packages/format/src/schema/decision.test.ts
+++ b/packages/format/src/schema/decision.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { DecisionNodeSchema } from "./decision";
+import { DecisionDocumentError, DecisionNodeSchema, parseDecisionDocument } from "./decision";
 
 const clientVsServer = {
   id: "state.client-vs-server",
@@ -41,5 +41,13 @@ describe("DecisionNodeSchema", () => {
       DecisionNodeSchema.safeParse({ ...clientVsServer, branches: [branchWithoutRecommend] })
         .success,
     ).toBe(false);
+  });
+
+  test("parseDecisionDocument normalizes an empty YAML document", () => {
+    expect(parseDecisionDocument(null)).toEqual([]);
+  });
+
+  test("parseDecisionDocument rejects a non-list document", () => {
+    expect(() => parseDecisionDocument({ id: "state.entry" })).toThrow(DecisionDocumentError);
   });
 });

--- a/packages/format/src/schema/decision.ts
+++ b/packages/format/src/schema/decision.ts
@@ -27,3 +27,22 @@ export const DecisionNodeSchema = z.object({
 });
 
 export type DecisionNode = z.infer<typeof DecisionNodeSchema>;
+
+/** Thrown when a decisions document is not a valid list of Decision Nodes. */
+export class DecisionDocumentError extends Error {
+  constructor() {
+    super("The decisions document is not a list of decision nodes.");
+    this.name = "DecisionDocumentError";
+  }
+}
+
+/**
+ * Parse a runtime decisions document so the format layer does not depend on
+ * CLI error codes. An empty YAML document (null) and an absent document
+ * (undefined) both normalize to an empty decision list.
+ */
+export function parseDecisionDocument(input: unknown): DecisionNode[] {
+  const result = DecisionNodeSchema.array().safeParse(input ?? []);
+  if (!result.success) throw new DecisionDocumentError();
+  return result.data;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,15 @@
  */
 
 export const PACKAGE_NAME = "@lorelum/shared";
+
+/** JSON Schema subset used for protocol result metadata (single source). */
+export type JsonSchema = {
+  oneOf?: readonly JsonSchema[];
+  type?: "array" | "boolean" | "integer" | "object" | "string";
+  const?: unknown;
+  enum?: readonly unknown[];
+  additionalProperties?: boolean;
+  required?: readonly string[];
+  properties?: Readonly<Record<string, JsonSchema>>;
+  items?: JsonSchema;
+};


### PR DESCRIPTION
## 关联

- Issue: [lorelum/lorelum#24](https://github.com/lorelum/lorelum/issues/24)（OPEN）— deterministic local lore decide command (structured decision graph evaluator, v1)
- 设计文档: [ADR 0008](https://github.com/lorelum/lorelum/blob/main/docs/adr/0008-decide-evaluation-contract.md)（本 PR 新增）、ADR 0004（agent-first CLI 协议）、ADR 0003（decisions.yaml / Decision Node schema）
- 参考实现: `SmallParamecium/lorelum#18`（fork `feat/cli-decide`，MERGED）；`#20`（F1 栈溢出修复，随本 PR 带入）

## 背景

官方 `main` 已有 `decisions.yaml` 与 Decision Node schema（ADR 0003）和 CLI 协议框架（#21），但没有执行决策树的运行时命令。本 PR 按 issue #24 的定位（D0）实现**结构化决策图求值器本地 v1**，与 README 的自然语言 `lore decide`（P0–P2 retrieval/LLM）明确划界：结构化 v1 确定性、可审计、离线可用，先落地；自然语言形态另开任务。

## 改动

按边界组织（与 issue 的「做」清单一致）：

- **engine（`packages/engine/src/decide/*`）**：纯函数决策图求值器 `evaluateDecisions` + when 条件语言解析/求值，无文件系统与进程 I/O，CLI 与未来 MCP adapter 复用同一套语义；错误码由 `decisionErrorCodes` 单源定义；F1 边界（一元/括号嵌套 ≤ 128、逻辑二元运算符 ≤ 1024）带回归测试。
- **format（`packages/format/src/schema/decision.ts`）**：新增 `parseDecisionDocument` + `DecisionDocumentError`，复用现有 `DecisionNodeSchema`；空 YAML 文档归一为空决策列表，非列表文档拒绝；format 层不依赖 CLI 错误码。
- **cli（`packages/cli/src/decide/*`）**：在官方 #21 框架上注册 `decide` 命令（`lore decide <pack-path> --decision <id> --context <json>`）；轻量 pack 读取（`decisions.yaml` + 256KiB 上限，D1）；engine/format 领域错误经 `toCliError` 映射为 `pack.*` / `decide.*` 错误码并进入 ADR 0004 allowlist；describe 发现、registry 元数据、进程级用例同步更新。
- **docs**：ADR 0008 冻结 when 语法、空安全、确定性、trace、结果信封与错误码/退出码契约，并说明与 `validate` exit 1/2 差异。

## 验证

- `bun test` — 205 pass / 0 fail（engine when/求值 + format 文档解析 + CLI 协议/错误码/边界用例）
- `bun run typecheck` — 5 个包全部通过
- `bun run lint` — 通过
- `bun run build:cli` — `bun build --compile` 成功
- `bun packages/cli/integration/process.integration.ts` — 通过（编译原生二进制后真实进程跑 `decide`，含 matched / 协议信封断言）

## 风险与未验证项

- **CI 暂不执行进程级集成测试**：仓库 CI 的 Test 步骤只跑 `bun test`，`process.integration.ts` 已入库但不在 CI 中运行（本地已验证通过）。建议后续将 integration 加入 CI verify 步骤。
- **框架层与领域错误耦合（已识别，留后续）**：`packages/cli/src/runtime/errors.ts` 目前按 `instanceof` 映射 engine/format 错误类，当前行为正确，但框架核心因此持有领域知识；待 query/get/check 落地时改为按 `code` 结构识别或下沉到 handler。
- **ADR 0008 状态为 Proposed**，随本 PR 提交审核。
- 非目标（issue 明示）：`--human` 渲染、MCP 工具接线、`lore validate` 的 when 语法检查、自然语言 decide、完整 v1 目录布局 loader。

## Review Notes

- when 条件语言**故意不是 JavaScript**：无函数调用/正则/集合量词；缺失字段与类型不匹配按 `false` 求值（空安全）；`&&`/`||` 不短路是有意为之，与 fork 参考实现一致，保证求值 total。
- `decisionResultSchema` 是 engine `DecideResult` 的手写镜像，用于 `describe` 发现与测试校验；框架运行时不校验 resultSchema（沿用仓库既有模式），CLI 测试已对 matched / no_match / 链式 next / 空推荐各形状做 schema 校验。
- 未新增依赖、无公共 schema 变更、未触碰官方 ADR 0007 与 release/publish 工作流。
