### PR TITLE
feat(cli): install Packs from repository Registries

### DIFF
--- a/docs/adr/0008-pack-registry-and-user-scope-install.md
+++ b/docs/adr/0008-pack-registry-and-user-scope-install.md
@@ -1,0 +1,119 @@
+# ADR 0008: Repository Registry and user-scope Pack install
+
+- **Date:** 2026-08-31
+- **Status:** Accepted
+- **Related:** ADR 0003, ADR 0004, ADR 0007
+
+## Context
+
+Lorelum 已能把有效 Pack 目录原子安装到 user-level LocalStore，但 CLI 还不能把 `lore install agentic-coding` 解析为可安装目录。公共 `lorelum/lorelum-packs` 也缺少 machine-readable Catalog。
+
+本轮需要连接三个已有边界：Pack root 格式、安装名到 Git release 的索引，以及 LocalStore 的 seal/activate 语义。若同时加入 project scope、lockfile、依赖解析和通用 transport，会把首个安装纵切扩成包管理器。
+
+同时，官方仓库不能成为唯一来源。团队或社区维护独立 Registry 仓库是合理扩展点；CLI 应允许用户显式选择这样的仓库，而不是只允许官方内容。
+
+## Decision
+
+### 1. Phase 1 只安装到 user scope
+
+`lore install <pack>` 安装并激活到 `defaultStorageRoot()`（`~/.lorelum`）。本轮不接受 `--scope`，也不扫描项目 `.lorelum/packs/`。
+
+项目自己维护的 Pack 源码仍建议放在 `<project>/.lorelum/packs/<name>/`。其 config/lock、trust 和与 user scope 的合并语义需要独立 ADR。
+
+### 2. Registry 的选择单位是 GitHub 仓库
+
+CLI 内置官方仓库标识 `lorelum/lorelum-packs`，不内置 Pack 内容。默认命令：
+
+```sh
+lore install agentic-coding
+```
+
+用户可以一次性显式选择另一个公开 GitHub Registry 仓库：
+
+```sh
+lore install backend-standards --registry acme/team-packs
+```
+
+`--registry` 接受 `owner/repository` 或规范的 `https://github.com/owner/repository(.git)`。CLI 从同一仓库的 `.lorelum/registry.yaml` 读取索引，并从同一仓库物化 release。Phase 1 不接受本地文件、`file:`、任意 HTTP descriptor、其他 Git host 或持久 `registry add`。
+
+这保留了团队/社区扩展能力，同时避免“descriptor 指向任意 repository”的第二跳和每个 release 重复 source repository。
+
+### 3. Registry v1 只索引仓库内的 release
+
+```yaml
+schema_version: 1
+name: lorelum-official
+packs:
+  - name: agentic-coding
+    description: Practices for evidence-aligned agentic coding workflows.
+    releases:
+      - version: 0.1.0
+        ref: agentic-coding-v0.1.0
+        path: packs/agentic-coding
+```
+
+`ref` 和 `path` 都相对于所选 Registry 仓库解释。`path` 是 Catalog 组织合同，不改变 Pack root 的 `pack.yaml + practices/**/*.md + decisions.yaml?` 格式。
+
+Registry schema 是 strict 的：拒绝未知字段、不安全 ref/path、重复 Pack 名，以及 semver precedence 相同的重复 release。它不携带 engine 内部 canonical artifact digest；该 digest 属于安装后 Store artifact，而不是发布者必须预计算的分发格式。
+
+### 4. 版本选择确定且保守
+
+- 默认选择最高稳定 semver，不依赖 YAML 顺序。
+- `--pack-version` 只接受 Registry 中存在的精确版本；prerelease 必须显式选择。
+- 物化后再次校验 `pack.yaml.name/version` 与 Registry entry/release 完全一致。
+- 已安装相同 canonical artifact 为幂等成功；同名但内容不同返回 `pack.upgrade-required`，不静默替换。
+
+Phase 1 不解析 semver range、依赖或 update policy。
+
+### 5. Git source 隔离物化，Pack 解析只保留一套
+
+CLI 在临时目录中用参数数组执行 Git，不经过 shell。clone 使用 `--no-checkout`；随后检查 Git tree 的类型、路径、数量和字节预算，并用 `git cat-file` 只读取 `pack.yaml`、可选 `decisions.yaml` 和 `practices/**/*.md`。它不执行 checkout、content filter 或 Pack 脚本。
+
+engine 暴露 `decodePackDirectory()`，复用 LocalStore snapshot decoder 和 `createPackCandidate()` 格式 gate。decoder 对目录项、深度、Practice 数量、单文件和总字节设置预算，并拒绝 symlink/非普通文件。
+
+临时 source 在候选构建后 best-effort 清理。LocalStore 从 candidate 重建并 seal 自己的不可变 artifact，不复用下载目录。
+
+### 6. 完成声明以 Store commit 和实际证据为准
+
+Registry/source/Pack/Store errors 在 CLI 边界映射为 install 命令声明的稳定错误码；未声明异常收敛为 `runtime.unexpected`。消息不回显 Git stderr、临时绝对路径或用户 home。
+
+成功结果包含：Registry 名与仓库、Pack 名与版本、resolved ref/commit、LocalStore 实际 `artifactDigest`、generation/effectiveRevision、delta、diagnostics、idempotent 和 Store cleanup 状态。它不声称 Registry 已签名，也不把安装后的 digest 冒充成下载前完整性证明。
+
+## Consequences
+
+### Positive
+
+- 官方 Pack 可独立发布，CLI binary 保持无内容绑定。
+- 团队和社区能用相同仓库结构提供 Pack，不需要修改 CLI。
+- Registry release 不再重复 repository/type，也不绑定 engine snapshot 实现。
+- Registry install、未来本地 source 与 Store recovery 共用一个 Pack decoder。
+- user scope 复用已有 LocalStore 原子性、幂等和恢复语义。
+
+### Negative / accepted risk
+
+- Phase 1 只支持公开 GitHub Registry 仓库；私有仓库认证和其他 Git host 尚未定义。
+- 系统必须有 Git；否则返回 `source.unavailable`。
+- Registry 没有签名、checksum 或 transparency log。可移动 ref 是供应链风险；resolved commit 和安装后 digest 只提供可审计证据，不提供发布者真实性。
+- user scope 对该用户的所有项目可见；项目级可复现依赖仍需 config/lock。
+
+## Rejected alternatives
+
+- **每个 release 内重复 `source.type/repository`：** 当前 Registry 已由仓库选定，多一层 repository 既冗余又扩大远端跳转面。
+- **Registry 内声明 engine `artifact_digest`：** 会要求发布工具复刻 LocalStore seal/projection，并把内部 artifact 格式固化为发布合同。
+- **任意本地/HTTP locator fallback：** 一个 flag 同时表示仓库、descriptor 文件和 URL，错误与信任语义不清；需要时应作为独立 source 合同设计。
+- **CLI 内置 Pack：** 把 Pack 发布节奏绑定 CLI release，违背独立 Catalog 目标。
+
+## Follow-ups
+
+1. 为 project/local scope、`.lorelum/packs`、config/lock 和 trust gate 编写独立 ADR。
+2. 设计私有 Registry 认证、其他 Git host、签名/checksum 和撤回机制。
+3. 增加显式 `lore upgrade` / `uninstall`，保持 install 不静默升级。
+4. 正式编写 `agentic-coding` 的 25–30 条 Practice，替换占位内容后再发布稳定 release。
+
+## References
+
+- ADR 0003 — Practice/Pack format and validation semantics.
+- ADR 0004 — agent-first CLI JSON protocol.
+- ADR 0007 — LocalStore lifecycle, idempotency, recovery and commit semantics.
+- `docs/plans/lorelum-packs-repository-plan.md` — public Catalog vs project-authored source.
+- `docs/plans/agentic-coding-pack-plan.md` — planned Practice content architecture.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ docs/adr/
 ├── 0004-agent-first-cli-protocol.md            # candidate CLI protocol contract
 ├── 0005-0006                                   # reserved for in-flight planning numbers; 0007 is numbered to match planning docs, not the strict next-free sequence
 ├── 0007-engine-local-store.md                 # @lorelum/engine LocalStore storage & lifecycle contract
+├── 0008-pack-registry-and-user-scope-install.md # Pack Registry and user-scope install contract
 └── 0000-template.md                           # copy this to start a new ADR
 ```
 

--- a/packages/cli/src/install/install-command.test.ts
+++ b/packages/cli/src/install/install-command.test.ts
@@ -1,0 +1,221 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createLocalStore, decodePackDirectory } from "@lorelum/engine";
+import { RegistrySchema, type RegistryRelease } from "@lorelum/format";
+
+import { run } from "../main.js";
+import { validateJsonSchema } from "../output/protocol-schema.test-helper.js";
+import { snapshotCommandDefinitions } from "../registry.js";
+import { createInstallCommand, type InstallCommandServices } from "./install-command.js";
+import { resolveRegistryRepository } from "./load-registry.js";
+
+class MemoryWriter {
+  value = "";
+
+  write(message: string): void {
+    this.value += message;
+  }
+}
+
+function registry(version = "0.1.0") {
+  return RegistrySchema.parse({
+    schema_version: 1,
+    name: "team-packs",
+    packs: [
+      {
+        name: "agentic-coding",
+        releases: [
+          {
+            version,
+            ref: `agentic-coding-v${version}`,
+            path: "packs/agentic-coding",
+          },
+        ],
+      },
+    ],
+  });
+}
+
+async function createPack(directory: string): Promise<string> {
+  const packDirectory = join(directory, "pack");
+  await mkdir(join(packDirectory, "practices"), { recursive: true });
+  await writeFile(
+    join(packDirectory, "pack.yaml"),
+    "name: agentic-coding\nversion: 0.1.0\ndescription: Installation placeholder.\n",
+  );
+  await writeFile(
+    join(packDirectory, "practices", "placeholder.md"),
+    `---
+id: agentic-coding.installation.placeholder
+title: Installation placeholder
+stage: installation
+tech_stack: [agentic-coding]
+applies_when: validating the Knowledge Pack installation pipeline
+severity: info
+---
+This placeholder proves the Pack can be decoded and installed.
+`,
+  );
+  return packDirectory;
+}
+
+function createServices(
+  packDirectory: string,
+  storageRoot: string,
+  registryVersion = "0.1.0",
+): {
+  services: InstallCommandServices;
+  observed: { cleaned: number; locator: string | undefined; repository: string | undefined };
+} {
+  const observed = { cleaned: 0, locator: undefined, repository: undefined } as {
+    cleaned: number;
+    locator: string | undefined;
+    repository: string | undefined;
+  };
+  return {
+    observed,
+    services: {
+      async loadRegistry(locator) {
+        observed.locator = locator;
+        return {
+          registry: registry(registryVersion),
+          repository: resolveRegistryRepository(locator),
+        };
+      },
+      async materializeRelease(release: RegistryRelease, repository: string) {
+        observed.repository = repository;
+        return {
+          directory: packDirectory,
+          resolvedRef: release.ref,
+          resolvedCommit: "0123456789abcdef0123456789abcdef01234567",
+          async cleanup() {
+            observed.cleaned += 1;
+          },
+        };
+      },
+      decodePackDirectory,
+      store: createLocalStore(),
+      storageRoot: { rootPath: storageRoot },
+    },
+  };
+}
+
+test("installs from an explicit Registry repository and is idempotent", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-install-command-"));
+  try {
+    const storageRoot = join(directory, "store");
+    const fixture = createServices(await createPack(directory), storageRoot);
+    const definitions = snapshotCommandDefinitions([createInstallCommand(fixture.services)]);
+    const firstOutput = new MemoryWriter();
+
+    expect(
+      await run(
+        ["install", "agentic-coding", "--registry", "acme/team-packs", "--pack-version", "0.1.0"],
+        { registry: definitions, stdout: firstOutput },
+      ),
+    ).toBe(0);
+    const first = JSON.parse(firstOutput.value);
+    expect(first).toMatchObject({
+      ok: true,
+      command: "install",
+      data: {
+        registry: { name: "team-packs", repository: "acme/team-packs" },
+        pack: { name: "agentic-coding", version: "0.1.0" },
+        idempotent: false,
+        generation: 1,
+        effectiveRevision: 1,
+        delta: { added: ["agentic-coding.installation.placeholder"] },
+      },
+    });
+    expect(first.data.artifactDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(fixture.observed.locator).toBe("acme/team-packs");
+    expect(fixture.observed.repository).toBe("https://github.com/acme/team-packs.git");
+    const installDefinition = definitions.find((definition) => definition.name === "install")!;
+    expect(validateJsonSchema(first.data, installDefinition.resultSchema)).toEqual([]);
+
+    const secondOutput = new MemoryWriter();
+    expect(
+      await run(["install", "agentic-coding", "--registry", "acme/team-packs"], {
+        registry: definitions,
+        stdout: secondOutput,
+      }),
+    ).toBe(0);
+    expect(JSON.parse(secondOutput.value)).toMatchObject({
+      data: {
+        idempotent: true,
+        generation: 1,
+        effectiveRevision: 1,
+        artifactDigest: first.data.artifactDigest,
+        delta: { added: [], changed: [], invalidated: [] },
+      },
+    });
+    expect(fixture.observed.cleaned).toBe(2);
+    expect(
+      await fixture.services.store.readEffectivePractices({ rootPath: storageRoot }),
+    ).toHaveLength(1);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("a changed installed Pack requires an explicit upgrade", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-install-command-"));
+  try {
+    const packDirectory = await createPack(directory);
+    const storageRoot = join(directory, "store");
+    const first = createServices(packDirectory, storageRoot);
+    const firstDefinitions = snapshotCommandDefinitions([createInstallCommand(first.services)]);
+    expect(
+      await run(["install", "agentic-coding"], {
+        registry: firstDefinitions,
+        stdout: new MemoryWriter(),
+      }),
+    ).toBe(0);
+
+    await writeFile(
+      join(packDirectory, "practices", "placeholder.md"),
+      `---
+id: agentic-coding.installation.placeholder
+title: Installation placeholder
+stage: installation
+tech_stack: [agentic-coding]
+applies_when: validating the Knowledge Pack installation pipeline
+severity: info
+---
+Changed content that must not be installed implicitly.
+`,
+    );
+    const changed = createServices(packDirectory, storageRoot);
+    const definitions = snapshotCommandDefinitions([createInstallCommand(changed.services)]);
+    const stdout = new MemoryWriter();
+    expect(await run(["install", "agentic-coding"], { registry: definitions, stdout })).toBe(2);
+    expect(JSON.parse(stdout.value)).toMatchObject({
+      ok: false,
+      error: { code: "pack.upgrade-required" },
+    });
+    const effective = await first.services.store.readEffectivePractices({ rootPath: storageRoot });
+    expect(effective[0]?.practice.body).toContain("can be decoded and installed");
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("rejects a release whose Pack identity does not match the Registry", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-install-command-"));
+  try {
+    const fixture = createServices(await createPack(directory), join(directory, "store"), "0.2.0");
+    const definitions = snapshotCommandDefinitions([createInstallCommand(fixture.services)]);
+    const stdout = new MemoryWriter();
+    expect(await run(["install", "agentic-coding"], { registry: definitions, stdout })).toBe(2);
+    expect(JSON.parse(stdout.value)).toMatchObject({
+      ok: false,
+      error: { code: "pack.invalid" },
+    });
+    expect(fixture.observed.cleaned).toBe(1);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});

--- a/packages/cli/src/install/install-command.ts
+++ b/packages/cli/src/install/install-command.ts
@@ -1,0 +1,258 @@
+import {
+  InvalidSourcePathError,
+  PackValidationError,
+  PracticeConflictError,
+  SnapshotFormatError,
+  StoreBusyError,
+  StoreRecoveryRequiredError,
+  UpgradeRequiredError,
+  createLocalStore,
+  decodePackDirectory,
+  defaultStorageRoot,
+  type DecodedPackDirectory,
+  type LocalStore,
+  type StorageRoot,
+} from "@lorelum/engine";
+import type { RegistryRelease } from "@lorelum/format";
+
+import type { JsonSchema, JsonValue } from "../output/protocol.js";
+import type { CommandDefinition } from "../registry.js";
+import { CliError, cliErrorCodes, frameworkErrorCodes } from "../runtime/errors.js";
+import { loadRegistry, type LoadedRegistry } from "./load-registry.js";
+import { materializeRegistryRelease, type MaterializedPackSource } from "./materialize-source.js";
+import { resolveRegistryRelease } from "./resolve-release.js";
+
+export interface InstallCommandServices {
+  readonly loadRegistry: (locator?: string) => Promise<LoadedRegistry>;
+  readonly materializeRelease: (
+    release: RegistryRelease,
+    repository: string,
+  ) => Promise<MaterializedPackSource>;
+  readonly decodePackDirectory: (directory: string) => Promise<DecodedPackDirectory>;
+  readonly store: LocalStore;
+  readonly storageRoot: StorageRoot;
+}
+
+function defaultInstallServices(): InstallCommandServices {
+  return {
+    loadRegistry,
+    materializeRelease: materializeRegistryRelease,
+    decodePackDirectory,
+    store: createLocalStore(),
+    storageRoot: defaultStorageRoot(),
+  };
+}
+
+const stringSchema: JsonSchema = { type: "string" };
+const stringArraySchema: JsonSchema = { type: "array", items: stringSchema };
+const deltaSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["added", "changed", "invalidated"],
+  properties: {
+    added: stringArraySchema,
+    changed: stringArraySchema,
+    invalidated: stringArraySchema,
+  },
+};
+const diagnosticSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["level", "code", "path", "message"],
+  properties: {
+    level: { enum: ["error", "warning", "info"] },
+    code: stringSchema,
+    path: stringSchema,
+    message: stringSchema,
+  },
+};
+const installResultSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "pack",
+    "registry",
+    "source",
+    "generation",
+    "effectiveRevision",
+    "delta",
+    "diagnostics",
+    "idempotent",
+    "cleanupPending",
+    "artifactDigest",
+  ],
+  properties: {
+    pack: {
+      type: "object",
+      additionalProperties: false,
+      required: ["name", "version"],
+      properties: { name: stringSchema, version: stringSchema },
+    },
+    registry: {
+      type: "object",
+      additionalProperties: false,
+      required: ["name", "repository"],
+      properties: { name: stringSchema, repository: stringSchema },
+    },
+    source: {
+      type: "object",
+      additionalProperties: false,
+      required: ["type", "ref", "commit"],
+      properties: { type: { const: "git" }, ref: stringSchema, commit: stringSchema },
+    },
+    generation: { type: "integer" },
+    effectiveRevision: { type: "integer" },
+    delta: deltaSchema,
+    diagnostics: { type: "array", items: diagnosticSchema },
+    idempotent: { type: "boolean" },
+    cleanupPending: { type: "boolean" },
+    artifactDigest: stringSchema,
+  },
+};
+
+const installErrorCodes = Object.freeze([
+  ...frameworkErrorCodes,
+  cliErrorCodes.registryUnavailable,
+  cliErrorCodes.registryInvalid,
+  cliErrorCodes.registryPackNotFound,
+  cliErrorCodes.registryVersionNotFound,
+  cliErrorCodes.sourceUnavailable,
+  cliErrorCodes.sourceInvalid,
+  cliErrorCodes.packInvalid,
+  cliErrorCodes.packUpgradeRequired,
+  cliErrorCodes.practiceConflict,
+  cliErrorCodes.storeBusy,
+  cliErrorCodes.storeRecoveryRequired,
+]);
+
+function optionString(
+  options: Readonly<Record<string, unknown>>,
+  name: string,
+): string | undefined {
+  const value = options[name];
+  return typeof value === "string" ? value : undefined;
+}
+
+function throwVisibleInstallError(error: unknown): never {
+  if (error instanceof CliError) throw error;
+  if (
+    error instanceof SnapshotFormatError ||
+    error instanceof PackValidationError ||
+    error instanceof InvalidSourcePathError
+  ) {
+    throw new CliError(cliErrorCodes.packInvalid, "The selected Pack is invalid.");
+  }
+  if (error instanceof UpgradeRequiredError) {
+    throw new CliError(cliErrorCodes.packUpgradeRequired, error.message);
+  }
+  if (error instanceof PracticeConflictError) {
+    throw new CliError(
+      cliErrorCodes.practiceConflict,
+      `Practice "${error.practiceId}" conflicts with an installed Pack.`,
+    );
+  }
+  if (error instanceof StoreBusyError) {
+    throw new CliError(cliErrorCodes.storeBusy, "The local Pack store is busy.");
+  }
+  if (error instanceof StoreRecoveryRequiredError) {
+    throw new CliError(
+      cliErrorCodes.storeRecoveryRequired,
+      "The local Pack store requires recovery.",
+    );
+  }
+  throw error;
+}
+
+async function installPack(
+  services: InstallCommandServices,
+  packName: string,
+  requestedVersion?: string,
+  registryLocator?: string,
+): Promise<JsonValue> {
+  const loaded = await services.loadRegistry(registryLocator);
+  const resolved = resolveRegistryRelease(loaded.registry, packName, requestedVersion);
+  const materialized = await services.materializeRelease(
+    resolved.release,
+    loaded.repository.gitUrl,
+  );
+  try {
+    const decoded = await services.decodePackDirectory(materialized.directory);
+    if (
+      decoded.candidate.pack.name !== resolved.pack.name ||
+      decoded.candidate.pack.version !== resolved.release.version
+    ) {
+      throw new CliError(
+        cliErrorCodes.packInvalid,
+        "The fetched Pack identity does not match the Registry release.",
+      );
+    }
+    const result = await services.store.install(
+      services.storageRoot,
+      decoded.candidate,
+      decoded.diagnostics,
+    );
+    return {
+      pack: { name: decoded.candidate.pack.name, version: decoded.candidate.pack.version },
+      registry: { name: loaded.registry.name, repository: loaded.repository.slug },
+      source: {
+        type: "git",
+        ref: materialized.resolvedRef,
+        commit: materialized.resolvedCommit,
+      },
+      generation: result.generation,
+      effectiveRevision: result.effectiveRevision,
+      delta: {
+        added: [...result.delta.added],
+        changed: [...result.delta.changed],
+        invalidated: [...result.delta.invalidated],
+      },
+      diagnostics: result.diagnostics.map((diagnostic) => ({ ...diagnostic })),
+      idempotent: result.idempotent,
+      cleanupPending: result.cleanupPending,
+      artifactDigest: result.artifactDigest,
+    };
+  } finally {
+    await materialized.cleanup().catch(() => undefined);
+  }
+}
+
+export function createInstallCommand(
+  services: InstallCommandServices = defaultInstallServices(),
+): CommandDefinition {
+  return {
+    name: "install",
+    summary: "Install a Knowledge Pack into the user-level local store.",
+    positionals: [{ name: "pack", required: true }],
+    options: [
+      {
+        longFlag: "--pack-version",
+        description: "Install one exact Registry release version.",
+        value: { name: "version", required: true },
+        optionRequired: false,
+      },
+      {
+        longFlag: "--registry",
+        description: "Use a GitHub repository containing .lorelum/registry.yaml.",
+        value: { name: "repository", required: true },
+        optionRequired: false,
+      },
+    ],
+    resultSchema: installResultSchema,
+    errorCodes: installErrorCodes,
+    exitCodes: [0, 2],
+    async handler(invocation) {
+      try {
+        return {
+          data: await installPack(
+            services,
+            invocation.positionals[0]!,
+            optionString(invocation.options, "packVersion"),
+            optionString(invocation.options, "registry"),
+          ),
+        };
+      } catch (error) {
+        throwVisibleInstallError(error);
+      }
+    },
+  };
+}

--- a/packages/cli/src/install/load-registry.test.ts
+++ b/packages/cli/src/install/load-registry.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+
+import { loadRegistry, resolveRegistryRepository } from "./load-registry.js";
+
+const validRegistry = `schema_version: 1
+name: lorelum-official
+packs:
+  - name: agentic-coding
+    releases:
+      - version: 0.1.0
+        ref: agentic-coding-v0.1.0
+        path: packs/agentic-coding
+`;
+
+function responseFetch(response: Response): typeof fetch {
+  return (() => Promise.resolve(response)) as unknown as typeof fetch;
+}
+
+test("uses the built-in official Registry repository", () => {
+  expect(resolveRegistryRepository()).toEqual({
+    slug: "lorelum/lorelum-packs",
+    gitUrl: "https://github.com/lorelum/lorelum-packs.git",
+    descriptorUrl:
+      "https://raw.githubusercontent.com/lorelum/lorelum-packs/HEAD/.lorelum/registry.yaml",
+  });
+});
+
+test("normalizes an explicit GitHub Registry repository", async () => {
+  const loaded = await loadRegistry(
+    "https://github.com/acme/team-packs.git",
+    responseFetch(new Response(validRegistry)),
+  );
+  expect(loaded.repository.slug).toBe("acme/team-packs");
+  expect(loaded.registry.packs[0]?.name).toBe("agentic-coding");
+});
+
+test("rejects arbitrary Registry locators", () => {
+  expect(() => resolveRegistryRepository("file:///tmp/packs")).toThrow("GitHub owner/repository");
+  expect(() => resolveRegistryRepository("https://example.com/acme/packs")).toThrow(
+    "valid GitHub repository",
+  );
+  expect(() => resolveRegistryRepository("https://github.com:444/acme/packs")).toThrow(
+    "valid GitHub repository",
+  );
+});
+
+test("distinguishes invalid content from an unavailable Registry", async () => {
+  await expect(
+    loadRegistry(undefined, responseFetch(new Response("schema_version: 2", { status: 200 }))),
+  ).rejects.toMatchObject({ code: "registry.invalid" });
+  await expect(
+    loadRegistry(undefined, responseFetch(new Response("missing", { status: 404 }))),
+  ).rejects.toMatchObject({ code: "registry.unavailable" });
+});

--- a/packages/cli/src/install/load-registry.ts
+++ b/packages/cli/src/install/load-registry.ts
@@ -1,0 +1,87 @@
+import { parseYaml, RegistrySchema, type Registry } from "@lorelum/format";
+
+import { CliError, cliErrorCodes } from "../runtime/errors.js";
+
+const OFFICIAL_REGISTRY_REPOSITORY = "lorelum/lorelum-packs";
+const MAX_REGISTRY_BYTES = 256 * 1024;
+
+export interface RegistryRepository {
+  readonly slug: string;
+  readonly gitUrl: string;
+  readonly descriptorUrl: string;
+}
+
+export interface LoadedRegistry {
+  readonly registry: Registry;
+  readonly repository: RegistryRepository;
+}
+
+function invalidRegistry(message = "The Pack Registry is invalid."): CliError {
+  return new CliError(cliErrorCodes.registryInvalid, message);
+}
+
+/** Resolve the official default or one explicit public GitHub Registry repository. */
+export function resolveRegistryRepository(locator?: string): RegistryRepository {
+  let slug = locator ?? OFFICIAL_REGISTRY_REPOSITORY;
+  if (slug.startsWith("https://")) {
+    let url: URL;
+    try {
+      url = new URL(slug);
+    } catch {
+      throw invalidRegistry("The Registry repository is not a valid GitHub repository.");
+    }
+    if (
+      url.hostname !== "github.com" ||
+      url.username !== "" ||
+      url.password !== "" ||
+      url.port !== "" ||
+      url.search !== "" ||
+      url.hash !== ""
+    ) {
+      throw invalidRegistry("The Registry repository is not a valid GitHub repository.");
+    }
+    slug = url.pathname
+      .replace(/^\//, "")
+      .replace(/\.git\/?$/, "")
+      .replace(/\/$/, "");
+  }
+  if (!/^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})\/[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})$/.test(slug)) {
+    throw invalidRegistry("The Registry repository must be a GitHub owner/repository name.");
+  }
+  return Object.freeze({
+    slug,
+    gitUrl: `https://github.com/${slug}.git`,
+    descriptorUrl: `https://raw.githubusercontent.com/${slug}/HEAD/.lorelum/registry.yaml`,
+  });
+}
+
+/** Load and validate a Registry descriptor from its repository. */
+export async function loadRegistry(
+  locator?: string,
+  fetchRegistry: typeof fetch = fetch,
+): Promise<LoadedRegistry> {
+  const repository = resolveRegistryRepository(locator);
+  let response: Response;
+  try {
+    response = await fetchRegistry(repository.descriptorUrl, {
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch {
+    throw new CliError(cliErrorCodes.registryUnavailable, "The Pack Registry is unavailable.");
+  }
+  if (!response.ok) {
+    throw new CliError(cliErrorCodes.registryUnavailable, "The Pack Registry is unavailable.");
+  }
+
+  const declaredSize = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredSize) && declaredSize > MAX_REGISTRY_BYTES) {
+    throw invalidRegistry();
+  }
+  const raw = await response.text();
+  if (new TextEncoder().encode(raw).byteLength > MAX_REGISTRY_BYTES) throw invalidRegistry();
+  try {
+    return Object.freeze({ registry: RegistrySchema.parse(parseYaml(raw)), repository });
+  } catch {
+    throw invalidRegistry();
+  }
+}

--- a/packages/cli/src/install/materialize-source.test.ts
+++ b/packages/cli/src/install/materialize-source.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test";
+import { chmod, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { RegistryRelease } from "@lorelum/format";
+
+import { materializeRegistryRelease } from "./materialize-source.js";
+
+async function git(directory: string, arguments_: readonly string[]): Promise<void> {
+  const process = Bun.spawn(["git", ...arguments_], {
+    cwd: directory,
+    stderr: "ignore",
+    stdout: "ignore",
+  });
+  if ((await process.exited) !== 0) throw new Error(`git ${arguments_[0]} failed`);
+}
+
+async function createReleaseSource(parent: string): Promise<{
+  release: RegistryRelease;
+  repository: string;
+}> {
+  const repository = join(parent, "source-repository");
+  await mkdir(join(repository, "packs", "agentic-coding", "practices"), { recursive: true });
+  await git(repository, ["init", "-b", "main"]);
+  await writeFile(join(repository, "packs", "agentic-coding", "pack.yaml"), "name: fixture\n");
+  await chmod(join(repository, "packs", "agentic-coding", "pack.yaml"), 0o755);
+  await writeFile(
+    join(repository, "packs", "agentic-coding", "practices", "需求.md"),
+    "Unicode filenames allowed by the Pack source-path contract.",
+  );
+  await writeFile(
+    join(repository, "packs", "agentic-coding", "ignored.bin"),
+    "This source-only file must not be materialized.",
+  );
+  await chmod(join(repository, "packs", "agentic-coding", "ignored.bin"), 0o755);
+  await git(repository, ["add", "."]);
+  await git(repository, [
+    "-c",
+    "user.name=Lorelum Test",
+    "-c",
+    "user.email=test@example.invalid",
+    "commit",
+    "-m",
+    "test fixture",
+  ]);
+  await git(repository, ["tag", "agentic-coding-v0.1.0"]);
+  return {
+    repository: pathToFileURL(repository).href,
+    release: {
+      version: "0.1.0",
+      ref: "agentic-coding-v0.1.0",
+      path: "packs/agentic-coding",
+    },
+  };
+}
+
+test("materializes only Pack files from a tagged repository subtree", async () => {
+  const parent = await mkdtemp(join(tmpdir(), "lorelum-materialize-test-"));
+  try {
+    const fixture = await createReleaseSource(parent);
+    const source = await materializeRegistryRelease(fixture.release, fixture.repository);
+    expect(source.resolvedCommit).toMatch(/^[0-9a-f]{40}$/);
+    expect(await Bun.file(join(source.directory, "pack.yaml")).text()).toContain("fixture");
+    expect(await Bun.file(join(source.directory, "practices", "需求.md")).exists()).toBe(true);
+    expect(await Bun.file(join(source.directory, "ignored.bin")).exists()).toBe(false);
+    const temporaryRoot = dirname(source.directory);
+    await source.cleanup();
+    expect(await Bun.file(temporaryRoot).exists()).toBe(false);
+  } finally {
+    await rm(parent, { force: true, recursive: true });
+  }
+});
+
+test("maps a missing release ref to source.unavailable", async () => {
+  const parent = await mkdtemp(join(tmpdir(), "lorelum-materialize-test-"));
+  try {
+    const fixture = await createReleaseSource(parent);
+    await expect(
+      materializeRegistryRelease({ ...fixture.release, ref: "missing-v9.0.0" }, fixture.repository),
+    ).rejects.toMatchObject({ code: "source.unavailable" });
+  } finally {
+    await rm(parent, { force: true, recursive: true });
+  }
+});

--- a/packages/cli/src/install/materialize-source.ts
+++ b/packages/cli/src/install/materialize-source.ts
@@ -1,0 +1,231 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { devNull, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { defaultPackDirectoryLimits, isPracticeSourcePath } from "@lorelum/engine";
+import type { RegistryRelease } from "@lorelum/format";
+
+import { CliError, cliErrorCodes } from "../runtime/errors.js";
+
+const GIT_TIMEOUT_MS = 60_000;
+const MAX_SOURCE_TREE_ENTRIES = 2_048;
+const MAX_SOURCE_TREE_LISTING_BYTES = 1024 * 1024;
+const GIT_ENVIRONMENT = Object.freeze({
+  PATH: process.env.PATH,
+  SystemRoot: process.env.SystemRoot,
+  TEMP: process.env.TEMP,
+  TMP: process.env.TMP,
+  TMPDIR: process.env.TMPDIR,
+  GIT_ASKPASS: "",
+  GIT_CONFIG_GLOBAL: devNull,
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_TERMINAL_PROMPT: "0",
+});
+
+interface SourceBlob {
+  readonly objectId: string;
+  readonly relativePath: string;
+}
+
+function sourceUnavailable(): CliError {
+  return new CliError(cliErrorCodes.sourceUnavailable, "The Pack source is unavailable.");
+}
+
+function sourceInvalid(): CliError {
+  return new CliError(cliErrorCodes.sourceInvalid, "The Pack source is invalid.");
+}
+
+export interface MaterializedPackSource {
+  readonly directory: string;
+  readonly resolvedRef: string;
+  readonly resolvedCommit: string;
+  cleanup(): Promise<void>;
+}
+
+async function runGit(arguments_: readonly string[], outputLimit?: number): Promise<Uint8Array> {
+  let subprocess: ReturnType<typeof Bun.spawn>;
+  try {
+    subprocess = Bun.spawn(["git", ...arguments_], {
+      env: GIT_ENVIRONMENT,
+      stderr: "ignore",
+      stdout: outputLimit === undefined ? "ignore" : "pipe",
+    });
+  } catch {
+    throw sourceUnavailable();
+  }
+  if (outputLimit !== undefined && !(subprocess.stdout instanceof ReadableStream)) {
+    throw sourceUnavailable();
+  }
+  const timeout = setTimeout(() => subprocess.kill(), GIT_TIMEOUT_MS);
+  try {
+    let output: Uint8Array | undefined;
+    if (outputLimit !== undefined) {
+      const reader = (subprocess.stdout as ReadableStream<Uint8Array>).getReader();
+      const chunks: Uint8Array[] = [];
+      let total = 0;
+      /* eslint-disable no-await-in-loop -- a process stream must be consumed serially */
+      for (;;) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        total += chunk.value.byteLength;
+        if (total > outputLimit) {
+          await reader.cancel();
+          throw sourceInvalid();
+        }
+        chunks.push(chunk.value);
+      }
+      /* eslint-enable no-await-in-loop */
+      output = new Uint8Array(total);
+      let offset = 0;
+      for (const chunk of chunks) {
+        output.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+    }
+    if ((await subprocess.exited) !== 0) throw sourceUnavailable();
+    return output ?? new Uint8Array();
+  } catch (error) {
+    try {
+      subprocess.kill();
+    } catch {
+      // The process already exited; retain the primary typed error.
+    }
+    await subprocess.exited.catch(() => undefined);
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function cloneRelease(ref: string, destination: string, repository: string): Promise<void> {
+  await runGit([
+    "-c",
+    "advice.detachedHead=false",
+    "clone",
+    "--depth",
+    "1",
+    "--single-branch",
+    "--branch",
+    ref,
+    "--filter=tree:0",
+    "--no-checkout",
+    "--",
+    repository,
+    destination,
+  ]);
+}
+
+async function readResolvedCommit(repositoryRoot: string): Promise<string> {
+  const output = await runGit(["-C", repositoryRoot, "rev-parse", "HEAD"], 256);
+  const commit = new TextDecoder().decode(output).trim();
+  if (!/^[0-9a-f]{40,64}$/.test(commit)) throw sourceInvalid();
+  return commit;
+}
+
+function isConsumedPackPath(path: string): boolean {
+  return path === "pack.yaml" || path === "decisions.yaml" || isPracticeSourcePath(path);
+}
+
+function parseSourceTree(output: Uint8Array, sourcePath: string): SourceBlob[] {
+  const entries = new TextDecoder().decode(output).split(String.fromCharCode(0)).filter(Boolean);
+  if (entries.length === 0 || entries.length > MAX_SOURCE_TREE_ENTRIES) {
+    throw sourceInvalid();
+  }
+
+  const prefix = `${sourcePath}/`;
+  const blobs: SourceBlob[] = [];
+  let practiceFiles = 0;
+  for (const entry of entries) {
+    const separator = entry.indexOf("\t");
+    if (separator < 0) throw sourceInvalid();
+    const header = entry.slice(0, separator);
+    const path = entry.slice(separator + 1);
+    const match = /^(\d{6}) (blob|tree|commit) ([0-9a-f]{40,64})$/.exec(header);
+    if (match === null) throw sourceInvalid();
+    if (!path.startsWith(prefix)) throw sourceInvalid();
+    const relativePath = path.slice(prefix.length);
+    if (!isConsumedPackPath(relativePath)) continue;
+    if (!["100644", "100755"].includes(match[1]!) || match[2] !== "blob") {
+      throw sourceInvalid();
+    }
+
+    if (isPracticeSourcePath(relativePath)) {
+      practiceFiles += 1;
+      if (practiceFiles > defaultPackDirectoryLimits.maxPracticeFiles) throw sourceInvalid();
+    }
+    blobs.push({ objectId: match[3]!, relativePath });
+  }
+  if (!blobs.some((blob) => blob.relativePath === "pack.yaml")) throw sourceInvalid();
+  return blobs;
+}
+
+async function inspectSourceTree(
+  repositoryRoot: string,
+  sourcePath: string,
+): Promise<SourceBlob[]> {
+  const output = await runGit(
+    [
+      "-C",
+      repositoryRoot,
+      "ls-tree",
+      "-r",
+      "-z",
+      "HEAD",
+      "--",
+      `${sourcePath}/pack.yaml`,
+      `${sourcePath}/decisions.yaml`,
+      `${sourcePath}/practices`,
+    ],
+    MAX_SOURCE_TREE_LISTING_BYTES,
+  );
+  return parseSourceTree(output, sourcePath);
+}
+
+async function materializeBlobs(
+  repositoryRoot: string,
+  blobs: readonly SourceBlob[],
+  targetDirectory: string,
+): Promise<void> {
+  await mkdir(join(targetDirectory, "practices"), { recursive: true });
+  let totalBytes = 0;
+  for (const blob of blobs) {
+    // eslint-disable-next-line no-await-in-loop -- bounded sequential reads keep byte accounting simple
+    const contents = await runGit(
+      ["-C", repositoryRoot, "cat-file", "blob", blob.objectId],
+      defaultPackDirectoryLimits.maxFileBytes,
+    );
+    totalBytes += contents.byteLength;
+    if (totalBytes > defaultPackDirectoryLimits.maxTotalBytes) throw sourceInvalid();
+    const target = join(targetDirectory, ...blob.relativePath.split("/"));
+    // eslint-disable-next-line no-await-in-loop -- each validated blob has one deterministic target
+    await mkdir(dirname(target), { recursive: true });
+    // eslint-disable-next-line no-await-in-loop -- writes remain serial with the shared byte budget
+    await writeFile(target, contents, { flag: "wx", mode: 0o600 });
+  }
+}
+
+/** Materialize only validated Pack blobs; no checkout or Git content filters run. */
+export async function materializeRegistryRelease(
+  release: RegistryRelease,
+  repository: string,
+): Promise<MaterializedPackSource> {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), "lorelum-install-"));
+  const repositoryRoot = join(temporaryRoot, "repository");
+  const packDirectory = join(temporaryRoot, "pack");
+  try {
+    await cloneRelease(release.ref, repositoryRoot, repository);
+    const resolvedCommit = await readResolvedCommit(repositoryRoot);
+    const blobs = await inspectSourceTree(repositoryRoot, release.path);
+    await materializeBlobs(repositoryRoot, blobs, packDirectory);
+    return {
+      directory: packDirectory,
+      resolvedRef: release.ref,
+      resolvedCommit,
+      cleanup: () => rm(temporaryRoot, { force: true, recursive: true }),
+    };
+  } catch (error) {
+    await rm(temporaryRoot, { force: true, recursive: true }).catch(() => undefined);
+    if (error instanceof CliError) throw error;
+    throw sourceInvalid();
+  }
+}

--- a/packages/cli/src/install/resolve-release.test.ts
+++ b/packages/cli/src/install/resolve-release.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import { RegistrySchema } from "@lorelum/format";
+
+import { resolveRegistryRelease } from "./resolve-release.js";
+
+function registry() {
+  return RegistrySchema.parse({
+    schema_version: 1,
+    name: "lorelum-official",
+    packs: [
+      {
+        name: "agentic-coding",
+        releases: [
+          { version: "2.0.0-beta.2", ref: "v2-beta", path: "packs/agentic-coding" },
+          { version: "1.2.0", ref: "v1.2", path: "packs/agentic-coding" },
+          { version: "1.10.0", ref: "v1.10", path: "packs/agentic-coding" },
+          { version: "1.0.0", ref: "v1", path: "packs/agentic-coding" },
+        ],
+      },
+    ],
+  });
+}
+
+describe("resolveRegistryRelease", () => {
+  test("selects the highest stable semver independent of YAML order", () => {
+    expect(resolveRegistryRelease(registry(), "agentic-coding").release.version).toBe("1.10.0");
+  });
+
+  test("selects an explicitly requested prerelease", () => {
+    expect(
+      resolveRegistryRelease(registry(), "agentic-coding", "2.0.0-beta.2").release.version,
+    ).toBe("2.0.0-beta.2");
+  });
+
+  test("does not fall back when an exact version is absent", () => {
+    expect(() => resolveRegistryRelease(registry(), "agentic-coding", "9.0.0")).toThrow(
+      'no release for version "9.0.0"',
+    );
+  });
+});

--- a/packages/cli/src/install/resolve-release.ts
+++ b/packages/cli/src/install/resolve-release.ts
@@ -1,0 +1,37 @@
+import type { Registry, RegistryPack, RegistryRelease } from "@lorelum/format";
+
+import { CliError, cliErrorCodes } from "../runtime/errors.js";
+
+interface ResolvedRegistryRelease {
+  readonly pack: RegistryPack;
+  readonly release: RegistryRelease;
+}
+
+export function resolveRegistryRelease(
+  registry: Registry,
+  packName: string,
+  requestedVersion?: string,
+): ResolvedRegistryRelease {
+  const pack = registry.packs.find((candidate) => candidate.name === packName);
+  if (pack === undefined) {
+    throw new CliError(
+      cliErrorCodes.registryPackNotFound,
+      `Pack "${packName}" is not present in the selected Registry.`,
+    );
+  }
+
+  const release =
+    requestedVersion === undefined
+      ? [...pack.releases]
+          .filter((candidate) => !candidate.version.split("+", 1)[0]!.includes("-"))
+          .sort((left, right) => Bun.semver.order(right.version, left.version))[0]
+      : pack.releases.find((candidate) => candidate.version === requestedVersion);
+  if (release === undefined) {
+    const message =
+      requestedVersion === undefined
+        ? `Pack "${packName}" has no stable release in the selected Registry.`
+        : `Pack "${packName}" has no release for version "${requestedVersion}".`;
+    throw new CliError(cliErrorCodes.registryVersionNotFound, message);
+  }
+  return { pack, release };
+}

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -29,7 +29,7 @@ test("returns machine-readable root capability discovery", async () => {
     ok: true,
     data: {
       name: "lore",
-      commands: [{ name: "describe" }],
+      commands: [{ name: "describe" }, { name: "install" }],
     },
   });
   expect(stderr.value).toBe("");

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -206,7 +206,11 @@ test("describes registered commands from a single registry", () => {
     commands: [
       {
         name: "describe",
-        positionals: [{ name: "command", values: ["describe"] }],
+        positionals: [{ name: "command", values: ["describe", "install"] }],
+      },
+      {
+        name: "install",
+        positionals: [{ name: "pack", required: true }],
       },
     ],
   });
@@ -216,6 +220,13 @@ test("describes registered commands from a single registry", () => {
       { behavior: "log-level", scope: "global" },
     ],
   });
+  const install = describeCommand("install") as { options: readonly { name: string }[] };
+  expect(install.options.map((option) => option.name)).toEqual([
+    "-h, --help",
+    "--log-level <level>",
+    "--pack-version <version>",
+    "--registry <repository>",
+  ]);
 });
 
 test("registers every command definition with an executable handler", () => {
@@ -238,7 +249,7 @@ test("derives parser options and describe metadata from registered commands", as
     ],
   });
   expect(describeCommand("describe", definitions)).toMatchObject({
-    positionals: [{ name: "command", values: ["describe", "future"] }],
+    positionals: [{ name: "command", values: ["describe", "install", "future"] }],
   });
 
   const stdout = new MemoryWriter();

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -6,6 +6,7 @@ import {
 } from "./output/protocol.js";
 import { frameworkErrorCodes, invalidInvocationError } from "./runtime/errors.js";
 import { logLevels } from "./runtime/logger.js";
+import { createInstallCommand } from "./install/install-command.js";
 
 export interface CommandOption {
   readonly longFlag: string;
@@ -189,20 +190,18 @@ const discoveryResultSchema: JsonSchema = {
   oneOf: [rootCapabilitySchema, commandCapabilitySchema],
 };
 
-const builtInCommandDefinitions = [
-  {
-    name: discoveryCommandName,
-    summary: "Return machine-readable command capabilities.",
-    positionals: [{ name: "command", required: false }],
-    options: [],
-    resultSchema: discoveryResultSchema,
-    errorCodes: frameworkErrorCodes,
-    exitCodes: [0, 2],
-    handler: (invocation) => ({
-      data: requireCommandDescription(invocation.describeCommand, invocation.positionals[0]),
-    }),
-  },
-] satisfies readonly CommandDefinition[];
+const discoveryCommandDefinition = {
+  name: discoveryCommandName,
+  summary: "Return machine-readable command capabilities.",
+  positionals: [{ name: "command", required: false }],
+  options: [],
+  resultSchema: discoveryResultSchema,
+  errorCodes: frameworkErrorCodes,
+  exitCodes: [0, 2],
+  handler: (invocation) => ({
+    data: requireCommandDescription(invocation.describeCommand, invocation.positionals[0]),
+  }),
+} satisfies CommandDefinition;
 
 /** Root parser metadata is separate because it is not an invokable child command. */
 export const rootCommand = snapshotCommandDefinition({
@@ -217,7 +216,10 @@ export const rootCommand = snapshotCommandDefinition({
 });
 
 /** Immutable child-command registry used unless a complete replacement is supplied. */
-export const commandRegistry = snapshotCommandDefinitions(builtInCommandDefinitions);
+export const commandRegistry = snapshotCommandDefinitions([
+  discoveryCommandDefinition,
+  createInstallCommand(),
+]);
 
 export type KnownCommand = "lore" | (typeof commandRegistry)[number]["name"];
 

--- a/packages/cli/src/runtime/errors.ts
+++ b/packages/cli/src/runtime/errors.ts
@@ -1,5 +1,16 @@
 export const cliErrorCodes = Object.freeze({
+  packInvalid: "pack.invalid",
+  packUpgradeRequired: "pack.upgrade-required",
+  practiceConflict: "practice.conflict",
+  registryInvalid: "registry.invalid",
+  registryPackNotFound: "registry.pack-not-found",
+  registryUnavailable: "registry.unavailable",
+  registryVersionNotFound: "registry.version-not-found",
   runtimeUnexpected: "runtime.unexpected",
+  sourceInvalid: "source.invalid",
+  sourceUnavailable: "source.unavailable",
+  storeBusy: "store.busy",
+  storeRecoveryRequired: "store.recovery-required",
   usageInvalid: "usage.invalid",
 });
 

--- a/packages/engine/src/local-store/index.ts
+++ b/packages/engine/src/local-store/index.ts
@@ -12,6 +12,13 @@ export {
   type StorageRoot,
 } from "./lifecycle/local-store";
 
+export {
+  decodeSnapshot as decodePackDirectory,
+  defaultPackDirectoryLimits,
+  type DecodedSnapshot as DecodedPackDirectory,
+  type PackDirectoryLimits,
+} from "./storage/artifacts/snapshot-codec";
+
 export type {
   InstallResult,
   MutationResultBase,
@@ -34,7 +41,7 @@ export {
   InvalidPracticeSourceError,
 } from "./model/errors";
 
-export { StoreBusyError, StoreRecoveryRequiredError } from "./storage/errors";
+export { SnapshotFormatError, StoreBusyError, StoreRecoveryRequiredError } from "./storage/errors";
 
 export type {
   PackCandidate,
@@ -42,3 +49,5 @@ export type {
   RevisionDelta,
   PracticeSource,
 } from "./model/types";
+
+export { isPracticeSourcePath } from "./model/candidate";

--- a/packages/engine/src/local-store/lifecycle/install.ts
+++ b/packages/engine/src/local-store/lifecycle/install.ts
@@ -132,6 +132,7 @@ export async function installOrUpgrade(
         delta: diffEffectivePractices([], []),
         diagnostics,
         cleanupPending: false,
+        artifactDigest,
         idempotent: true,
       });
     }
@@ -240,6 +241,7 @@ export async function installOrUpgrade(
       delta: reconciled.delta,
       diagnostics,
       cleanupPending,
+      artifactDigest,
       idempotent: false,
     });
   });

--- a/packages/engine/src/local-store/lifecycle/local-store.test.ts
+++ b/packages/engine/src/local-store/lifecycle/local-store.test.ts
@@ -109,6 +109,18 @@ test("fresh store open + install + reopen round-trips state", async () => {
   });
 });
 
+test("first install creates a missing storage root before acquiring its lock", async () => {
+  const parent = await mkdtemp(join(tmpdir(), "lorelum-store-parent-"));
+  const root = { rootPath: join(parent, "missing-store") };
+  try {
+    const installed = await createLocalStore().install(root, candidate("platform", platform));
+    expect(installed.generation).toBe(1);
+    expect(await readManifest(root.rootPath)).toMatchObject({ generation: 1 });
+  } finally {
+    await removeStoreRoot(parent);
+  }
+});
+
 test("install is idempotent for the same artifact digest", async () => {
   await withRoot(async (root) => {
     const store = createLocalStore();

--- a/packages/engine/src/local-store/lifecycle/mutation.ts
+++ b/packages/engine/src/local-store/lifecycle/mutation.ts
@@ -54,6 +54,10 @@ export async function withStoreMutation<T>(
   run: (context: MutationContext) => Promise<T>,
   options: MutationLockOptions = {},
 ): Promise<T> {
+  // A first install may target the default `~/.lorelum` before it exists.
+  // Directory creation is idempotent and must precede atomic lock-file create;
+  // recovery and every other store side effect still remain under the lock.
+  await mkdir(rootPath, { recursive: true });
   const lock = await acquireMutationLock(rootPath, {
     ...(options.waitMs === undefined ? {} : { waitMs: options.waitMs }),
   });

--- a/packages/engine/src/local-store/lifecycle/types.ts
+++ b/packages/engine/src/local-store/lifecycle/types.ts
@@ -16,6 +16,8 @@ export interface MutationResultBase {
 }
 
 export interface InstallResult extends MutationResultBase {
+  /** Digest of the canonical sealed Pack artifact active after the operation. */
+  artifactDigest: string;
   /** True when the candidate matched the already-active artifact digest. */
   idempotent: boolean;
 }

--- a/packages/engine/src/local-store/model/candidate.test.ts
+++ b/packages/engine/src/local-store/model/candidate.test.ts
@@ -53,6 +53,10 @@ describe("createPackCandidate", () => {
     illegalCharacter["react.api.layered-design"] = `practices/unsafe${String.fromCharCode(63)}.md`;
     expect(() => createPackCandidate(input, illegalCharacter)).toThrow(InvalidSourcePathError);
 
+    const controlCharacter = sourcePaths();
+    controlCharacter["react.api.layered-design"] = "practices/unsafe\nname.md";
+    expect(() => createPackCandidate(input, controlCharacter)).toThrow(InvalidSourcePathError);
+
     const unexpected = sourcePaths();
     unexpected["react.extra.practice"] = "practices/guide..draft.md";
     expect(() => createPackCandidate(input, unexpected)).toThrow(InvalidSourcePathError);

--- a/packages/engine/src/local-store/model/candidate.ts
+++ b/packages/engine/src/local-store/model/candidate.ts
@@ -24,6 +24,13 @@ function isWindowsReservedPathSegment(segment: string): boolean {
   );
 }
 
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}
+
 /** Verify a Pack-root-relative Practice source path without resolving it on disk. */
 export function isPracticeSourcePath(path: string): boolean {
   return (
@@ -36,7 +43,7 @@ export function isPracticeSourcePath(path: string): boolean {
     !path.includes("|") &&
     !path.includes(String.fromCharCode(34)) &&
     !path.includes(String.fromCharCode(63)) &&
-    !path.includes(String.fromCharCode(0)) &&
+    !hasControlCharacter(path) &&
     !path
       .split("/")
       .some(

--- a/packages/engine/src/local-store/storage/artifacts/snapshot-codec.test.ts
+++ b/packages/engine/src/local-store/storage/artifacts/snapshot-codec.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { PackValidationError } from "../../model";
+import { decodePackDirectory } from "../../index";
 import { decodeSnapshot } from "./snapshot-codec";
 
 async function withSnapshot(run: (path: string) => Promise<void>): Promise<void> {
@@ -61,5 +62,42 @@ test("SnapshotCodec rejects a symbolic pack manifest before parsing it", async (
     }
 
     await expect(decodeSnapshot(path)).rejects.toThrow("symbolic links are not allowed");
+  });
+});
+
+test("public Pack directory decoder enforces Practice-count and byte budgets", async () => {
+  await withSnapshot(async (path) => {
+    await expect(
+      decodePackDirectory(path, {
+        maxPracticeFiles: 0,
+        maxEntries: 2_048,
+        maxDirectories: 256,
+        maxDirectoryDepth: 32,
+        maxFileBytes: 256 * 1024,
+        maxTotalBytes: 16 * 1024 * 1024,
+      }),
+    ).rejects.toThrow("Practice file budget");
+
+    await expect(
+      decodePackDirectory(path, {
+        maxPracticeFiles: 10,
+        maxEntries: 2_048,
+        maxDirectories: 256,
+        maxDirectoryDepth: 32,
+        maxFileBytes: 8,
+        maxTotalBytes: 16 * 1024 * 1024,
+      }),
+    ).rejects.toThrow("per-file byte budget");
+
+    await expect(
+      decodePackDirectory(path, {
+        maxPracticeFiles: 10,
+        maxEntries: 0,
+        maxDirectories: 256,
+        maxDirectoryDepth: 32,
+        maxFileBytes: 256 * 1024,
+        maxTotalBytes: 16 * 1024 * 1024,
+      }),
+    ).rejects.toThrow("directory-entry budget");
   });
 });

--- a/packages/engine/src/local-store/storage/artifacts/snapshot-codec.ts
+++ b/packages/engine/src/local-store/storage/artifacts/snapshot-codec.ts
@@ -1,5 +1,4 @@
-import type { Dirent } from "node:fs";
-import { lstat, readdir, readFile } from "node:fs/promises";
+import { lstat, opendir, readFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
 import { parseFrontmatter, parseYaml, type ValidationIssue } from "@lorelum/format";
@@ -8,37 +7,85 @@ import { createPackCandidate, type PackCandidate } from "../../model";
 
 import { SnapshotFormatError } from "../errors";
 
+export interface PackDirectoryLimits {
+  readonly maxPracticeFiles: number;
+  readonly maxEntries: number;
+  readonly maxDirectories: number;
+  readonly maxDirectoryDepth: number;
+  readonly maxFileBytes: number;
+  readonly maxTotalBytes: number;
+}
+
+export const defaultPackDirectoryLimits: PackDirectoryLimits = Object.freeze({
+  maxPracticeFiles: 500,
+  maxEntries: 2_048,
+  maxDirectories: 256,
+  maxDirectoryDepth: 32,
+  maxFileBytes: 256 * 1024,
+  maxTotalBytes: 16 * 1024 * 1024,
+});
+
+interface DecodeBudget {
+  practiceFiles: number;
+  entries: number;
+  directories: number;
+  totalBytes: number;
+}
+
 function relativePath(rootPath: string, filePath: string): string {
   return relative(rootPath, filePath).split(sep).join("/");
 }
 
-async function discoverPractices(directory: string): Promise<string[]> {
-  let entries: Dirent[];
+async function discoverPractices(
+  directory: string,
+  limits: PackDirectoryLimits,
+  budget: DecodeBudget,
+  depth = 0,
+): Promise<string[]> {
+  if (depth > limits.maxDirectoryDepth) {
+    throw new SnapshotFormatError(directory, "practices directory exceeds the depth budget");
+  }
+  budget.directories += 1;
+  if (budget.directories > limits.maxDirectories) {
+    throw new SnapshotFormatError(directory, "snapshot exceeds the directory budget");
+  }
+  let directoryHandle;
   try {
-    entries = await readdir(directory, { withFileTypes: true });
+    directoryHandle = await opendir(directory);
   } catch (error) {
     throw new SnapshotFormatError(directory, "cannot read practices directory", error);
   }
   const paths: string[] = [];
-  async function visit(index: number): Promise<void> {
-    const entry = entries[index];
-    if (entry === undefined) return;
+  /* eslint-disable no-await-in-loop -- recursive discovery follows one bounded directory stream */
+  for await (const entry of directoryHandle) {
+    budget.entries += 1;
+    if (budget.entries > limits.maxEntries) {
+      throw new SnapshotFormatError(directory, "snapshot exceeds the directory-entry budget");
+    }
     const path = join(directory, entry.name);
     if (entry.isSymbolicLink()) {
       throw new SnapshotFormatError(directory, "symbolic links are not allowed in a snapshot");
     }
     if (entry.isDirectory()) {
-      paths.push(...(await discoverPractices(path)));
+      paths.push(...(await discoverPractices(path, limits, budget, depth + 1)));
     } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      budget.practiceFiles += 1;
+      if (budget.practiceFiles > limits.maxPracticeFiles) {
+        throw new SnapshotFormatError(directory, "snapshot exceeds the Practice file budget");
+      }
       paths.push(path);
     }
-    await visit(index + 1);
   }
-  await visit(0);
+  /* eslint-enable no-await-in-loop */
   return paths.sort();
 }
 
-async function readSnapshotFile(snapshotPath: string, path: string): Promise<string> {
+async function readSnapshotFile(
+  snapshotPath: string,
+  path: string,
+  limits: PackDirectoryLimits,
+  budget: DecodeBudget,
+): Promise<string> {
   try {
     const metadata = await lstat(path);
     if (metadata.isSymbolicLink()) {
@@ -47,7 +94,18 @@ async function readSnapshotFile(snapshotPath: string, path: string): Promise<str
     if (!metadata.isFile()) {
       throw new SnapshotFormatError(snapshotPath, "snapshot path is not a regular file");
     }
-    return await readFile(path, "utf8");
+    if (metadata.size > limits.maxFileBytes) {
+      throw new SnapshotFormatError(snapshotPath, "snapshot file exceeds the per-file byte budget");
+    }
+    const contents = await readFile(path);
+    if (contents.byteLength > limits.maxFileBytes) {
+      throw new SnapshotFormatError(snapshotPath, "snapshot file exceeds the per-file byte budget");
+    }
+    budget.totalBytes += contents.byteLength;
+    if (budget.totalBytes > limits.maxTotalBytes) {
+      throw new SnapshotFormatError(snapshotPath, "snapshot exceeds the total byte budget");
+    }
+    return contents.toString("utf8");
   } catch (error) {
     if (error instanceof SnapshotFormatError) throw error;
     throw new SnapshotFormatError(
@@ -61,23 +119,26 @@ async function readSnapshotFile(snapshotPath: string, path: string): Promise<str
 async function decodePracticeFiles(
   snapshotPath: string,
   practicePaths: readonly string[],
+  limits: PackDirectoryLimits,
+  budget: DecodeBudget,
 ): Promise<unknown[]> {
   const practices: unknown[] = [];
-  async function visit(index: number): Promise<void> {
-    const path = practicePaths[index];
-    if (path === undefined) return;
-    practices.push(await decodePracticeFile(snapshotPath, path));
-    await visit(index + 1);
+  for (const path of practicePaths) {
+    // eslint-disable-next-line no-await-in-loop -- decoding shares one total-byte budget
+    practices.push(await decodePracticeFile(snapshotPath, path, limits, budget));
   }
-  await visit(0);
   return practices;
 }
 
-async function decodeDecisions(snapshotPath: string): Promise<unknown[]> {
+async function decodeDecisions(
+  snapshotPath: string,
+  limits: PackDirectoryLimits,
+  budget: DecodeBudget,
+): Promise<unknown[]> {
   const path = join(snapshotPath, "decisions.yaml");
   let raw: string;
   try {
-    raw = await readSnapshotFile(snapshotPath, path);
+    raw = await readSnapshotFile(snapshotPath, path, limits, budget);
   } catch (error) {
     if (
       error instanceof SnapshotFormatError &&
@@ -107,10 +168,15 @@ export interface DecodedSnapshot {
   diagnostics: readonly ValidationIssue[];
 }
 
-async function decodePracticeFile(snapshotPath: string, path: string): Promise<unknown> {
+async function decodePracticeFile(
+  snapshotPath: string,
+  path: string,
+  limits: PackDirectoryLimits,
+  budget: DecodeBudget,
+): Promise<unknown> {
   let frontmatter;
   try {
-    frontmatter = parseFrontmatter(await readSnapshotFile(snapshotPath, path));
+    frontmatter = parseFrontmatter(await readSnapshotFile(snapshotPath, path, limits, budget));
   } catch (error) {
     if (error instanceof SnapshotFormatError) throw error;
     throw new SnapshotFormatError(
@@ -123,16 +189,25 @@ async function decodePracticeFile(snapshotPath: string, path: string): Promise<u
 }
 
 /** Reads Pack files and applies the format validation gate before storage sees a candidate. */
-export async function decodeSnapshot(snapshotPath: string): Promise<DecodedSnapshot> {
-  const rawPack = await readSnapshotFile(snapshotPath, join(snapshotPath, "pack.yaml"));
+export async function decodeSnapshot(
+  snapshotPath: string,
+  limits: PackDirectoryLimits = defaultPackDirectoryLimits,
+): Promise<DecodedSnapshot> {
+  const budget: DecodeBudget = { practiceFiles: 0, entries: 0, directories: 0, totalBytes: 0 };
+  const rawPack = await readSnapshotFile(
+    snapshotPath,
+    join(snapshotPath, "pack.yaml"),
+    limits,
+    budget,
+  );
   let parsedYaml: unknown;
   try {
     parsedYaml = parseYaml(rawPack);
   } catch (error) {
     throw new SnapshotFormatError(snapshotPath, "pack.yaml cannot be parsed as YAML", error);
   }
-  const practicePaths = await discoverPractices(join(snapshotPath, "practices"));
-  const practices = await decodePracticeFiles(snapshotPath, practicePaths);
+  const practicePaths = await discoverPractices(join(snapshotPath, "practices"), limits, budget);
+  const practices = await decodePracticeFiles(snapshotPath, practicePaths, limits, budget);
   const sourcePaths: Record<string, string> = Object.create(null) as Record<string, string>;
   for (const [index, practice] of practices.entries()) {
     const practicePath = practicePaths[index];
@@ -153,7 +228,7 @@ export async function decodeSnapshot(snapshotPath: string): Promise<DecodedSnaps
   const input = {
     pack: parsedYaml,
     practices,
-    decisions: await decodeDecisions(snapshotPath),
+    decisions: await decodeDecisions(snapshotPath, limits, budget),
   };
   return Object.freeze(createPackCandidate(input, sourcePaths));
 }

--- a/packages/format/src/schema/common.test.ts
+++ b/packages/format/src/schema/common.test.ts
@@ -44,7 +44,7 @@ describe("SEMVER_REGEX", () => {
     },
   );
 
-  test.each(["1.2", "v1.2.3", "01.2.3", "1.2.3.beta", ""])("rejects %p", (v) => {
+  test.each(["1.2", "v1.2.3", "01.2.3", "1.0.0-01", "1.2.3.beta", ""])("rejects %p", (v) => {
     expect(SEMVER_REGEX.test(v)).toBe(false);
   });
 });

--- a/packages/format/src/schema/common.ts
+++ b/packages/format/src/schema/common.ts
@@ -12,7 +12,7 @@ export const PACK_NAME_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 /** Semver (zod has no built-in helper): x.y.z with optional prerelease/build. */
 export const SEMVER_REGEX =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
 
 export const SeverityEnum = z
   .enum(["info", "warn", "critical"])

--- a/packages/format/src/schema/index.ts
+++ b/packages/format/src/schema/index.ts
@@ -2,3 +2,4 @@ export * from "./common";
 export * from "./pack";
 export * from "./practice";
 export * from "./decision";
+export * from "./registry";

--- a/packages/format/src/schema/registry.test.ts
+++ b/packages/format/src/schema/registry.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import { RegistrySchema } from "./registry";
+
+function registry(): {
+  schema_version: 1;
+  name: string;
+  extra?: boolean;
+  packs: Array<{
+    name: string;
+    releases: Array<{ version: string; ref: string; path: string }>;
+  }>;
+} {
+  return {
+    schema_version: 1,
+    name: "lorelum-official",
+    packs: [
+      {
+        name: "agentic-coding",
+        releases: [
+          {
+            version: "0.1.0",
+            ref: "agentic-coding-v0.1.0",
+            path: "packs/agentic-coding",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("RegistrySchema", () => {
+  test("accepts a version, ref, and Pack path", () => {
+    expect(RegistrySchema.parse(registry()).packs[0]?.releases[0]?.version).toBe("0.1.0");
+  });
+
+  test("rejects unknown fields", () => {
+    const input = registry();
+    input.extra = true;
+    expect(RegistrySchema.safeParse(input).success).toBe(false);
+  });
+
+  test("rejects duplicate pack names", () => {
+    const input = registry();
+    input.packs.push(structuredClone(input.packs[0]!));
+    const result = RegistrySchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.message.includes("duplicate pack"))).toBe(
+        true,
+      );
+    }
+  });
+
+  test("rejects duplicate semver precedence", () => {
+    const input = registry();
+    input.packs[0]!.releases.push({
+      version: "0.1.0+rebuilt",
+      ref: "rebuilt",
+      path: "packs/agentic-coding",
+    });
+    expect(RegistrySchema.safeParse(input).success).toBe(false);
+  });
+
+  test("rejects numeric prerelease identifiers with leading zeros", () => {
+    const input = registry();
+    input.packs[0]!.releases[0]!.version = "1.0.0-01";
+    expect(RegistrySchema.safeParse(input).success).toBe(false);
+  });
+
+  test("rejects traversal paths and malformed refs", () => {
+    const badPath = registry();
+    badPath.packs[0]!.releases[0]!.path = "packs/../agentic-coding";
+    expect(RegistrySchema.safeParse(badPath).success).toBe(false);
+
+    const badRef = registry();
+    badRef.packs[0]!.releases[0]!.ref = "refs//main";
+    expect(RegistrySchema.safeParse(badRef).success).toBe(false);
+  });
+});

--- a/packages/format/src/schema/registry.ts
+++ b/packages/format/src/schema/registry.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+import { PACK_NAME_REGEX, SEMVER_REGEX } from "./common";
+
+export const REGISTRY_SCHEMA_VERSION = 1 as const;
+
+const SourcePathSchema = z
+  .string()
+  .regex(
+    /^[A-Za-z0-9][A-Za-z0-9._-]*(?:\/[A-Za-z0-9][A-Za-z0-9._-]*)*$/,
+    "path must be a safe repository-relative path",
+  );
+
+const GitRefSchema = z
+  .string()
+  .regex(/^(?!-)(?!.*\.\.)(?!.*@\{)[A-Za-z0-9][A-Za-z0-9._/-]*$/, "ref is unsafe")
+  .refine(
+    (ref) =>
+      !ref.endsWith(".") &&
+      !ref.endsWith("/") &&
+      ref
+        .split("/")
+        .every(
+          (segment) => segment.length > 0 && !segment.startsWith(".") && !segment.endsWith(".lock"),
+        ),
+    "ref is unsafe",
+  );
+
+export const RegistryReleaseSchema = z
+  .object({
+    version: z.string().regex(SEMVER_REGEX, "version must be semver"),
+    ref: GitRefSchema,
+    path: SourcePathSchema,
+  })
+  .strict();
+
+export const RegistryPackSchema = z
+  .object({
+    name: z.string().regex(PACK_NAME_REGEX, "pack name must be kebab-case"),
+    description: z.string().min(1).optional(),
+    releases: z.array(RegistryReleaseSchema).min(1).max(128),
+  })
+  .strict()
+  .superRefine((pack, context) => {
+    const precedences = new Set<string>();
+    for (const [index, release] of pack.releases.entries()) {
+      const precedence = release.version.split("+", 1)[0]!;
+      if (precedences.has(precedence)) {
+        context.addIssue({
+          code: "custom",
+          path: ["releases", index, "version"],
+          message: `release version "${release.version}" has duplicate semver precedence`,
+        });
+      }
+      precedences.add(precedence);
+    }
+  });
+
+/** Repository catalog descriptor consumed by `lore install`. */
+export const RegistrySchema = z
+  .object({
+    schema_version: z.literal(REGISTRY_SCHEMA_VERSION),
+    name: z.string().regex(PACK_NAME_REGEX, "registry name must be kebab-case"),
+    description: z.string().min(1).optional(),
+    packs: z.array(RegistryPackSchema).max(256),
+  })
+  .strict()
+  .superRefine((registry, context) => {
+    const names = new Set<string>();
+    for (const [index, pack] of registry.packs.entries()) {
+      if (names.has(pack.name)) {
+        context.addIssue({
+          code: "custom",
+          path: ["packs", index, "name"],
+          message: `duplicate pack name "${pack.name}"`,
+        });
+      }
+      names.add(pack.name);
+    }
+  });
+
+export type Registry = z.infer<typeof RegistrySchema>;
+export type RegistryPack = z.infer<typeof RegistryPackSchema>;
+export type RegistryRelease = z.infer<typeof RegistryReleaseSchema>;


### PR DESCRIPTION
## Summary

- add the strict Registry v1 schema and deterministic release resolution
- add `lore install <pack>` with the built-in official Registry repository and explicit `--registry owner/repo`
- materialize only bounded Pack files from Git without checkout or source execution
- reuse the engine Pack decoder, return the active LocalStore artifact digest, and create a missing user Store root
- document the repository Registry and user-scope install contract in ADR 0008

## Scope

This PR intentionally excludes project scope, local/file/HTTP Registry fallback, persistent Registry configuration, private repository authentication, dependency resolution, and upgrade/uninstall CLI commands.

## Verification

- `bun test` — 252 passed
- `bun run typecheck`
- `bun run lint`
- `bun run test:integration`
- changed-file `oxfmt --check`
- `git diff --check`
- staged and branch secret-pattern scans

Full-repository `fmt:check` still reports the existing 11-file baseline outside this PR.

Closes #37