### PR TITLE
fix(cli): batch Pack blob materialization

### DIFF
--- a/packages/cli/src/install/materialize-source.test.ts
+++ b/packages/cli/src/install/materialize-source.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "bun:test";
 import { defaultPackDirectoryLimits } from "@lorelum/engine";
 import type { RegistryRelease } from "@lorelum/format";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { devNull, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { CliError, cliErrorCodes } from "../runtime/errors.js";
 import { materializeRegistryRelease, type MaterializeGitRunner } from "./materialize-source.js";
@@ -161,6 +164,33 @@ function inputLines(call: GitCall): string[] {
   return new TextDecoder().decode(call.input).trimEnd().split("\n");
 }
 
+async function setupGit(directory: string, gitArguments: readonly string[]): Promise<string> {
+  const subprocess = Bun.spawn(["git", ...gitArguments], {
+    cwd: directory,
+    env: {
+      PATH: process.env.PATH,
+      SystemRoot: process.env.SystemRoot,
+      TEMP: process.env.TEMP,
+      TMP: process.env.TMP,
+      TMPDIR: process.env.TMPDIR,
+      GIT_CONFIG_GLOBAL: devNull,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_TERMINAL_PROMPT: "0",
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(subprocess.stdout).text(),
+    new Response(subprocess.stderr).text(),
+    subprocess.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`git ${gitArguments[0] ?? "command"} failed: ${stderr.trim()}`);
+  }
+  return stdout.trim();
+}
+
 test("materializes many Pack blobs with one exact acquisition and one local batch read", async () => {
   const git = new FakeGit(packEntries());
   const source = await materializeRegistryRelease(release, repository, git.run);
@@ -201,6 +231,96 @@ test("materializes many Pack blobs with one exact acquisition and one local batc
     const temporaryRoot = git.temporaryRoot();
     await source.cleanup();
     expect(await Bun.file(temporaryRoot).exists()).toBe(false);
+  }
+});
+
+test("production runner materializes a filtered local Git remote through batch stdin", async () => {
+  const parent = await mkdtemp(join(tmpdir(), "lorelum-materialize-git-test-"));
+  const sourceRepository = join(parent, "source");
+  const remoteRepository = join(parent, "remote.git");
+  await mkdir(join(sourceRepository, release.path, "practices"), { recursive: true });
+  await setupGit(sourceRepository, ["init", "-b", "main"]);
+  await writeFile(
+    join(sourceRepository, release.path, "pack.yaml"),
+    "name: agentic-coding\nversion: 0.2.0\n",
+  );
+  await writeFile(
+    join(sourceRepository, release.path, "practices", "需求.md"),
+    "Unicode Practice from a promisor remote.\n",
+  );
+  await writeFile(
+    join(sourceRepository, release.path, "ignored.bin"),
+    "Repository content outside the Pack materialization contract.\n",
+  );
+  await setupGit(sourceRepository, ["add", "."]);
+  await setupGit(sourceRepository, [
+    "-c",
+    "user.name=Lorelum Test",
+    "-c",
+    "user.email=test@example.invalid",
+    "commit",
+    "-m",
+    "fixture",
+  ]);
+  await setupGit(sourceRepository, ["tag", release.ref]);
+  const expectedCommit = await setupGit(sourceRepository, ["rev-parse", "HEAD"]);
+  await setupGit(parent, ["clone", "--bare", "--", sourceRepository, remoteRepository]);
+  await setupGit(parent, ["-C", remoteRepository, "config", "uploadpack.allowFilter", "true"]);
+
+  let source: Awaited<ReturnType<typeof materializeRegistryRelease>> | undefined;
+  try {
+    source = await materializeRegistryRelease(release, pathToFileURL(remoteRepository).href);
+    expect(source.resolvedCommit).toBe(expectedCommit);
+    expect(
+      await setupGit(parent, [
+        "-C",
+        join(dirname(source.directory), "repository"),
+        "config",
+        "--get",
+        "remote.origin.promisor",
+      ]),
+    ).toBe("true");
+    expect(await Bun.file(join(source.directory, "pack.yaml")).text()).toContain(
+      "name: agentic-coding",
+    );
+    expect(await Bun.file(join(source.directory, "practices", "需求.md")).text()).toBe(
+      "Unicode Practice from a promisor remote.\n",
+    );
+    expect(await Bun.file(join(source.directory, "ignored.bin")).exists()).toBe(false);
+    const temporaryRoot = dirname(source.directory);
+    await source.cleanup();
+    source = undefined;
+    expect(await Bun.file(temporaryRoot).exists()).toBe(false);
+  } finally {
+    await source?.cleanup().catch(() => undefined);
+    await rm(parent, { force: true, recursive: true });
+  }
+});
+
+test("fetches a shared object once and reads it for every validated target", async () => {
+  const sharedPractice = entry("practices/first.md", "Shared Practice contents.\n", 2);
+  const git = new FakeGit([
+    entry("pack.yaml", "name: fixture\nversion: 0.2.0\n", 1),
+    sharedPractice,
+    {
+      ...entry("practices/second.md", "Shared Practice contents.\n", 3),
+      objectId: sharedPractice.objectId,
+    },
+  ]);
+  const source = await materializeRegistryRelease(release, repository, git.run);
+  try {
+    expect(inputLines(git.callsFor("fetch")[0]!)).toHaveLength(2);
+    const readObjectIds = inputLines(git.callsFor("cat-file")[0]!);
+    expect(readObjectIds).toHaveLength(3);
+    expect(readObjectIds.filter((id) => id === sharedPractice.objectId)).toHaveLength(2);
+    expect(await Bun.file(join(source.directory, "practices", "first.md")).text()).toBe(
+      "Shared Practice contents.\n",
+    );
+    expect(await Bun.file(join(source.directory, "practices", "second.md")).text()).toBe(
+      "Shared Practice contents.\n",
+    );
+  } finally {
+    await source.cleanup();
   }
 });
 

--- a/packages/cli/src/install/materialize-source.test.ts
+++ b/packages/cli/src/install/materialize-source.test.ts
@@ -1,86 +1,329 @@
 import { expect, test } from "bun:test";
-import { chmod, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { pathToFileURL } from "node:url";
-
+import { defaultPackDirectoryLimits } from "@lorelum/engine";
 import type { RegistryRelease } from "@lorelum/format";
+import { dirname, join } from "node:path";
 
-import { materializeRegistryRelease } from "./materialize-source.js";
+import { CliError, cliErrorCodes } from "../runtime/errors.js";
+import { materializeRegistryRelease, type MaterializeGitRunner } from "./materialize-source.js";
 
-async function git(directory: string, arguments_: readonly string[]): Promise<void> {
-  const process = Bun.spawn(["git", ...arguments_], {
-    cwd: directory,
-    stderr: "ignore",
-    stdout: "ignore",
-  });
-  if ((await process.exited) !== 0) throw new Error(`git ${arguments_[0]} failed`);
+const release: RegistryRelease = {
+  version: "0.2.0",
+  ref: "agentic-coding-v0.2.0",
+  path: "packs/agentic-coding",
+};
+const repository = "https://github.com/lorelum/lorelum-packs.git";
+const resolvedCommit = "f".repeat(40);
+
+interface TreeEntry {
+  readonly contents: Uint8Array;
+  readonly mode: string;
+  readonly objectId: string;
+  readonly path: string;
+  readonly type: "blob" | "commit" | "tree";
 }
 
-async function createReleaseSource(parent: string): Promise<{
-  release: RegistryRelease;
-  repository: string;
-}> {
-  const repository = join(parent, "source-repository");
-  await mkdir(join(repository, "packs", "agentic-coding", "practices"), { recursive: true });
-  await git(repository, ["init", "-b", "main"]);
-  await writeFile(join(repository, "packs", "agentic-coding", "pack.yaml"), "name: fixture\n");
-  await chmod(join(repository, "packs", "agentic-coding", "pack.yaml"), 0o755);
-  await writeFile(
-    join(repository, "packs", "agentic-coding", "practices", "需求.md"),
-    "Unicode filenames allowed by the Pack source-path contract.",
-  );
-  await writeFile(
-    join(repository, "packs", "agentic-coding", "ignored.bin"),
-    "This source-only file must not be materialized.",
-  );
-  await chmod(join(repository, "packs", "agentic-coding", "ignored.bin"), 0o755);
-  await git(repository, ["add", "."]);
-  await git(repository, [
-    "-c",
-    "user.name=Lorelum Test",
-    "-c",
-    "user.email=test@example.invalid",
-    "commit",
-    "-m",
-    "test fixture",
-  ]);
-  await git(repository, ["tag", "agentic-coding-v0.1.0"]);
+interface GitCall {
+  readonly args: readonly string[];
+  readonly input?: Uint8Array;
+  readonly outputLimit?: number;
+}
+
+function bytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function concat(chunks: readonly Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(chunks.reduce((total, chunk) => total + chunk.byteLength, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+function objectId(index: number): string {
+  return index.toString(16).padStart(40, "0");
+}
+
+function entry(
+  relativePath: string,
+  contents: string | Uint8Array,
+  index: number,
+  options: Partial<Pick<TreeEntry, "mode" | "type">> = {},
+): TreeEntry {
   return {
-    repository: pathToFileURL(repository).href,
-    release: {
-      version: "0.1.0",
-      ref: "agentic-coding-v0.1.0",
-      path: "packs/agentic-coding",
-    },
+    contents: typeof contents === "string" ? bytes(contents) : contents,
+    mode: options.mode ?? "100644",
+    objectId: objectId(index),
+    path: `${release.path}/${relativePath}`,
+    type: options.type ?? "blob",
   };
 }
 
-test("materializes only Pack files from a tagged repository subtree", async () => {
-  const parent = await mkdtemp(join(tmpdir(), "lorelum-materialize-test-"));
+function packEntries(practiceCount = 29): TreeEntry[] {
+  const entries = [
+    entry("pack.yaml", "name: agentic-coding\nversion: 0.2.0\n", 1, { mode: "100755" }),
+    entry("decisions.yaml", "[]\n", 2),
+  ];
+  for (let index = 0; index < practiceCount; index += 1) {
+    entries.push(
+      entry(
+        `practices/practice-${index.toString().padStart(2, "0")}.md`,
+        `Practice ${index}\n`,
+        index + 3,
+      ),
+    );
+  }
+  entries.push(entry("ignored.bin", "not materialized", practiceCount + 3));
+  return entries.reverse();
+}
+
+class FakeGit {
+  readonly calls: GitCall[] = [];
+  batchOutput?: (objectIds: readonly string[]) => Uint8Array;
+  cloneError?: Error;
+  fetchError?: Error;
+
+  constructor(readonly entries: readonly TreeEntry[]) {}
+
+  readonly run: MaterializeGitRunner = async (gitArguments, options) => {
+    this.calls.push({
+      args: [...gitArguments],
+      ...(options?.input === undefined ? {} : { input: options.input }),
+      ...(options?.outputLimit === undefined ? {} : { outputLimit: options.outputLimit }),
+    });
+    if (gitArguments.includes("clone")) {
+      if (this.cloneError !== undefined) throw this.cloneError;
+      return new Uint8Array();
+    }
+    if (gitArguments.includes("rev-parse")) return bytes(`${resolvedCommit}\n`);
+    if (gitArguments.includes("ls-tree")) {
+      return bytes(
+        this.entries
+          .map(
+            (source) =>
+              `${source.mode} ${source.type} ${source.objectId}\t${source.path}${String.fromCharCode(0)}`,
+          )
+          .join(""),
+      );
+    }
+    if (gitArguments.includes("fetch")) {
+      if (this.fetchError !== undefined) throw this.fetchError;
+      return new Uint8Array();
+    }
+    if (gitArguments.some((argument) => argument.startsWith("--batch="))) {
+      const objectIds = this.readObjectIds(options?.input);
+      return this.batchOutput?.(objectIds) ?? this.encodeBatch(objectIds);
+    }
+    throw new Error(`Unexpected Git command: ${gitArguments.join(" ")}`);
+  };
+
+  private readObjectIds(input: Uint8Array | undefined): string[] {
+    if (input === undefined) throw new Error("Expected object ids on stdin");
+    return new TextDecoder().decode(input).trimEnd().split("\n");
+  }
+
+  private encodeBatch(objectIds: readonly string[]): Uint8Array {
+    const chunks: Uint8Array[] = [];
+    for (const id of objectIds) {
+      const source = this.entries.find((candidate) => candidate.objectId === id);
+      if (source === undefined) {
+        chunks.push(bytes(`${id} missing\n`));
+        continue;
+      }
+      chunks.push(
+        bytes(`${id} ${source.type} ${source.contents.byteLength}\n`),
+        source.contents,
+        bytes("\n"),
+      );
+    }
+    return concat(chunks);
+  }
+
+  callsFor(command: string): GitCall[] {
+    return this.calls.filter((call) =>
+      command === "cat-file"
+        ? call.args.some((argument) => argument.startsWith("--batch="))
+        : call.args.includes(command),
+    );
+  }
+
+  temporaryRoot(): string {
+    const clone = this.callsFor("clone")[0];
+    if (clone === undefined) throw new Error("clone was not called");
+    return dirname(clone.args.at(-1)!);
+  }
+}
+
+function inputLines(call: GitCall): string[] {
+  if (call.input === undefined) throw new Error("Expected Git stdin");
+  return new TextDecoder().decode(call.input).trimEnd().split("\n");
+}
+
+test("materializes many Pack blobs with one exact acquisition and one local batch read", async () => {
+  const git = new FakeGit(packEntries());
+  const source = await materializeRegistryRelease(release, repository, git.run);
   try {
-    const fixture = await createReleaseSource(parent);
-    const source = await materializeRegistryRelease(fixture.release, fixture.repository);
-    expect(source.resolvedCommit).toMatch(/^[0-9a-f]{40}$/);
-    expect(await Bun.file(join(source.directory, "pack.yaml")).text()).toContain("fixture");
-    expect(await Bun.file(join(source.directory, "practices", "需求.md")).exists()).toBe(true);
+    expect(source.resolvedCommit).toBe(resolvedCommit);
+    expect(await Bun.file(join(source.directory, "pack.yaml")).text()).toContain(
+      "name: agentic-coding",
+    );
+    expect(await Bun.file(join(source.directory, "decisions.yaml")).text()).toBe("[]\n");
+    const practiceContents = await Promise.all(
+      Array.from({ length: 29 }, (_, index) =>
+        Bun.file(
+          join(source.directory, "practices", `practice-${index.toString().padStart(2, "0")}.md`),
+        ).text(),
+      ),
+    );
+    for (const [index, contents] of practiceContents.entries()) {
+      expect(contents).toBe(`Practice ${index}\n`);
+    }
     expect(await Bun.file(join(source.directory, "ignored.bin")).exists()).toBe(false);
-    const temporaryRoot = dirname(source.directory);
+
+    expect(git.calls).toHaveLength(5);
+    expect(git.callsFor("fetch")).toHaveLength(1);
+    expect(git.callsFor("cat-file")).toHaveLength(1);
+    const fetched = inputLines(git.callsFor("fetch")[0]!);
+    const read = inputLines(git.callsFor("cat-file")[0]!);
+    expect(fetched).toEqual(read);
+    expect(fetched).toHaveLength(31);
+    expect(git.callsFor("fetch")[0]?.args).toContain("fetch.negotiationAlgorithm=noop");
+    expect(git.callsFor("fetch")[0]?.args).toContain("--filter=blob:none");
+    expect(git.callsFor("fetch")[0]?.args).toContain("--no-auto-gc");
+    expect(git.callsFor("cat-file")[0]?.args[0]).toBe("-C");
+    expect(git.callsFor("cat-file")[0]?.outputLimit).toBe(
+      defaultPackDirectoryLimits.maxTotalBytes + fetched.length * 128,
+    );
+    expect(git.calls.some((call) => call.args.includes("checkout"))).toBe(false);
+  } finally {
+    const temporaryRoot = git.temporaryRoot();
     await source.cleanup();
     expect(await Bun.file(temporaryRoot).exists()).toBe(false);
-  } finally {
-    await rm(parent, { force: true, recursive: true });
   }
 });
 
-test("maps a missing release ref to source.unavailable", async () => {
-  const parent = await mkdtemp(join(tmpdir(), "lorelum-materialize-test-"));
+test("materializes a Unicode Practice path without optional decisions", async () => {
+  const git = new FakeGit([
+    entry("pack.yaml", "name: fixture\nversion: 0.2.0\n", 1),
+    entry("practices/需求.md", "Unicode Practice path.\n", 2),
+  ]);
+  const source = await materializeRegistryRelease(release, repository, git.run);
   try {
-    const fixture = await createReleaseSource(parent);
-    await expect(
-      materializeRegistryRelease({ ...fixture.release, ref: "missing-v9.0.0" }, fixture.repository),
-    ).rejects.toMatchObject({ code: "source.unavailable" });
+    expect(await Bun.file(join(source.directory, "practices", "需求.md")).text()).toBe(
+      "Unicode Practice path.\n",
+    );
+    expect(await Bun.file(join(source.directory, "decisions.yaml")).exists()).toBe(false);
   } finally {
-    await rm(parent, { force: true, recursive: true });
+    await source.cleanup();
   }
+});
+
+test("maps a missing release ref to source.unavailable and cleans the temporary source", async () => {
+  const git = new FakeGit(packEntries());
+  git.cloneError = new CliError(cliErrorCodes.sourceUnavailable, "mock unavailable source");
+  await expect(materializeRegistryRelease(release, repository, git.run)).rejects.toMatchObject({
+    code: "source.unavailable",
+  });
+  expect(await Bun.file(git.temporaryRoot()).exists()).toBe(false);
+});
+
+test("preserves source.unavailable from batched object acquisition", async () => {
+  const git = new FakeGit(packEntries());
+  git.fetchError = new CliError(cliErrorCodes.sourceUnavailable, "mock unavailable objects");
+  await expect(materializeRegistryRelease(release, repository, git.run)).rejects.toMatchObject({
+    code: "source.unavailable",
+  });
+  expect(git.callsFor("fetch")).toHaveLength(1);
+  expect(git.callsFor("cat-file")).toHaveLength(0);
+  expect(await Bun.file(git.temporaryRoot()).exists()).toBe(false);
+});
+
+test.each([
+  {
+    name: "malformed header",
+    output: (id: string) => bytes(`${id} tree 0\n\n`),
+  },
+  {
+    name: "wrong object id",
+    output: () => bytes(`${"e".repeat(40)} blob 0\n\n`),
+  },
+  {
+    name: "missing object output",
+    output: (id: string) => bytes(`${id} missing\n`),
+  },
+  {
+    name: "truncated contents",
+    output: (id: string) => bytes(`${id} blob 10\nshort\n`),
+  },
+  {
+    name: "unexpected trailing output",
+    output: (id: string) => bytes(`${id} blob 0\n\nextra`),
+  },
+])("rejects $name from the local object batch", async ({ output }) => {
+  const git = new FakeGit([entry("pack.yaml", "fixture", 1)]);
+  git.batchOutput = ([id]) => output(id!);
+  await expect(materializeRegistryRelease(release, repository, git.run)).rejects.toMatchObject({
+    code: "source.invalid",
+  });
+  expect(git.callsFor("fetch")).toHaveLength(1);
+  expect(git.callsFor("cat-file")).toHaveLength(1);
+  expect(await Bun.file(git.temporaryRoot()).exists()).toBe(false);
+});
+
+test("rejects a blob over the per-file byte budget", async () => {
+  const git = new FakeGit([
+    entry("pack.yaml", new Uint8Array(defaultPackDirectoryLimits.maxFileBytes + 1), 1),
+  ]);
+  await expect(materializeRegistryRelease(release, repository, git.run)).rejects.toMatchObject({
+    code: "source.invalid",
+  });
+});
+
+test("rejects a batch over the total byte budget", async () => {
+  const contents = new Uint8Array(defaultPackDirectoryLimits.maxFileBytes);
+  const entries = [entry("pack.yaml", contents, 1)];
+  for (let index = 0; index < 64; index += 1) {
+    entries.push(entry(`practices/${index}.md`, contents, index + 2));
+  }
+  const git = new FakeGit(entries);
+  await expect(materializeRegistryRelease(release, repository, git.run)).rejects.toMatchObject({
+    code: "source.invalid",
+  });
+});
+
+test.each([
+  {
+    name: "missing pack manifest",
+    entries: [entry("practices/only.md", "practice", 1)],
+  },
+  {
+    name: "non-regular Pack path",
+    entries: [entry("pack.yaml", "target", 1, { mode: "120000" })],
+  },
+  {
+    name: "path outside the selected subtree",
+    entries: [{ ...entry("pack.yaml", "fixture", 1), path: "packs/other/pack.yaml" }],
+  },
+  {
+    name: "duplicate materialized path",
+    entries: [entry("pack.yaml", "one", 1), entry("pack.yaml", "two", 2)],
+  },
+])("rejects $name before object acquisition", async ({ entries }) => {
+  const git = new FakeGit(entries);
+  await expect(materializeRegistryRelease(release, repository, git.run)).rejects.toMatchObject({
+    code: "source.invalid",
+  });
+  expect(git.callsFor("fetch")).toHaveLength(0);
+  expect(git.callsFor("cat-file")).toHaveLength(0);
+  expect(await Bun.file(git.temporaryRoot()).exists()).toBe(false);
+});
+
+test("rejects more than the bounded number of Practice paths before acquisition", async () => {
+  const git = new FakeGit(packEntries(defaultPackDirectoryLimits.maxPracticeFiles + 1));
+  await expect(materializeRegistryRelease(release, repository, git.run)).rejects.toMatchObject({
+    code: "source.invalid",
+  });
+  expect(git.callsFor("fetch")).toHaveLength(0);
 });

--- a/packages/cli/src/install/materialize-source.test.ts
+++ b/packages/cli/src/install/materialize-source.test.ts
@@ -286,6 +286,7 @@ test("production runner materializes a filtered local Git remote through batch s
     expect(await Bun.file(join(source.directory, "practices", "需求.md")).text()).toBe(
       "Unicode Practice from a promisor remote.\n",
     );
+    expect(await Bun.file(join(source.directory, "decisions.yaml")).exists()).toBe(false);
     expect(await Bun.file(join(source.directory, "ignored.bin")).exists()).toBe(false);
     const temporaryRoot = dirname(source.directory);
     await source.cleanup();
@@ -319,22 +320,6 @@ test("fetches a shared object once and reads it for every validated target", asy
     expect(await Bun.file(join(source.directory, "practices", "second.md")).text()).toBe(
       "Shared Practice contents.\n",
     );
-  } finally {
-    await source.cleanup();
-  }
-});
-
-test("materializes a Unicode Practice path without optional decisions", async () => {
-  const git = new FakeGit([
-    entry("pack.yaml", "name: fixture\nversion: 0.2.0\n", 1),
-    entry("practices/需求.md", "Unicode Practice path.\n", 2),
-  ]);
-  const source = await materializeRegistryRelease(release, repository, git.run);
-  try {
-    expect(await Bun.file(join(source.directory, "practices", "需求.md")).text()).toBe(
-      "Unicode Practice path.\n",
-    );
-    expect(await Bun.file(join(source.directory, "decisions.yaml")).exists()).toBe(false);
   } finally {
     await source.cleanup();
   }

--- a/packages/cli/src/install/materialize-source.ts
+++ b/packages/cli/src/install/materialize-source.ts
@@ -27,6 +27,16 @@ interface SourceBlob {
   readonly relativePath: string;
 }
 
+interface GitCommandOptions {
+  readonly input?: Uint8Array;
+  readonly outputLimit?: number;
+}
+
+export type MaterializeGitRunner = (
+  arguments_: readonly string[],
+  options?: GitCommandOptions,
+) => Promise<Uint8Array>;
+
 function sourceUnavailable(): CliError {
   return new CliError(cliErrorCodes.sourceUnavailable, "The Pack source is unavailable.");
 }
@@ -42,11 +52,16 @@ export interface MaterializedPackSource {
   cleanup(): Promise<void>;
 }
 
-async function runGit(arguments_: readonly string[], outputLimit?: number): Promise<Uint8Array> {
+async function runGit(
+  arguments_: readonly string[],
+  options: GitCommandOptions = {},
+): Promise<Uint8Array> {
+  const { input, outputLimit } = options;
   let subprocess: ReturnType<typeof Bun.spawn>;
   try {
     subprocess = Bun.spawn(["git", ...arguments_], {
       env: GIT_ENVIRONMENT,
+      ...(input === undefined ? {} : { stdin: input }),
       stderr: "ignore",
       stdout: outputLimit === undefined ? "ignore" : "pipe",
     });
@@ -97,8 +112,13 @@ async function runGit(arguments_: readonly string[], outputLimit?: number): Prom
   }
 }
 
-async function cloneRelease(ref: string, destination: string, repository: string): Promise<void> {
-  await runGit([
+async function cloneRelease(
+  ref: string,
+  destination: string,
+  repository: string,
+  git: MaterializeGitRunner,
+): Promise<void> {
+  await git([
     "-c",
     "advice.detachedHead=false",
     "clone",
@@ -115,8 +135,13 @@ async function cloneRelease(ref: string, destination: string, repository: string
   ]);
 }
 
-async function readResolvedCommit(repositoryRoot: string): Promise<string> {
-  const output = await runGit(["-C", repositoryRoot, "rev-parse", "HEAD"], 256);
+async function readResolvedCommit(
+  repositoryRoot: string,
+  git: MaterializeGitRunner,
+): Promise<string> {
+  const output = await git(["-C", repositoryRoot, "rev-parse", "HEAD"], {
+    outputLimit: 256,
+  });
   const commit = new TextDecoder().decode(output).trim();
   if (!/^[0-9a-f]{40,64}$/.test(commit)) throw sourceInvalid();
   return commit;
@@ -134,6 +159,7 @@ function parseSourceTree(output: Uint8Array, sourcePath: string): SourceBlob[] {
 
   const prefix = `${sourcePath}/`;
   const blobs: SourceBlob[] = [];
+  const relativePaths = new Set<string>();
   let practiceFiles = 0;
   for (const entry of entries) {
     const separator = entry.indexOf("\t");
@@ -148,6 +174,8 @@ function parseSourceTree(output: Uint8Array, sourcePath: string): SourceBlob[] {
     if (!["100644", "100755"].includes(match[1]!) || match[2] !== "blob") {
       throw sourceInvalid();
     }
+    if (relativePaths.has(relativePath)) throw sourceInvalid();
+    relativePaths.add(relativePath);
 
     if (isPracticeSourcePath(relativePath)) {
       practiceFiles += 1;
@@ -156,14 +184,17 @@ function parseSourceTree(output: Uint8Array, sourcePath: string): SourceBlob[] {
     blobs.push({ objectId: match[3]!, relativePath });
   }
   if (!blobs.some((blob) => blob.relativePath === "pack.yaml")) throw sourceInvalid();
-  return blobs;
+  return blobs.sort((left, right) =>
+    left.relativePath < right.relativePath ? -1 : left.relativePath > right.relativePath ? 1 : 0,
+  );
 }
 
 async function inspectSourceTree(
   repositoryRoot: string,
   sourcePath: string,
+  git: MaterializeGitRunner,
 ): Promise<SourceBlob[]> {
-  const output = await runGit(
+  const output = await git(
     [
       "-C",
       repositoryRoot,
@@ -176,31 +207,98 @@ async function inspectSourceTree(
       `${sourcePath}/decisions.yaml`,
       `${sourcePath}/practices`,
     ],
-    MAX_SOURCE_TREE_LISTING_BYTES,
+    { outputLimit: MAX_SOURCE_TREE_LISTING_BYTES },
   );
   return parseSourceTree(output, sourcePath);
+}
+
+function encodeObjectIds(objectIds: readonly string[]): Uint8Array {
+  return new TextEncoder().encode(`${objectIds.join("\n")}\n`);
+}
+
+function findLineFeed(output: Uint8Array, start: number): number {
+  for (let index = start; index < output.byteLength; index += 1) {
+    if (output[index] === 0x0a) return index;
+  }
+  return -1;
+}
+
+function parseBlobBatch(output: Uint8Array, blobs: readonly SourceBlob[]): Uint8Array[] {
+  const contents: Uint8Array[] = [];
+  let offset = 0;
+  let totalBytes = 0;
+  for (const blob of blobs) {
+    const headerEnd = findLineFeed(output, offset);
+    if (headerEnd < 0) throw sourceInvalid();
+    const header = new TextDecoder().decode(output.subarray(offset, headerEnd));
+    const match = /^([0-9a-f]{40,64}) blob ([0-9]+)$/.exec(header);
+    if (match === null || match[1] !== blob.objectId) throw sourceInvalid();
+    const byteLength = Number(match[2]);
+    if (!Number.isSafeInteger(byteLength) || byteLength > defaultPackDirectoryLimits.maxFileBytes) {
+      throw sourceInvalid();
+    }
+    const contentsStart = headerEnd + 1;
+    const contentsEnd = contentsStart + byteLength;
+    if (contentsEnd >= output.byteLength || output[contentsEnd] !== 0x0a) {
+      throw sourceInvalid();
+    }
+    totalBytes += byteLength;
+    if (totalBytes > defaultPackDirectoryLimits.maxTotalBytes) throw sourceInvalid();
+    contents.push(output.subarray(contentsStart, contentsEnd));
+    offset = contentsEnd + 1;
+  }
+  if (offset !== output.byteLength) throw sourceInvalid();
+  return contents;
+}
+
+async function readBlobs(
+  repositoryRoot: string,
+  blobs: readonly SourceBlob[],
+  git: MaterializeGitRunner,
+): Promise<Uint8Array[]> {
+  const batchObjectIds = blobs.map((blob) => blob.objectId);
+  const fetchObjectIds = [...new Set(batchObjectIds)];
+  await git(
+    [
+      "-C",
+      repositoryRoot,
+      "-c",
+      "fetch.negotiationAlgorithm=noop",
+      "fetch",
+      "origin",
+      "--no-tags",
+      "--no-write-fetch-head",
+      "--recurse-submodules=no",
+      "--filter=blob:none",
+      "--no-auto-gc",
+      "--stdin",
+    ],
+    { input: encodeObjectIds(fetchObjectIds) },
+  );
+  const output = await git(
+    ["-C", repositoryRoot, "cat-file", "--batch=%(objectname) %(objecttype) %(objectsize)"],
+    {
+      input: encodeObjectIds(batchObjectIds),
+      outputLimit: defaultPackDirectoryLimits.maxTotalBytes + blobs.length * 128,
+    },
+  );
+  return parseBlobBatch(output, blobs);
 }
 
 async function materializeBlobs(
   repositoryRoot: string,
   blobs: readonly SourceBlob[],
   targetDirectory: string,
+  git: MaterializeGitRunner,
 ): Promise<void> {
   await mkdir(join(targetDirectory, "practices"), { recursive: true });
-  let totalBytes = 0;
-  for (const blob of blobs) {
-    // eslint-disable-next-line no-await-in-loop -- bounded sequential reads keep byte accounting simple
-    const contents = await runGit(
-      ["-C", repositoryRoot, "cat-file", "blob", blob.objectId],
-      defaultPackDirectoryLimits.maxFileBytes,
-    );
-    totalBytes += contents.byteLength;
-    if (totalBytes > defaultPackDirectoryLimits.maxTotalBytes) throw sourceInvalid();
+  const contents = await readBlobs(repositoryRoot, blobs, git);
+  for (const [index, blob] of blobs.entries()) {
     const target = join(targetDirectory, ...blob.relativePath.split("/"));
     // eslint-disable-next-line no-await-in-loop -- each validated blob has one deterministic target
     await mkdir(dirname(target), { recursive: true });
     // eslint-disable-next-line no-await-in-loop -- writes remain serial with the shared byte budget
-    await writeFile(target, contents, { flag: "wx", mode: 0o600 });
+    await writeFile(target, contents[index]!, { flag: "wx", mode: 0o600 });
   }
 }
 
@@ -208,15 +306,16 @@ async function materializeBlobs(
 export async function materializeRegistryRelease(
   release: RegistryRelease,
   repository: string,
+  git: MaterializeGitRunner = runGit,
 ): Promise<MaterializedPackSource> {
   const temporaryRoot = await mkdtemp(join(tmpdir(), "lorelum-install-"));
   const repositoryRoot = join(temporaryRoot, "repository");
   const packDirectory = join(temporaryRoot, "pack");
   try {
-    await cloneRelease(release.ref, repositoryRoot, repository);
-    const resolvedCommit = await readResolvedCommit(repositoryRoot);
-    const blobs = await inspectSourceTree(repositoryRoot, release.path);
-    await materializeBlobs(repositoryRoot, blobs, packDirectory);
+    await cloneRelease(release.ref, repositoryRoot, repository, git);
+    const resolvedCommit = await readResolvedCommit(repositoryRoot, git);
+    const blobs = await inspectSourceTree(repositoryRoot, release.path, git);
+    await materializeBlobs(repositoryRoot, blobs, packDirectory, git);
     return {
       directory: packDirectory,
       resolvedRef: release.ref,

--- a/packages/cli/src/install/materialize-source.ts
+++ b/packages/cli/src/install/materialize-source.ts
@@ -216,19 +216,12 @@ function encodeObjectIds(objectIds: readonly string[]): Uint8Array {
   return new TextEncoder().encode(`${objectIds.join("\n")}\n`);
 }
 
-function findLineFeed(output: Uint8Array, start: number): number {
-  for (let index = start; index < output.byteLength; index += 1) {
-    if (output[index] === 0x0a) return index;
-  }
-  return -1;
-}
-
 function parseBlobBatch(output: Uint8Array, blobs: readonly SourceBlob[]): Uint8Array[] {
   const contents: Uint8Array[] = [];
   let offset = 0;
   let totalBytes = 0;
   for (const blob of blobs) {
-    const headerEnd = findLineFeed(output, offset);
+    const headerEnd = output.indexOf(0x0a, offset);
     if (headerEnd < 0) throw sourceInvalid();
     const header = new TextDecoder().decode(output.subarray(offset, headerEnd));
     const match = /^([0-9a-f]{40,64}) blob ([0-9]+)$/.exec(header);


### PR DESCRIPTION
## Summary

- acquire all already validated Pack blob object IDs in one bounded Git fetch instead of triggering one promisor-remote fetch per file
- read the selected objects through one local cat-file batch with strict OID, type, size, framing, per-file, total-byte, and output limits
- preserve partial clone, path/ref validation, typed errors, cleanup, deterministic target mapping, and the no-checkout/no-filter-execution boundary
- add fake-runner adversarial coverage plus a hermetic real filtered-Git boundary test

## Why

The complete agentic-coding 0.2.0 Pack has 29 Practice files. The previous materializer cloned and validated the tree successfully, then invoked cat-file separately for each missing blob. A filtered clone therefore created many lazy remote fetches and repeatedly failed mid-materialization with GitHub TLS source.unavailable, while local decode and LocalStore installation were valid.

## Review and subtractive CR

An independent Sol High security review requested restoration of a real Git/Bun boundary test before merge. A second subtractive review removed a bespoke byte scanner and a duplicate test while retaining parser/security cases tied to current invariants.

## Verification

- focused materializer tests: 17 passed
- full core tests: 267 passed
- workspace typecheck: passed
- lint: passed
- CLI integration and compiled build: passed
- changed-file format and diff checks: passed
- sensitive-data scan: clean
- live official install: agentic-coding 0.2.0 from agentic-coding-v0.2.0 at commit 118f689, 29 added/effective Practices, zero diagnostics, cleanup complete

Closes #39