### PR TITLE
feat(cli): allow isolated LocalStore roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@ The codebase is **Bun + TypeScript**, organized as a Bun workspace monorepo (`pa
 
 The companion knowledge-pack repo lives elsewhere (`lorelum/lorelum-packs`). This repo does not contain knowledge-pack content.
 
+For local CLI work, including isolated Store roots and multi-worktree usage, see
+[the development guide](./docs/development/README.md).
+
 ## Layout
 
 The source tree is a Bun workspace monorepo (`packages/cli`, `packages/engine`, `packages/format`, `packages/mcp`, `packages/shared`). Repo-root `package.json` declares `workspaces: ["packages/*"]`.
@@ -30,6 +33,13 @@ The source tree is a Bun workspace monorepo (`packages/cli`, `packages/engine`, 
 - **Build single binary:** `bun build --compile`
 
 Precise scripts live in each `packages/*/package.json`; the above is what the root delegates to. Keep CI green on whatever it runs.
+
+### LocalStore CLI constraint
+
+- Every LocalStore-consuming CLI command must use the shared Store-root resolver;
+  do not call `defaultStorageRoot` directly when honoring the global override.
+- When manually writing Store data from a branch or worktree, use an isolated
+  Store root. Never point it at another worktree's or the user's default Store.
 
 ## Code style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,9 @@ bun install
 
 Precise scripts live in each `packages/*/package.json`.
 
+For the complete local CLI and multi-worktree setup (including isolated
+Store roots), see [Development guide](./docs/development/README.md).
+
 ## Contributor License Agreement (CLA)
 
 Before we can merge your first pull request, you need to sign our CLA. It's quick and one-time:

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,102 @@
+# Development guide
+
+This is the index for day-to-day development topics that do not belong in the
+product README. Start with [CONTRIBUTING.md](../../CONTRIBUTING.md) for the
+human contribution contract, then use the relevant links below.
+
+## Topics
+
+- [Environment and dependencies](../../CONTRIBUTING.md#development-environment)
+- [Tests and CI](../../CONTRIBUTING.md#testing--ci)
+- [Issues, branches, and PRs](../../CONTRIBUTING.md#development-workflow)
+- [Local CLI and worktrees](#local-cli-and-multiple-worktrees)
+
+## Local CLI and multiple worktrees
+
+The CLI's discoverable global option is:
+
+```text
+--store-root <path>
+```
+
+When omitted, the Store remains `~/.lorelum`. A relative path is resolved from
+the calling process's current working directory. At present, `install` is the
+only CLI command that consumes `LocalStore`; do not infer support for other
+commands from this guide.
+
+### A copyable `lore-dev` function
+
+Define this function in the shell where you are working (or temporarily paste
+it into a session):
+
+```zsh
+lore-dev() {
+  local repo_root store_root cli_entry
+
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    print -u2 "lore-dev: current directory is not inside a Git worktree"
+    return 1
+  }
+
+  cli_entry="$repo_root/packages/cli/src/main.ts"
+  if [[ ! -f "$cli_entry" ]]; then
+    print -u2 "lore-dev: expected CLI entrypoint not found: $cli_entry"
+    return 1
+  fi
+
+  store_root="$(git rev-parse --path-format=absolute --git-path lorelum/store 2>/dev/null)" || {
+    print -u2 "lore-dev: could not resolve the worktree-specific Git administrative Store"
+    return 1
+  }
+
+  bun "$cli_entry" --store-root "$store_root" "$@"
+}
+```
+
+The function anchors the source entrypoint to the current worktree and derives
+its Store from Git administrative data. That Store is worktree-specific and is
+not part of a commit. For example:
+
+```zsh
+lore-dev install pack-creator --pack-version 0.1.0
+```
+
+Use the source function while iterating. To check compiled behavior for the
+same checkout, run:
+
+```zsh
+bun run build:cli
+./dist/lore --store-root "$(git rev-parse --path-format=absolute --git-path lorelum/store)" install pack-creator --pack-version 0.1.0
+```
+
+The globally available `lore` command should be a stable link into the primary
+checkout, such as `packages/cli/src/main.ts`. Do not repoint that link between
+worktrees, and do not point it at a Codex or temporary worktree. Use
+`lore-dev` when the current branch's source is what you need to exercise.
+
+From the primary checkout, create that link once:
+
+```zsh
+mkdir -p "$HOME/.local/bin"
+ln -s "$PWD/packages/cli/src/main.ts" "$HOME/.local/bin/lore"
+rehash
+```
+
+This assumes `~/.local/bin` is already in `PATH`. If the destination exists,
+inspect it instead of replacing it blindly.
+
+### Store isolation rules
+
+Any manual Store-writing workflow (for example, future `uninstall` or
+`reindex` commands) must pass an explicitly isolated `--store-root`. These
+commands are not implemented merely because they are named here; the rule is a
+forward-looking safety constraint. Today, only `install` is implemented as a
+LocalStore consumer.
+
+Automated tests should continue to use temporary directories for Store data.
+They must not write to `~/.lorelum` or to a developer's shared Store.
+
+There is intentionally no Store-related environment variable, automatic
+worktree detection in the global CLI, project scope, or implicit Store. The
+global override is explicit and discoverable; callers that need isolation must
+provide it.

--- a/packages/cli/integration/process.integration.ts
+++ b/packages/cli/integration/process.integration.ts
@@ -45,6 +45,18 @@ try {
   assert.deepEqual(selectProtocolFields(discovery.stdout), { command: "describe", ok: true });
   assert.equal(discovery.stderr, "");
 
+  const isolatedDiscovery = await runProcess([
+    executable,
+    "--store-root",
+    join(directory, "worktree-store"),
+  ]);
+  assert.equal(isolatedDiscovery.exitCode, 0);
+  assert.deepEqual(selectProtocolFields(isolatedDiscovery.stdout), {
+    command: "describe",
+    ok: true,
+  });
+  assert.equal(isolatedDiscovery.stderr, "");
+
   const invalid = await runProcess([executable, "--private-token"]);
   assert.equal(invalid.exitCode, 2);
   assert.deepEqual(selectProtocolFields(invalid.stdout), {

--- a/packages/cli/src/install/install-command.test.ts
+++ b/packages/cli/src/install/install-command.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -156,6 +157,41 @@ test("installs from an explicit Registry repository and is idempotent", async ()
     expect(
       await fixture.services.store.readEffectivePractices({ rootPath: storageRoot }),
     ).toHaveLength(1);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("uses an explicit global Store root without touching the default Store", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-install-command-"));
+  try {
+    const defaultRoot = join(directory, "default-store");
+    const isolatedRoot = join(directory, "worktree-store");
+    const fixture = createServices(await createPack(directory), defaultRoot);
+    const definitions = snapshotCommandDefinitions([createInstallCommand(fixture.services)]);
+    const firstOutput = new MemoryWriter();
+
+    expect(
+      await run(["--store-root", isolatedRoot, "install", "agentic-coding"], {
+        registry: definitions,
+        stdout: firstOutput,
+      }),
+    ).toBe(0);
+    expect(JSON.parse(firstOutput.value)).toMatchObject({ data: { idempotent: false } });
+    expect(existsSync(defaultRoot)).toBe(false);
+    expect(
+      await fixture.services.store.readEffectivePractices({ rootPath: isolatedRoot }),
+    ).toHaveLength(1);
+
+    const secondOutput = new MemoryWriter();
+    expect(
+      await run(["install", "agentic-coding", "--store-root", isolatedRoot], {
+        registry: definitions,
+        stdout: secondOutput,
+      }),
+    ).toBe(0);
+    expect(JSON.parse(secondOutput.value)).toMatchObject({ data: { idempotent: true } });
+    expect(existsSync(defaultRoot)).toBe(false);
   } finally {
     await rm(directory, { force: true, recursive: true });
   }

--- a/packages/cli/src/install/install-command.ts
+++ b/packages/cli/src/install/install-command.ts
@@ -18,6 +18,7 @@ import type { RegistryRelease } from "@lorelum/format";
 import type { JsonSchema, JsonValue } from "../output/protocol.js";
 import type { CommandDefinition } from "../registry.js";
 import { CliError, cliErrorCodes, frameworkErrorCodes } from "../runtime/errors.js";
+import { resolveInvocationStorageRoot } from "../store/storage-root.js";
 import { loadRegistry, type LoadedRegistry } from "./load-registry.js";
 import { materializeRegistryRelease, type MaterializedPackSource } from "./materialize-source.js";
 import { resolveRegistryRelease } from "./resolve-release.js";
@@ -165,6 +166,7 @@ function throwVisibleInstallError(error: unknown): never {
 
 async function installPack(
   services: InstallCommandServices,
+  storageRoot: StorageRoot,
   packName: string,
   requestedVersion?: string,
   registryLocator?: string,
@@ -187,7 +189,7 @@ async function installPack(
       );
     }
     const result = await services.store.install(
-      services.storageRoot,
+      storageRoot,
       decoded.candidate,
       decoded.diagnostics,
     );
@@ -221,7 +223,7 @@ export function createInstallCommand(
 ): CommandDefinition {
   return {
     name: "install",
-    summary: "Install a Knowledge Pack into the user-level local store.",
+    summary: "Install a Knowledge Pack into the selected local Store.",
     positionals: [{ name: "pack", required: true }],
     options: [
       {
@@ -245,6 +247,7 @@ export function createInstallCommand(
         return {
           data: await installPack(
             services,
+            resolveInvocationStorageRoot(invocation.options.storeRoot, services.storageRoot),
             invocation.positionals[0]!,
             optionString(invocation.options, "packVersion"),
             optionString(invocation.options, "registry"),

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -135,6 +135,8 @@ test("validates invalid calls before help and version responses", async () => {
     ["--help", "--version"],
     ["describe", "--version"],
     ["--log-level"],
+    ["--store-root"],
+    ["install", "agentic-coding", "--store-root="],
     ["--private-token"],
   ];
   await Promise.all(

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -202,6 +202,11 @@ test("describes registered commands from a single registry", () => {
         name: "--log-level <level>",
         scope: "global",
       },
+      {
+        behavior: "store-root",
+        name: "--store-root <path>",
+        scope: "global",
+      },
     ],
     commands: [
       {
@@ -223,12 +228,14 @@ test("describes registered commands from a single registry", () => {
     options: [
       { behavior: "help", scope: "global" },
       { behavior: "log-level", scope: "global" },
+      { behavior: "store-root", scope: "global" },
     ],
   });
   const install = describeCommand("install") as { options: readonly { name: string }[] };
   expect(install.options.map((option) => option.name)).toEqual([
     "-h, --help",
     "--log-level <level>",
+    "--store-root <path>",
     "--pack-version <version>",
     "--registry <repository>",
   ]);
@@ -250,6 +257,7 @@ test("derives parser options and describe metadata from registered commands", as
     options: [
       { behavior: "help", scope: "global" },
       { behavior: "log-level", scope: "global" },
+      { behavior: "store-root", scope: "global" },
       { name: "--future-mode <mode>", scope: "command" },
     ],
   });

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -18,7 +18,7 @@ export interface CommandOption {
   /** Requires callers to provide the option; defaults are therefore not allowed. */
   readonly optionRequired: boolean;
   /** Reserved for framework-owned global options on the root command. */
-  readonly behavior?: "help" | "log-level" | "version";
+  readonly behavior?: "help" | "log-level" | "store-root" | "version";
   /** Framework option availability; local command options omit this field. */
   readonly scope?: "global" | "root";
   /** Static framework response metadata, including its discoverable data contract. */
@@ -116,6 +116,14 @@ const globalOptions: readonly CommandOption[] = [
     defaultValue: "error",
     values: logLevels,
   },
+  {
+    longFlag: "--store-root",
+    description: "Use an explicit LocalStore directory instead of the user-level default.",
+    value: { name: "path", required: true },
+    optionRequired: false,
+    behavior: "store-root",
+    scope: "global",
+  },
 ] as const satisfies readonly CommandOption[];
 
 const positionalDescriptionSchema: JsonSchema = {
@@ -146,7 +154,7 @@ const optionDescriptionSchema: JsonSchema = {
     description: stringSchema,
     required: { type: "boolean" },
     scope: { enum: ["command", "global", "root"] },
-    behavior: { enum: ["help", "log-level", "version"] },
+    behavior: { enum: ["help", "log-level", "store-root", "version"] },
     response: optionResponseDescriptionSchema,
     defaultValue: stringSchema,
     values: { type: "array", items: stringSchema },

--- a/packages/cli/src/store/storage-root.test.ts
+++ b/packages/cli/src/store/storage-root.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+
+import { CliError } from "../runtime/errors.js";
+import { resolveInvocationStorageRoot } from "./storage-root.js";
+
+test("keeps the default Store when no override is supplied", () => {
+  const fallback = { rootPath: "/user/.lorelum" };
+
+  expect(resolveInvocationStorageRoot(undefined, fallback, "/worktree")).toBe(fallback);
+});
+
+test("resolves a relative Store override from the invocation working directory", () => {
+  expect(
+    resolveInvocationStorageRoot(".git/lorelum/store", { rootPath: "/user/.lorelum" }, "/worktree"),
+  ).toEqual({ rootPath: "/worktree/.git/lorelum/store" });
+});
+
+test("rejects an empty Store override", () => {
+  expect(() =>
+    resolveInvocationStorageRoot("", { rootPath: "/user/.lorelum" }, "/worktree"),
+  ).toThrow(CliError);
+});

--- a/packages/cli/src/store/storage-root.ts
+++ b/packages/cli/src/store/storage-root.ts
@@ -1,0 +1,16 @@
+import { resolve } from "node:path";
+
+import type { StorageRoot } from "@lorelum/engine";
+
+import { invalidInvocationError } from "../runtime/errors.js";
+
+/** Select the invocation Store while preserving the user-level default. */
+export function resolveInvocationStorageRoot(
+  override: unknown,
+  fallback: StorageRoot,
+  workingDirectory = process.cwd(),
+): StorageRoot {
+  if (override === undefined) return fallback;
+  if (typeof override !== "string" || override.length === 0) throw invalidInvocationError();
+  return { rootPath: resolve(workingDirectory, override) };
+}


### PR DESCRIPTION
## Summary

Add a discoverable global `--store-root <path>` override while preserving `~/.lorelum` as the default. Document a stable global CLI plus current-worktree `lore-dev` workflow through a progressive development index rather than duplicating the full setup in AGENTS.md and CONTRIBUTING.md.

## Linked issue

Closes #43

## Type of change

- [ ] 🐛 Bug fix (non-breaking)
- [x] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change (fix or feature that would cause existing behavior to change)
- [ ] 📚 Docs only
- [ ] 🔧 Refactor / chore

## How was this tested?

- `bun test` — 304 passed
- `bun run test:integration`
- `bun run typecheck`
- `bun run lint`
- `bun run build:cli`
- focused `oxfmt --check` for changed TypeScript and the new development guide
- source and compiled CLI both installed `pack-creator@0.1.0` into the worktree-specific Git administrative Store; the compiled repeat was idempotent
- `git diff --check` and sensitive-pattern scan

The repository-wide `bun run fmt:check` remains a non-blocking CI signal and reports the same existing formatting backlog across unrelated Markdown, package, and plan files; this PR does not mechanically reformat those files.

## Checklist

- [x] Linked the issue this closes (`Closes #43`)
- [x] CLI-surface design is recorded in Issue #43 before implementation
- [x] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

## AI assistance

- [x] Parts of this PR were generated or assisted by an AI tool
- [x] I have reviewed every line of the AI-generated code and take full responsibility for it

## Notes for reviewers

Please focus on the boundary between the global option and Store-consuming commands. `install` is the only current consumer; the shared resolver and AGENTS.md constraint are intended to prevent future commands from silently bypassing the invocation override. This change intentionally does not add an environment variable, automatic worktree detection, project install scope, or implicit Store selection.
