### PR TITLE
feat(cli): 新增基于 LocalStore 的 lore query 与 lore get 检索命令

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Test
         run: bun test
 
+      - name: Integration
+        run: bun run test:integration
+
       # oxfmt is still alpha (ADR 0002). Run as a non-blocking signal for now;
       # promote to blocking once it stabilizes.
       - name: Format check

--- a/docs/adr/0010-query-retrieval-contract.md
+++ b/docs/adr/0010-query-retrieval-contract.md
@@ -1,0 +1,48 @@
+# ADR 0010: LocalStore-backed lore query retrieval contract
+
+- **Date:** 2026-09-03
+- **Status:** Proposed (local implementation)
+- **Related:** ADR 0003 (Practice format), ADR 0004 (agent-first CLI protocol), ADR 0007 (LocalStore), ADR 0008 (user-scope Pack install)
+
+## Context
+
+ADR 0007 makes LocalStore the runtime source for `query/get/decide/check`, and ADR 0008 installs active Packs into the user scope. The README already promises `lore query` as the primary task-and-moment retrieval entry point, but the official CLI model has no executable query command yet.
+
+An earlier fork prototype used `lore query <pack-path> --query <text>` with an explicit Pack path and a `--full` body switch. That contract pushed Pack discovery onto the caller and created a second runtime source beside LocalStore. Its deterministic ranking evidence is reusable; its command surface is not the product boundary.
+
+## Decision
+
+### Command surface
+
+```text
+lore query <query> [--top-k <count>]
+```
+
+`<query>` is non-empty natural-language text describing the engineering task or the current work moment. It may mention a path, but v1 does not parse or read that path. `--top-k` defaults to 5 and accepts only integers 1..50.
+
+The command honors the global `--store-root` option through the same invocation Store resolution as `lore install`, so retrieval reads the same selected Store instead of silently falling back to the user-level default.
+
+### Application boundary
+
+`@lorelum/engine` exposes:
+
+- pure `retrievePractices()` over LocalStore `EffectivePractice[]`;
+- `createQueryService()`, which cold-opens the configured LocalStore and returns the retrieval result plus `generation` and `effectiveRevision`.
+
+The CLI adapter calls `QueryService`; it never accepts a Pack path, decodes a Pack, or performs its own filesystem discovery. A future MCP tool and `lore get` full-body retrieval will call the same LocalStore boundary.
+
+### Result
+
+Each result contains the Practice summary metadata only:
+
+- `id`, `title`, `stage`, `tech_stack`, `applies_when`.
+
+The top level reports `query`, `k`, `total`, LocalStore `generation`, `effectiveRevision`, and ranked `results`. Ranking is descending deterministic token-match score (title weight 3, `applies_when` weight 2, stage/tech_stack/body weight 1), then ascending Practice id. Query and Practice text share the engine's retrieval tokenizer (`normalizeTokens`), including overlapping CJK bigrams, so Chinese tasks match contiguous Chinese Practice text without a segmentation dependency. Token-less or unmatched queries return successful empty results; blank input remains a usage error. LocalStore busy/recovery failures remain typed errors at the adapter boundary.
+
+### Non-goals
+
+Full-body results, explicit-Pack debug paths, structured filters, semantic/vector retrieval, project scope, and MCP wiring are deferred. Full Practice bodies belong to a separate `lore get` contract so query output stays a cheap summary slice.
+
+## Consequences
+
+The first official query slice reuses installed, validated, effective Practices, preserves LocalStore provenance metadata at the top level, and keeps the command shape the README already documents. Until semantic/vector retrieval lands, recall is limited to deterministic token matching. The fork's `--full` switch is intentionally not migrated; summary-versus-full retrieval is split between `query` and a future `get`.

--- a/docs/adr/0010-query-retrieval-contract.md
+++ b/docs/adr/0010-query-retrieval-contract.md
@@ -27,9 +27,17 @@ The command honors the global `--store-root` option through the same invocation 
 `@lorelum/engine` exposes:
 
 - pure `retrievePractices()` over LocalStore `EffectivePractice[]`;
-- `createQueryService()`, which cold-opens the configured LocalStore and returns the retrieval result plus `generation` and `effectiveRevision`.
+- `createQueryService()`, which cold-opens the configured LocalStore and returns
+  the retrieval result plus `generation` and `effectiveRevision`.
 
 The CLI adapter calls `QueryService`; it never accepts a Pack path, decodes a Pack, or performs its own filesystem discovery. A future MCP tool and `lore get` full-body retrieval will call the same LocalStore boundary.
+
+For the CLI's single invocation, the service cold-opens the configured
+LocalStore once per call; this preserves the ADR 0007 integrity checks without
+holding a long-lived process open. A future long-lived MCP adapter must not
+copy that per-call policy unchanged: it should reuse one open store and
+re-open only when `generation` changes, then carry that policy in its own MCP
+contract.
 
 ### Result
 
@@ -37,7 +45,13 @@ Each result contains the Practice summary metadata only:
 
 - `id`, `title`, `stage`, `tech_stack`, `applies_when`.
 
-The top level reports `query`, `k`, `total`, LocalStore `generation`, `effectiveRevision`, and ranked `results`. Ranking is descending deterministic token-match score (title weight 3, `applies_when` weight 2, stage/tech_stack/body weight 1), then ascending Practice id. Query and Practice text share the engine's retrieval tokenizer (`normalizeTokens`), including overlapping CJK bigrams, so Chinese tasks match contiguous Chinese Practice text without a segmentation dependency. Token-less or unmatched queries return successful empty results; blank input remains a usage error. LocalStore busy/recovery failures remain typed errors at the adapter boundary.
+The top level reports `query`, `k`, `total`, LocalStore `generation`, `effectiveRevision`, and ranked `results`. `total` is the count of all matching Practices before `k` truncation; v1 does not paginate beyond `k`, so callers must not interpret the omitted tail as absent. Ranking is descending deterministic token-match score (title weight 3, `applies_when` weight 2, stage/tech_stack/body weight 1), then ascending Practice id.
+
+Query and Practice text share the engine's retrieval tokenizer (`normalizeTokens`), including overlapping CJK bigrams, so Chinese tasks match contiguous Chinese Practice text without a segmentation dependency. Mixed-script runs such as `Add remote 接口请求` are split into contiguous Latin/numeric words plus CJK bigram pieces (`remote` / `接口` / `口请` / `请求`); a query on either side of that split can therefore match the Chinese or English segment without dropping the other.
+
+The result slice intentionally exposes no body or match rationale. Scoring is not fully auditable from a summary result alone; callers that need the evidence behind a body-only ranking must resolve the full Practice and source text through `lore get`. v1 does not promise that ranking weights were tuned against measured retrieval quality.
+
+Token-less or unmatched queries return successful empty results; blank input remains a usage error. LocalStore busy/recovery failures remain typed errors at the adapter boundary.
 
 ### Non-goals
 
@@ -45,4 +59,8 @@ Full-body results, explicit-Pack debug paths, structured filters, semantic/vecto
 
 ## Consequences
 
-The first official query slice reuses installed, validated, effective Practices, preserves LocalStore provenance metadata at the top level, and keeps the command shape the README already documents. Until semantic/vector retrieval lands, recall is limited to deterministic token matching. The fork's `--full` switch is intentionally not migrated; summary-versus-full retrieval is split between `query` and a future `get`.
+The first official query slice reuses installed, validated, effective Practices, preserves LocalStore provenance metadata at the top level, and keeps the command shape the README already documents. Until semantic/vector retrieval lands, recall is limited to deterministic token matching. The fork's `--full` switch is intentionally not migrated; summary-versus-full retrieval is split between `query` and `get`.
+
+**Follow-ups:**
+
+- Cross-call read consistency is not defined here. A single invocation reads one consistent LocalStore snapshot, but orchestrating query-then-get across separate invocations can cross a store revision or observe a Practice removed between calls. A future batch/sequence contract must define the snapshot semantics before adding such an orchestration surface.

--- a/docs/adr/0011-get-retrieval-contract.md
+++ b/docs/adr/0011-get-retrieval-contract.md
@@ -1,0 +1,51 @@
+# ADR 0011: LocalStore-backed lore get retrieval contract
+
+- **Date:** 2026-09-04
+- **Status:** Proposed (local implementation)
+- **Related:** ADR 0003 (Practice format), ADR 0004 (agent-first CLI protocol), ADR 0007 (LocalStore), ADR 0008 (user-scope Pack install), ADR 0010 (query retrieval)
+
+## Context
+
+ADR 0010 splits retrieval output in two: `lore query` returns a cheap summary slice (Practice `id`, `title`, `stage`, `tech_stack`, `applies_when`) without the body, and explicitly deferred full Practice bodies to a separate `lore get` contract. ADR 0007 makes LocalStore the runtime source for `query/get/decide/check`, and ADR 0008 installs active Packs into the user scope.
+
+An earlier fork prototype used `lore get <pack-path> <practice-id>` with an explicit Pack path. That contract pushed Pack discovery onto the caller and created a second runtime source beside LocalStore. Its error semantics are reusable evidence; its command surface is not the product boundary.
+
+## Decision
+
+### Command surface
+
+```text
+lore get <practice-id> [--store-root <path>]
+```
+
+`<practice-id>` is the dotted Practice key declared by PracticeSchema. `get` retrieves exactly one Practice by id; it is not a search command and takes no `--top-k`. The command honors the global `--store-root` option through the same invocation Store resolution as `lore install` and `query`, so retrieval reads the same selected Store instead of silently falling back to the user-level default.
+
+### Application boundary
+
+`@lorelum/engine` exposes:
+
+- pure `retrievePractice()` over LocalStore `EffectivePractice[]` returning a get-specific projection (`practice` plus projected `sources`) or `null`;
+- `createGetService()`, which cold-opens the configured LocalStore, resolves the id against the effective Practices, and throws `UnknownPracticeError` when no Practice matches. It returns the result plus `generation` and `effectiveRevision`.
+
+The `sources` projection type `PracticeSourceResult` lives in the engine's shared retrieval layer (the same neutral home as `tokenize`/`top-k`). The `null` → `UnknownPracticeError` conversion happens only inside `createGetService()`; the CLI never inspects `null` and never constructs that error itself.
+
+The CLI adapter calls `GetService`; it never accepts a Pack path, decodes a Pack, or performs its own filesystem discovery. A future MCP tool will call the same service.
+
+### Result
+
+A successful result contains:
+
+- the complete effective Practice as produced by LocalStore canonicalization, including `severity`, `body`, and `anti_patterns` — these are always present and normalized (`severity` defaults to `warn`, `body` to `""`, `anti_patterns` to `[]`). The `PracticeSnapshot` model type is tightened to reflect this canonicalization invariant: the three fields are required, not optional, so consumers need no `undefined` defense;
+- every active LocalStore source claim via the shared `PracticeSourceResult` projection, not a re-declared copy. `PracticeSourceResult` lives in the engine's shared retrieval layer and is available to future retrieval features.
+
+The top level reports LocalStore `generation`, `effectiveRevision`, `practice`, and `sources`. The Practice `id` is the single source of truth for the resolved key; no redundant top-level `practiceId` is emitted.
+
+An unknown id raises `UnknownPracticeError` from the engine, which the CLI adapter maps to the `get.unknown_practice` error code with exit code 2. `get.unknown_practice` must be listed in the command's `errorCodes` allowlist alongside `store.busy` and `store.recovery-required` (ADR 0004 requires every visible error be declared). It uses exit 2 rather than ADR 0004's exit 1 for domain findings to stay consistent with `decide.unknown_decision` and the fork's `get.unknown_practice`. LocalStore busy/recovery failures remain typed errors at the adapter boundary.
+
+### Non-goals
+
+Batch retrieval by multiple ids, explicit-Pack debug paths, `--full` switches, structured filters, semantic/vector retrieval, project scope, and MCP wiring are deferred. Batch or filtered retrieval requires its own contract and must not be implied by this command.
+
+## Consequences
+
+The first official get slice reuses installed, validated, effective Practices, returns the complete canonical Practice the caller asked for by id, and preserves source provenance. It replaces the fork's Pack-path get without reintroducing a second runtime source. Unknown-id remains a hard error rather than a silent empty result, matching the precise-by-id nature of `get` and the existing `decide.unknown_decision` pattern. Batch access remains a future extension.

--- a/docs/adr/0011-get-retrieval-contract.md
+++ b/docs/adr/0011-get-retrieval-contract.md
@@ -25,22 +25,38 @@ lore get <practice-id> [--store-root <path>]
 `@lorelum/engine` exposes:
 
 - pure `retrievePractice()` over LocalStore `EffectivePractice[]` returning a get-specific projection (`practice` plus projected `sources`) or `null`;
-- `createGetService()`, which cold-opens the configured LocalStore, resolves the id against the effective Practices, and throws `UnknownPracticeError` when no Practice matches. It returns the result plus `generation` and `effectiveRevision`.
+- `createGetService()`, which cold-opens the configured LocalStore, resolves the
+  id against the effective Practices, and throws `UnknownPracticeError` when no
+  Practice matches. It returns the result plus `generation` and
+  `effectiveRevision`.
 
 The `sources` projection type `PracticeSourceResult` lives in the engine's shared retrieval layer (the same neutral home as `tokenize`/`top-k`). The `null` → `UnknownPracticeError` conversion happens only inside `createGetService()`; the CLI never inspects `null` and never constructs that error itself.
 
 The CLI adapter calls `GetService`; it never accepts a Pack path, decodes a Pack, or performs its own filesystem discovery. A future MCP tool will call the same service.
 
+For the CLI's single invocation, the service cold-opens the configured
+LocalStore once per call; this preserves the ADR 0007 integrity checks without
+holding a long-lived process open. A future long-lived MCP adapter must not
+copy that per-call policy unchanged: it should reuse one open store and
+re-open only when `generation` changes, then carry that policy in its own MCP
+contract.
+
 ### Result
 
 A successful result contains:
 
-- the complete effective Practice as produced by LocalStore canonicalization, including `severity`, `body`, and `anti_patterns` — these are always present and normalized (`severity` defaults to `warn`, `body` to `""`, `anti_patterns` to `[]`). The `PracticeSnapshot` model type is tightened to reflect this canonicalization invariant: the three fields are required, not optional, so consumers need no `undefined` defense;
+- the complete effective Practice as produced by LocalStore canonicalization, including `severity`, `body`, and `anti_patterns` — these are always present and normalized (`severity` defaults to `warn`, `body` to `""`, `anti_patterns` to `[]`, and each anti-pattern `severity` defaults to `warn`). The `PracticeSnapshot` model type is tightened to reflect this canonicalization invariant: the three fields are required, not optional, so consumers need no `undefined` defense. ADR 0007 §2 freezes the canonical object and author-visible array order; this ADR makes the nested `anti_patterns[].severity` default explicit as an extension of the same canonicalization rule.
 - every active LocalStore source claim via the shared `PracticeSourceResult` projection, not a re-declared copy. `PracticeSourceResult` lives in the engine's shared retrieval layer and is available to future retrieval features.
 
 The top level reports LocalStore `generation`, `effectiveRevision`, `practice`, and `sources`. The Practice `id` is the single source of truth for the resolved key; no redundant top-level `practiceId` is emitted.
 
-An unknown id raises `UnknownPracticeError` from the engine, which the CLI adapter maps to the `get.unknown_practice` error code with exit code 2. `get.unknown_practice` must be listed in the command's `errorCodes` allowlist alongside `store.busy` and `store.recovery-required` (ADR 0004 requires every visible error be declared). It uses exit 2 rather than ADR 0004's exit 1 for domain findings to stay consistent with `decide.unknown_decision` and the fork's `get.unknown_practice`. LocalStore busy/recovery failures remain typed errors at the adapter boundary.
+An unknown id raises `UnknownPracticeError` from the engine, which the CLI adapter maps to the `get.unknown_practice` error code with exit code 2. `get.unknown_practice` must be listed in the command's `errorCodes` allowlist alongside `store.busy` and `store.recovery-required` (ADR 0004 requires every visible error be declared). It uses exit 2 because an unknown id is an exact-address error, not a successful domain finding; this matches the current `sync` command's `localization.practice-not-found` precedent. Exit 1 remains reserved for ADR 0004 blocking domain findings, and the removed `decide.unknown_decision` command is not used as a precedent. LocalStore busy/recovery failures remain typed errors at the adapter boundary.
+
+An id that is not a valid dotted Practice id (ADR 0003 `ID_REGEX`) is rejected
+by the CLI before store dispatch as `usage.invalid`. This keeps invalid
+addresses distinct from valid but unknown Practice ids (`get.unknown_practice`).
+Engine callers still see valid-format unknown ids as `UnknownPracticeError`;
+the CLI owns the user-facing syntax boundary.
 
 ### Non-goals
 
@@ -48,4 +64,8 @@ Batch retrieval by multiple ids, explicit-Pack debug paths, `--full` switches, s
 
 ## Consequences
 
-The first official get slice reuses installed, validated, effective Practices, returns the complete canonical Practice the caller asked for by id, and preserves source provenance. It replaces the fork's Pack-path get without reintroducing a second runtime source. Unknown-id remains a hard error rather than a silent empty result, matching the precise-by-id nature of `get` and the existing `decide.unknown_decision` pattern. Batch access remains a future extension.
+The first official get slice reuses installed, validated, effective Practices, returns the complete canonical Practice the caller asked for by id, and preserves source provenance. It replaces the fork's Pack-path get without reintroducing a second runtime source. Unknown-id remains a hard error rather than a silent empty result, matching the precise-by-id nature of `get` and the current `sync` command's exact-address error pattern. Batch access remains a future extension.
+
+**Follow-ups:**
+
+- Cross-call read consistency is not defined here. A single invocation reads one consistent LocalStore snapshot, but orchestrating query-then-get across separate invocations can cross a store revision or observe a Practice removed between calls. A future batch/sequence contract must define the snapshot semantics before adding such an orchestration surface.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,8 @@ docs/adr/
 ├── 0007-engine-local-store.md                 # @lorelum/engine LocalStore storage & lifecycle contract
 ├── 0008-pack-registry-and-user-scope-install.md # Pack Registry and user-scope install contract
 ├── 0009-pack-localization-authoring.md         # Pack localization source assets and synchronization
+├── 0010-query-retrieval-contract.md          # LocalStore-backed lore query retrieval contract
+├── 0011-get-retrieval-contract.md            # LocalStore-backed lore get retrieval contract
 └── 0000-template.md                           # copy this to start a new ADR
 ```
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -20,9 +20,8 @@ The CLI's discoverable global option is:
 ```
 
 When omitted, the Store remains `~/.lorelum`. A relative path is resolved from
-the calling process's current working directory. At present, `install` is the
-only CLI command that consumes `LocalStore`; do not infer support for other
-commands from this guide.
+the calling process's current working directory. `install`, `query`, and `get`
+consume the selected LocalStore.
 
 ### A copyable `lore-dev` function
 
@@ -90,8 +89,9 @@ inspect it instead of replacing it blindly.
 Any manual Store-writing workflow (for example, future `uninstall` or
 `reindex` commands) must pass an explicitly isolated `--store-root`. These
 commands are not implemented merely because they are named here; the rule is a
-forward-looking safety constraint. Today, only `install` is implemented as a
-LocalStore consumer.
+forward-looking safety constraint. Read-only commands such as `query` and `get`
+are safe against the worktree Store, but they still honor `--store-root`
+explicitly when an alternate Store is intended.
 
 Automated tests should continue to use temporary directories for Store data.
 They must not write to `~/.lorelum` or to a developer's shared Store.

--- a/packages/cli/integration/process.integration.ts
+++ b/packages/cli/integration/process.integration.ts
@@ -1,11 +1,51 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+import { createLocalStore, decodePackDirectory } from "@lorelum/engine";
 
 const entrypoint = join(import.meta.dir, "../src/main.ts");
 const bunExecutable = Bun.which("bun");
 const processTimeoutMs = 60_000;
+
+async function writeLocalStoreFixturePack(directory: string): Promise<string> {
+  const packRoot = join(directory, "localstore-fixture-pack");
+  const practices = join(packRoot, "practices", "react");
+  await mkdir(practices, { recursive: true });
+  await writeFile(join(packRoot, "pack.yaml"), "name: integration-query-get\nversion: 0.1.0\n");
+  await writeFile(
+    join(practices, "api-client.md"),
+    [
+      "---",
+      "id: react.api-client",
+      "title: Layer React API access",
+      "stage: api-layer",
+      "tech_stack: [react, typescript]",
+      "applies_when: adding remote requests to a React interface",
+      "severity: warn",
+      "---",
+      "Keep transport, DTO translation, and expected failures behind a feature API boundary.",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    join(practices, "resource-state.md"),
+    [
+      "---",
+      "id: react.resource-state",
+      "title: Separate resource and UI state",
+      "stage: state",
+      "tech_stack: [react, typescript]",
+      "applies_when: storing remote resource data used by a React interface",
+      "severity: warn",
+      "---",
+      "Model resource data separately from view state and transform DTOs at the boundary.",
+      "",
+    ].join("\n"),
+  );
+  return packRoot;
+}
 
 if (bunExecutable === null) {
   throw new Error("Bun executable is required for CLI integration tests.");
@@ -39,6 +79,83 @@ try {
   assert.equal(binary.exitCode, 0);
   assert.deepEqual(selectProtocolFields(binary.stdout), { command: "version", ok: true });
   assert.equal(binary.stderr, "");
+
+  const packRoot = await writeLocalStoreFixturePack(directory);
+  const decoded = await decodePackDirectory(packRoot);
+  const storeRoot = { rootPath: join(directory, "store") };
+  await createLocalStore().install(storeRoot, decoded.candidate, decoded.diagnostics);
+
+  const query = await runProcess([
+    executable,
+    "--store-root",
+    storeRoot.rootPath,
+    "query",
+    "remote requests React interface",
+  ]);
+  assert.equal(query.exitCode, 0);
+  const queryResponse: unknown = JSON.parse(query.stdout);
+  assert(isRecord(queryResponse));
+  assert.equal(queryResponse.command, "query");
+  assert.equal(queryResponse.ok, true);
+  assert(isRecord(queryResponse.data));
+  assert.equal(queryResponse.data.total, 2);
+  assert(Array.isArray(queryResponse.data.results));
+  assert.equal(queryResponse.data.results[0]?.id, "react.api-client");
+  assert.equal(query.stderr, "");
+
+  const get = await runProcess([
+    executable,
+    "--store-root",
+    storeRoot.rootPath,
+    "get",
+    "react.api-client",
+  ]);
+  assert.equal(get.exitCode, 0);
+  const getResponse: unknown = JSON.parse(get.stdout);
+  assert(isRecord(getResponse));
+  assert.equal(getResponse.command, "get");
+  assert.equal(getResponse.ok, true);
+  assert(isRecord(getResponse.data));
+  assert(isRecord(getResponse.data.practice));
+  assert.equal(getResponse.data.practice.id, "react.api-client");
+  assert.equal(getResponse.data.practice.title, "Layer React API access");
+  assert.equal(
+    getResponse.data.practice.body,
+    "Keep transport, DTO translation, and expected failures behind a feature API boundary.\n",
+  );
+  assert.equal(get.stderr, "");
+
+  const emptyQuery = await runProcess([
+    executable,
+    "--store-root",
+    join(directory, "empty-store"),
+    "query",
+    "remote requests",
+  ]);
+  assert.equal(emptyQuery.exitCode, 0);
+  const emptyQueryResponse: unknown = JSON.parse(emptyQuery.stdout);
+  assert(isRecord(emptyQueryResponse));
+  assert.equal(emptyQueryResponse.command, "query");
+  assert.equal(emptyQueryResponse.ok, true);
+  assert(isRecord(emptyQueryResponse.data));
+  assert.equal(emptyQueryResponse.data.total, 0);
+  assert.deepEqual(emptyQueryResponse.data.results, []);
+  assert.equal(emptyQuery.stderr, "");
+
+  const unknown = await runProcess([
+    executable,
+    "--store-root",
+    storeRoot.rootPath,
+    "get",
+    "react.missing",
+  ]);
+  assert.equal(unknown.exitCode, 2);
+  assert.deepEqual(selectProtocolFields(unknown.stdout), {
+    command: "get",
+    errorCode: "get.unknown_practice",
+    ok: false,
+  });
+  assert.equal(unknown.stderr, "");
 
   const discovery = await runProcess([executable]);
   assert.equal(discovery.exitCode, 0);

--- a/packages/cli/src/get/get-command.test.ts
+++ b/packages/cli/src/get/get-command.test.ts
@@ -116,7 +116,7 @@ test("maps an unknown id to the declared get.unknown_practice error", async () =
   });
 });
 
-test("rejects blank ids and empty --store-root values before service dispatch", async () => {
+test("rejects blank, malformed, and non-dotted ids before service dispatch", async () => {
   const calls: string[] = [];
   const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
     createGetCommand({
@@ -132,7 +132,10 @@ test("rejects blank ids and empty --store-root values before service dispatch", 
 
   const invocations = [
     ["get", "   "],
-    ["get", "react.api", "--store-root", ""],
+    ["get", "React.x"],
+    ["get", "foo"],
+    ["get", "react..api"],
+    ["get", "react.api_client"],
   ] as const;
   await Promise.all(
     invocations.map(async (invocation) => {
@@ -145,6 +148,32 @@ test("rejects blank ids and empty --store-root values before service dispatch", 
       });
     }),
   );
+  expect(calls).toEqual([]);
+});
+
+test("rejects an empty --store-root value before service dispatch", async () => {
+  const calls: string[] = [];
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createGetCommand({
+      get: {
+        async get(request) {
+          calls.push(request.practiceId);
+          return fixtureResult;
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  const stdout = new MemoryWriter();
+  expect(await run(["get", "react.api", "--store-root", ""], { registry: definitions, stdout })).toBe(
+    2,
+  );
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "get",
+    ok: false,
+    error: { code: "usage.invalid" },
+  });
   expect(calls).toEqual([]);
 });
 

--- a/packages/cli/src/get/get-command.test.ts
+++ b/packages/cli/src/get/get-command.test.ts
@@ -1,0 +1,201 @@
+import { expect, test } from "bun:test";
+
+import {
+  StoreRecoveryRequiredError,
+  UnknownPracticeError,
+  defaultStorageRoot,
+  type GetRequest,
+  type GetResult,
+  type GetService,
+} from "@lorelum/engine";
+import { resolve } from "node:path";
+
+import { run } from "../main.js";
+import {
+  commandRegistry,
+  describeCommand,
+  snapshotCommandDefinitions,
+  type CommandDefinition,
+} from "../registry.js";
+import { validateJsonSchema } from "../output/protocol-schema.test-helper.js";
+import type { JsonSchema } from "../output/protocol.js";
+import { createGetCommand } from "./get-command.js";
+
+class MemoryWriter {
+  value = "";
+
+  write(message: string): void {
+    this.value += message;
+  }
+}
+
+const fixtureResult: GetResult = {
+  generation: 1,
+  effectiveRevision: 1,
+  practice: {
+    id: "react.api-client",
+    title: "Layer React API access",
+    stage: "api-layer",
+    tech_stack: ["react", "typescript"],
+    applies_when: "adding remote requests to a React interface",
+    severity: "critical",
+    body: "Keep transport behind a feature API boundary.",
+    anti_patterns: [
+      {
+        id: "react.direct-http-in-component",
+        name: "Direct HTTP client in component",
+        description: "Calling axios or fetch directly from a component couples UI to transport.",
+        severity: "critical",
+      },
+    ],
+  },
+  sources: [{ pack: "local-get-fixture", sourcePath: "practices/react/api-client.md" }],
+};
+
+function service(result: GetResult = fixtureResult): GetService {
+  return {
+    async get() {
+      return result;
+    },
+  };
+}
+
+test("describes the LocalStore-backed get command contract", () => {
+  expect(describeCommand("get")).toMatchObject({
+    name: "get",
+    usage: "get <practice-id>",
+    positionals: [{ name: "practice-id", required: true }],
+    options: [
+      { name: "-h, --help", required: false },
+      { name: "--log-level <level>", required: false },
+      { name: "--store-root <path>", required: false },
+    ],
+    errorCodes: [
+      "usage.invalid",
+      "runtime.unexpected",
+      "store.busy",
+      "store.recovery-required",
+      "get.unknown_practice",
+    ],
+    exitCodes: [0, 2],
+  });
+});
+
+test("returns the canonical Practice through the JSON protocol", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createGetCommand({ get: service(), storageRoot: defaultStorageRoot() }),
+  ]);
+
+  expect(await run(["get", fixtureResult.practice.id], { registry: definitions, stdout })).toBe(0);
+  const response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({ command: "get", ok: true, data: fixtureResult });
+
+  const description = describeCommand("get") as { resultSchema: JsonSchema };
+  expect(validateJsonSchema(response.data, description.resultSchema)).toEqual([]);
+});
+
+test("maps an unknown id to the declared get.unknown_practice error", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createGetCommand({
+      get: {
+        async get() {
+          throw new UnknownPracticeError("react.missing");
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  expect(await run(["get", "react.missing"], { registry: definitions, stdout })).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "get",
+    ok: false,
+    error: { code: "get.unknown_practice" },
+  });
+});
+
+test("rejects blank ids and empty --store-root values before service dispatch", async () => {
+  const calls: string[] = [];
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createGetCommand({
+      get: {
+        async get(request) {
+          calls.push(request.practiceId);
+          return fixtureResult;
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  const invocations = [
+    ["get", "   "],
+    ["get", "react.api", "--store-root", ""],
+  ] as const;
+  await Promise.all(
+    invocations.map(async (invocation) => {
+      const stdout = new MemoryWriter();
+      expect(await run([...invocation], { registry: definitions, stdout })).toBe(2);
+      expect(JSON.parse(stdout.value)).toMatchObject({
+        command: "get",
+        ok: false,
+        error: { code: "usage.invalid" },
+      });
+    }),
+  );
+  expect(calls).toEqual([]);
+});
+
+test("maps LocalStore recovery failures to the declared public error", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createGetCommand({
+      get: {
+        async get() {
+          throw new StoreRecoveryRequiredError("test recovery failure");
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  expect(await run(["get", "react.api-client"], { registry: definitions, stdout })).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "get",
+    ok: false,
+    error: { code: "store.recovery-required" },
+  });
+});
+
+test("resolves --store-root and forwards the selected Store to the service", async () => {
+  const requests: GetRequest[] = [];
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createGetCommand({
+      get: {
+        async get(request) {
+          requests.push(request);
+          return fixtureResult;
+        },
+      },
+      storageRoot: { rootPath: "default-user-store" },
+    }),
+  ]);
+
+  const stdout = new MemoryWriter();
+  expect(
+    await run(["get", "react.api-client", "--store-root", "isolated-store"], {
+      registry: definitions,
+      stdout,
+    }),
+  ).toBe(0);
+  expect(requests[0]?.practiceId).toBe("react.api-client");
+  expect(requests[0]?.storageRoot).toEqual({
+    rootPath: resolve(process.cwd(), "isolated-store"),
+  });
+});
+
+test("get is included in the production command registry", () => {
+  expect(commandRegistry.map((definition) => definition.name)).toContain("get");
+});

--- a/packages/cli/src/get/get-command.ts
+++ b/packages/cli/src/get/get-command.ts
@@ -36,6 +36,7 @@ const resultSchema: JsonSchema = {
   },
 };
 
+/** `lore get` data contract (ADR 0011); registry validates handler output. */
 export function createGetCommand(
   services: GetCommandServices = defaultGetServices(),
 ): CommandDefinition {
@@ -48,6 +49,8 @@ export function createGetCommand(
     errorCodes: getRetrievalErrorCodes,
     exitCodes: [0, 2],
     async handler(invocation) {
+      // Syntax validation belongs to the CLI adapter: malformed ids are
+      // `usage.invalid`, while valid-format unknown ids stay domain errors.
       const practiceId = invocation.positionals[0];
       if (
         practiceId === undefined ||

--- a/packages/cli/src/get/get-command.ts
+++ b/packages/cli/src/get/get-command.ts
@@ -4,6 +4,7 @@ import {
   type GetService,
   type StorageRoot,
 } from "@lorelum/engine";
+import { ID_REGEX } from "@lorelum/format";
 
 import type { JsonSchema, JsonValue } from "../output/protocol.js";
 import { getPracticeSchema, sourceSchema } from "../output/schema-primitives.js";
@@ -48,7 +49,11 @@ export function createGetCommand(
     exitCodes: [0, 2],
     async handler(invocation) {
       const practiceId = invocation.positionals[0];
-      if (practiceId === undefined || practiceId.trim().length === 0) {
+      if (
+        practiceId === undefined ||
+        practiceId.trim().length === 0 ||
+        !ID_REGEX.test(practiceId)
+      ) {
         throw invalidInvocationError();
       }
       const storageRoot = resolveInvocationStorageRoot(

--- a/packages/cli/src/get/get-command.ts
+++ b/packages/cli/src/get/get-command.ts
@@ -1,0 +1,67 @@
+import {
+  createGetService,
+  defaultStorageRoot,
+  type GetService,
+  type StorageRoot,
+} from "@lorelum/engine";
+
+import type { JsonSchema, JsonValue } from "../output/protocol.js";
+import { getPracticeSchema, sourceSchema } from "../output/schema-primitives.js";
+import { getRetrievalErrorCodes } from "../retrieval/errors.js";
+import type { CommandDefinition } from "../registry.js";
+import { invalidInvocationError } from "../runtime/errors.js";
+import { throwGetVisibleError } from "../retrieval/errors.js";
+import { resolveInvocationStorageRoot } from "../store/storage-root.js";
+
+export interface GetCommandServices {
+  readonly get: GetService;
+  readonly storageRoot: StorageRoot;
+}
+
+function defaultGetServices(): GetCommandServices {
+  const storageRoot = defaultStorageRoot();
+  return { get: createGetService({ storageRoot }), storageRoot };
+}
+
+const resultSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["generation", "effectiveRevision", "practice", "sources"],
+  properties: {
+    generation: { type: "integer" },
+    effectiveRevision: { type: "integer" },
+    practice: getPracticeSchema,
+    sources: { type: "array", items: sourceSchema },
+  },
+};
+
+export function createGetCommand(
+  services: GetCommandServices = defaultGetServices(),
+): CommandDefinition {
+  return {
+    name: "get",
+    summary: "Retrieve exactly one canonical Practice by id from the LocalStore.",
+    positionals: [{ name: "practice-id", required: true }],
+    options: [],
+    resultSchema,
+    errorCodes: getRetrievalErrorCodes,
+    exitCodes: [0, 2],
+    async handler(invocation) {
+      const practiceId = invocation.positionals[0];
+      if (practiceId === undefined || practiceId.trim().length === 0) {
+        throw invalidInvocationError();
+      }
+      const storageRoot = resolveInvocationStorageRoot(
+        invocation.options.storeRoot,
+        services.storageRoot,
+      );
+
+      try {
+        const result = await services.get.get({ practiceId, storageRoot });
+        return { data: result as unknown as JsonValue };
+      } catch (error) {
+        throwGetVisibleError(error);
+      }
+    },
+  };
+}

--- a/packages/cli/src/install/install-command.ts
+++ b/packages/cli/src/install/install-command.ts
@@ -3,8 +3,6 @@ import {
   PackValidationError,
   PracticeConflictError,
   SnapshotFormatError,
-  StoreBusyError,
-  StoreRecoveryRequiredError,
   UpgradeRequiredError,
   createLocalStore,
   decodePackDirectory,
@@ -18,6 +16,7 @@ import type { RegistryRelease } from "@lorelum/format";
 import type { JsonSchema, JsonValue } from "../output/protocol.js";
 import type { CommandDefinition } from "../registry.js";
 import { CliError, cliErrorCodes, frameworkErrorCodes } from "../runtime/errors.js";
+import { throwVisibleStoreError } from "../runtime/store-errors.js";
 import { resolveInvocationStorageRoot } from "../store/storage-root.js";
 import { loadRegistry, type LoadedRegistry } from "./load-registry.js";
 import { materializeRegistryRelease, type MaterializedPackSource } from "./materialize-source.js";
@@ -152,16 +151,7 @@ function throwVisibleInstallError(error: unknown): never {
       `Practice "${error.practiceId}" conflicts with an installed Pack.`,
     );
   }
-  if (error instanceof StoreBusyError) {
-    throw new CliError(cliErrorCodes.storeBusy, "The local Pack store is busy.");
-  }
-  if (error instanceof StoreRecoveryRequiredError) {
-    throw new CliError(
-      cliErrorCodes.storeRecoveryRequired,
-      "The local Pack store requires recovery.",
-    );
-  }
-  throw error;
+  throwVisibleStoreError(error);
 }
 
 async function installPack(

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -35,6 +35,8 @@ test("returns machine-readable root capability discovery", async () => {
         { name: "format" },
         { name: "i18n.sync" },
         { name: "validate" },
+        { name: "query" },
+        { name: "get" },
       ],
     },
   });

--- a/packages/cli/src/output/schema-primitives.ts
+++ b/packages/cli/src/output/schema-primitives.ts
@@ -1,0 +1,64 @@
+import type { JsonSchema } from "./protocol.js";
+
+export const stringSchema: JsonSchema = { type: "string" };
+export const stringArraySchema: JsonSchema = { type: "array", items: stringSchema };
+
+/** Canonical severity values shared by Practice and anti-pattern schemas. */
+export const severitySchema: JsonSchema = { enum: ["info", "warn", "critical"] };
+
+/** One LocalStore source claim projected for retrieval consumers. */
+export const sourceSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["pack", "sourcePath"],
+  properties: { pack: stringSchema, sourcePath: stringSchema },
+};
+
+/** One structured anti-pattern in canonical get output. */
+export const antiPatternSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["id", "name", "description", "severity"],
+  properties: {
+    id: stringSchema,
+    name: stringSchema,
+    description: stringSchema,
+    severity: severitySchema,
+  },
+};
+
+/** Summary Practice fields shared by retrieval result schemas (ADR 0010). */
+export const practiceSummarySchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["id", "title", "stage", "tech_stack", "applies_when"],
+  properties: {
+    id: stringSchema,
+    title: stringSchema,
+    stage: stringSchema,
+    tech_stack: stringArraySchema,
+    applies_when: stringSchema,
+  },
+};
+
+/** Complete canonical Practice returned by `lore get` (ADR 0011). */
+export const getPracticeSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "id",
+    "title",
+    "stage",
+    "tech_stack",
+    "applies_when",
+    "severity",
+    "body",
+    "anti_patterns",
+  ],
+  properties: {
+    ...practiceSummarySchema.properties,
+    severity: severitySchema,
+    body: stringSchema,
+    anti_patterns: { type: "array", items: antiPatternSchema },
+  },
+};

--- a/packages/cli/src/query/query-command.test.ts
+++ b/packages/cli/src/query/query-command.test.ts
@@ -1,0 +1,196 @@
+import { expect, test } from "bun:test";
+
+import {
+  StoreRecoveryRequiredError,
+  defaultStorageRoot,
+  type QueryRequest,
+  type QueryResult,
+  type QueryService,
+} from "@lorelum/engine";
+import { resolve } from "node:path";
+
+import { run } from "../main.js";
+import {
+  commandRegistry,
+  describeCommand,
+  snapshotCommandDefinitions,
+  type CommandDefinition,
+} from "../registry.js";
+import { validateJsonSchema } from "../output/protocol-schema.test-helper.js";
+import type { JsonSchema } from "../output/protocol.js";
+import { createQueryCommand } from "./query-command.js";
+
+class MemoryWriter {
+  value = "";
+
+  write(message: string): void {
+    this.value += message;
+  }
+}
+
+const fixtureResult: QueryResult = {
+  query: "axios call in React component",
+  k: 5,
+  total: 1,
+  generation: 1,
+  effectiveRevision: 1,
+  results: [
+    {
+      id: "react.api-client",
+      title: "Layer React API access",
+      stage: "api-layer",
+      tech_stack: ["react", "typescript"],
+      applies_when: "adding remote requests to a React interface",
+    },
+  ],
+};
+
+function service(result: QueryResult = fixtureResult): QueryService {
+  return {
+    async query() {
+      return result;
+    },
+  };
+}
+
+test("describes the LocalStore-backed query command contract", () => {
+  expect(describeCommand("query")).toMatchObject({
+    name: "query",
+    usage: "query <query>",
+    positionals: [{ name: "query", required: true }],
+    options: [
+      { name: "-h, --help", required: false },
+      { name: "--log-level <level>", required: false },
+      { name: "--store-root <path>", required: false },
+      { name: "--top-k <count>", required: false },
+    ],
+    errorCodes: ["usage.invalid", "runtime.unexpected", "store.busy", "store.recovery-required"],
+    exitCodes: [0, 2],
+  });
+});
+
+test("returns Practices through the JSON protocol", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createQueryCommand({ query: service(), storageRoot: defaultStorageRoot() }),
+  ]);
+
+  expect(
+    await run(["query", fixtureResult.query, "--top-k", "5"], { registry: definitions, stdout }),
+  ).toBe(0);
+  const response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({ command: "query", ok: true, data: fixtureResult });
+
+  const description = describeCommand("query") as { resultSchema: JsonSchema };
+  expect(validateJsonSchema(response.data, description.resultSchema)).toEqual([]);
+});
+
+test("rejects blank queries and invalid top-k values before service dispatch", async () => {
+  const calls: string[] = [];
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createQueryCommand({
+      query: {
+        async query(request) {
+          calls.push(request.query);
+          return fixtureResult;
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  const invocations = [
+    ["query", "   "],
+    ["query", "axios", "--top-k", "0"],
+    ["query", "axios", "--top-k", "51"],
+  ] as const;
+  await Promise.all(
+    invocations.map(async (invocation) => {
+      const stdout = new MemoryWriter();
+      expect(await run([...invocation], { registry: definitions, stdout })).toBe(2);
+      expect(JSON.parse(stdout.value)).toMatchObject({
+        command: "query",
+        ok: false,
+        error: { code: "usage.invalid" },
+      });
+    }),
+  );
+  expect(calls).toEqual([]);
+});
+
+test("maps LocalStore recovery failures to the declared public error", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createQueryCommand({
+      query: {
+        async query() {
+          throw new StoreRecoveryRequiredError("test recovery failure");
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  expect(await run(["query", "axios component"], { registry: definitions, stdout })).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "query",
+    ok: false,
+    error: { code: "store.recovery-required" },
+  });
+});
+
+test("resolves --store-root and forwards the selected Store to the service", async () => {
+  const requests: QueryRequest[] = [];
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createQueryCommand({
+      query: {
+        async query(request) {
+          requests.push(request);
+          return fixtureResult;
+        },
+      },
+      storageRoot: { rootPath: "default-user-store" },
+    }),
+  ]);
+
+  const stdout = new MemoryWriter();
+  expect(
+    await run(["query", "axios", "--store-root", "isolated-store"], {
+      registry: definitions,
+      stdout,
+    }),
+  ).toBe(0);
+  expect(requests[0]?.storageRoot).toEqual({
+    rootPath: resolve(process.cwd(), "isolated-store"),
+  });
+});
+
+test("rejects an empty --store-root value before service dispatch", async () => {
+  const calls: string[] = [];
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createQueryCommand({
+      query: {
+        async query(request) {
+          calls.push(request.query);
+          return fixtureResult;
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  const stdout = new MemoryWriter();
+  expect(await run(["query", "axios", "--store-root", ""], { registry: definitions, stdout })).toBe(
+    2,
+  );
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "query",
+    ok: false,
+    error: { code: "usage.invalid" },
+  });
+  expect(calls).toEqual([]);
+});
+
+test("query is included in the production command registry", () => {
+  expect(commandRegistry.map((definition) => definition.name)).toContain("query");
+});

--- a/packages/cli/src/query/query-command.ts
+++ b/packages/cli/src/query/query-command.ts
@@ -1,0 +1,85 @@
+import {
+  DEFAULT_QUERY_TOP_K,
+  MAX_QUERY_TOP_K,
+  MIN_QUERY_TOP_K,
+  createQueryService,
+  defaultStorageRoot,
+  type QueryService,
+  type StorageRoot,
+} from "@lorelum/engine";
+
+import type { JsonSchema, JsonValue } from "../output/protocol.js";
+import { practiceSummarySchema, stringSchema } from "../output/schema-primitives.js";
+import { retrievalErrorCodes } from "../retrieval/errors.js";
+import { parseTopKOption } from "../retrieval/top-k-option.js";
+import type { CommandDefinition } from "../registry.js";
+import { invalidInvocationError } from "../runtime/errors.js";
+import { throwVisibleStoreError } from "../runtime/store-errors.js";
+import { resolveInvocationStorageRoot } from "../store/storage-root.js";
+
+export interface QueryCommandServices {
+  readonly query: QueryService;
+  readonly storageRoot: StorageRoot;
+}
+
+function defaultQueryServices(): QueryCommandServices {
+  const storageRoot = defaultStorageRoot();
+  return { query: createQueryService({ storageRoot }), storageRoot };
+}
+
+const resultSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["query", "k", "total", "generation", "effectiveRevision", "results"],
+  properties: {
+    query: stringSchema,
+    k: { type: "integer" },
+    total: { type: "integer" },
+    generation: { type: "integer" },
+    effectiveRevision: { type: "integer" },
+    results: { type: "array", items: practiceSummarySchema },
+  },
+};
+
+const topKBounds = {
+  defaultTopK: DEFAULT_QUERY_TOP_K,
+  minTopK: MIN_QUERY_TOP_K,
+  maxTopK: MAX_QUERY_TOP_K,
+} as const;
+
+export function createQueryCommand(
+  services: QueryCommandServices = defaultQueryServices(),
+): CommandDefinition {
+  return {
+    name: "query",
+    summary: "Retrieve Practices relevant to a natural-language engineering task.",
+    positionals: [{ name: "query", required: true }],
+    options: [
+      {
+        longFlag: "--top-k",
+        description: "Maximum Practices to return; default 5, valid range 1-50.",
+        value: { name: "count", required: true },
+        optionRequired: false,
+      },
+    ],
+    resultSchema,
+    errorCodes: retrievalErrorCodes,
+    exitCodes: [0, 2],
+    async handler(invocation) {
+      const query = invocation.positionals[0];
+      if (query === undefined || query.trim().length === 0) throw invalidInvocationError();
+      const topK = parseTopKOption(invocation.options.topK, topKBounds);
+      const storageRoot = resolveInvocationStorageRoot(
+        invocation.options.storeRoot,
+        services.storageRoot,
+      );
+
+      try {
+        const result = await services.query.query({ query, topK, storageRoot });
+        return { data: result as unknown as JsonValue };
+      } catch (error) {
+        throwVisibleStoreError(error);
+      }
+    },
+  };
+}

--- a/packages/cli/src/query/query-command.ts
+++ b/packages/cli/src/query/query-command.ts
@@ -41,6 +41,7 @@ const resultSchema: JsonSchema = {
   },
 };
 
+/** `lore query` data contract (ADR 0010); registry validates handler output. */
 const topKBounds = {
   defaultTopK: DEFAULT_QUERY_TOP_K,
   minTopK: MIN_QUERY_TOP_K,
@@ -66,6 +67,8 @@ export function createQueryCommand(
     errorCodes: retrievalErrorCodes,
     exitCodes: [0, 2],
     async handler(invocation) {
+      // Validate CLI-owned arguments before Store dispatch; Store health is
+      // reported separately through the shared visible error mapping below.
       const query = invocation.positionals[0];
       if (query === undefined || query.trim().length === 0) throw invalidInvocationError();
       const topK = parseTopKOption(invocation.options.topK, topKBounds);

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -212,7 +212,10 @@ test("describes registered commands from a single registry", () => {
       {
         name: "describe",
         positionals: [
-          { name: "command", values: ["describe", "install", "format", "i18n.sync", "validate"] },
+          {
+            name: "command",
+            values: ["describe", "install", "format", "i18n.sync", "validate", "query", "get"],
+          },
         ],
       },
       {
@@ -222,6 +225,14 @@ test("describes registered commands from a single registry", () => {
       { name: "format" },
       { name: "i18n.sync" },
       { name: "validate" },
+      {
+        name: "query",
+        positionals: [{ name: "query", required: true }],
+      },
+      {
+        name: "get",
+        positionals: [{ name: "practice-id", required: true }],
+      },
     ],
   });
   expect(describeCommand("describe")).toMatchObject({
@@ -265,7 +276,16 @@ test("derives parser options and describe metadata from registered commands", as
     positionals: [
       {
         name: "command",
-        values: ["describe", "install", "format", "i18n.sync", "validate", "future"],
+        values: [
+          "describe",
+          "install",
+          "format",
+          "i18n.sync",
+          "validate",
+          "query",
+          "get",
+          "future",
+        ],
       },
     ],
   });

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -8,6 +8,8 @@ import { frameworkErrorCodes, invalidInvocationError } from "./runtime/errors.js
 import { logLevels } from "./runtime/logger.js";
 import { createInstallCommand } from "./install/install-command.js";
 import { createLocalizationCommands } from "./localization/index.js";
+import { createQueryCommand } from "./query/query-command.js";
+import { createGetCommand } from "./get/get-command.js";
 
 export interface CommandOption {
   readonly longFlag: string;
@@ -229,6 +231,8 @@ export const commandRegistry = snapshotCommandDefinitions([
   discoveryCommandDefinition,
   createInstallCommand(),
   ...createLocalizationCommands(),
+  createQueryCommand(),
+  createGetCommand(),
 ]);
 
 export type KnownCommand = "lore" | (typeof commandRegistry)[number]["name"];

--- a/packages/cli/src/retrieval/errors.ts
+++ b/packages/cli/src/retrieval/errors.ts
@@ -6,6 +6,8 @@ import { throwVisibleStoreError } from "../runtime/store-errors.js";
 /** Error allowlist shared by LocalStore-backed retrieval commands. */
 export const retrievalErrorCodes = Object.freeze([
   ...frameworkErrorCodes,
+  // CLI-owned domain codes for retrieval commands stay in `retrieval/errors`;
+  // engine/store failures are translated here instead of leaking internals.
   cliErrorCodes.storeBusy,
   cliErrorCodes.storeRecoveryRequired,
 ]);

--- a/packages/cli/src/retrieval/errors.ts
+++ b/packages/cli/src/retrieval/errors.ts
@@ -1,0 +1,33 @@
+import { UnknownPracticeError } from "@lorelum/engine";
+
+import { CliError, cliErrorCodes, frameworkErrorCodes } from "../runtime/errors.js";
+import { throwVisibleStoreError } from "../runtime/store-errors.js";
+
+/** Error allowlist shared by LocalStore-backed retrieval commands. */
+export const retrievalErrorCodes = Object.freeze([
+  ...frameworkErrorCodes,
+  cliErrorCodes.storeBusy,
+  cliErrorCodes.storeRecoveryRequired,
+]);
+
+/** Error allowlist for id-addressed LocalStore retrieval (`lore get`). */
+export const getRetrievalErrorCodes = Object.freeze([
+  ...retrievalErrorCodes,
+  cliErrorCodes.getUnknownPractice,
+]);
+
+/** Convert engine domain errors to visible CLI errors; returns undefined when not one. */
+export function toGetCliError(error: unknown): CliError | undefined {
+  if (error instanceof UnknownPracticeError) {
+    return new CliError(cliErrorCodes.getUnknownPractice, error.message);
+  }
+  return undefined;
+}
+
+/** Re-throw a mapped CliError, a get domain error, or a store error verbatim. */
+export function throwGetVisibleError(error: unknown): never {
+  if (error instanceof CliError) throw error;
+  const getError = toGetCliError(error);
+  if (getError !== undefined) throw getError;
+  throwVisibleStoreError(error);
+}

--- a/packages/cli/src/retrieval/top-k-option.ts
+++ b/packages/cli/src/retrieval/top-k-option.ts
@@ -1,0 +1,23 @@
+import { invalidInvocationError } from "../runtime/errors.js";
+
+export interface TopKOptionBounds {
+  readonly defaultTopK: number;
+  readonly minTopK: number;
+  readonly maxTopK: number;
+}
+
+/**
+ * Parse the `--top-k <count>` option against the given command bounds.
+ * Undefined falls back to the default; malformed or out-of-range values
+ * are `usage.invalid`. Used by `query` (ADR 0010) and future retrieval
+ * commands that expose the same bounded option.
+ */
+export function parseTopKOption(value: unknown, bounds: TopKOptionBounds): number {
+  if (value === undefined) return bounds.defaultTopK;
+  if (typeof value !== "string" || !/^[1-9]\d*$/.test(value)) {
+    throw invalidInvocationError();
+  }
+  const topK = Number.parseInt(value, 10);
+  if (topK < bounds.minTopK || topK > bounds.maxTopK) throw invalidInvocationError();
+  return topK;
+}

--- a/packages/cli/src/runtime/errors.ts
+++ b/packages/cli/src/runtime/errors.ts
@@ -2,6 +2,8 @@ export const cliErrorCodes = Object.freeze({
   packInvalid: "pack.invalid",
   packUpgradeRequired: "pack.upgrade-required",
   practiceConflict: "practice.conflict",
+  // Error codes are the stable agent-visible surface; handler allowlists and
+  // tests must stay in sync with these canonical string values.
   registryInvalid: "registry.invalid",
   registryPackNotFound: "registry.pack-not-found",
   registryUnavailable: "registry.unavailable",

--- a/packages/cli/src/runtime/errors.ts
+++ b/packages/cli/src/runtime/errors.ts
@@ -11,6 +11,7 @@ export const cliErrorCodes = Object.freeze({
   sourceUnavailable: "source.unavailable",
   storeBusy: "store.busy",
   storeRecoveryRequired: "store.recovery-required",
+  getUnknownPractice: "get.unknown_practice",
   localizationInvalid: "localization.invalid",
   localizationPracticeNotFound: "localization.practice-not-found",
   usageInvalid: "usage.invalid",

--- a/packages/cli/src/runtime/store-errors.ts
+++ b/packages/cli/src/runtime/store-errors.ts
@@ -2,6 +2,7 @@ import { StoreBusyError, StoreRecoveryRequiredError } from "@lorelum/engine";
 
 import { CliError, cliErrorCodes } from "./errors.js";
 
+/** Keep LocalStore error translation in one place for every CLI consumer. */
 export function toStoreCliError(error: unknown): CliError | undefined {
   if (error instanceof StoreBusyError) {
     return new CliError(cliErrorCodes.storeBusy, "The local Pack store is busy.");

--- a/packages/cli/src/runtime/store-errors.ts
+++ b/packages/cli/src/runtime/store-errors.ts
@@ -1,0 +1,27 @@
+import { StoreBusyError, StoreRecoveryRequiredError } from "@lorelum/engine";
+
+import { CliError, cliErrorCodes } from "./errors.js";
+
+export function toStoreCliError(error: unknown): CliError | undefined {
+  if (error instanceof StoreBusyError) {
+    return new CliError(cliErrorCodes.storeBusy, "The local Pack store is busy.");
+  }
+  if (error instanceof StoreRecoveryRequiredError) {
+    return new CliError(
+      cliErrorCodes.storeRecoveryRequired,
+      "The local Pack store requires recovery.",
+    );
+  }
+  return undefined;
+}
+
+/**
+ * Re-throw an already-mapped CliError or a LocalStore failure verbatim; fall
+ * through to the original error otherwise. Shared by retrieval commands.
+ */
+export function throwVisibleStoreError(error: unknown): never {
+  if (error instanceof CliError) throw error;
+  const storeError = toStoreCliError(error);
+  if (storeError !== undefined) throw storeError;
+  throw error;
+}

--- a/packages/engine/src/get/errors.ts
+++ b/packages/engine/src/get/errors.ts
@@ -1,0 +1,7 @@
+/** Thrown when `get` resolves a Practice id that matches no effective Practice. */
+export class UnknownPracticeError extends Error {
+  constructor(practiceId: string) {
+    super(`No effective Practice exists with id "${practiceId}".`);
+    this.name = "UnknownPracticeError";
+  }
+}

--- a/packages/engine/src/get/index.ts
+++ b/packages/engine/src/get/index.ts
@@ -1,0 +1,4 @@
+export { UnknownPracticeError } from "./errors.js";
+export { retrievePractice } from "./retrieve.js";
+export { createGetService, type GetService, type GetServiceOptions } from "./service.js";
+export type { GetPractice, GetPracticeResult, GetRequest, GetResult } from "./types.js";

--- a/packages/engine/src/get/retrieve.test.ts
+++ b/packages/engine/src/get/retrieve.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+
+import type { EffectivePractice } from "../local-store/model/types.js";
+import { retrievePractice } from "./retrieve.js";
+
+function effectivePractice(
+  id: string,
+  overrides: Partial<EffectivePractice["practice"]> = {},
+): EffectivePractice {
+  const practice: EffectivePractice["practice"] = {
+    id,
+    title: `Practice ${id}`,
+    stage: "test",
+    tech_stack: ["typescript"],
+    applies_when: "testing get retrieval",
+    severity: "warn",
+    body: `Guidance for ${id}.`,
+    anti_patterns: [],
+    ...overrides,
+  };
+  const contentDigest = `${id}-digest`;
+  return {
+    practiceId: id,
+    contentDigest,
+    canonicalContent: id,
+    practice,
+    sources: [
+      {
+        packName: `pack-${id.replaceAll(".", "-")}`,
+        practiceId: id,
+        contentDigest,
+        sourcePath: `practices/${id}.md`,
+        canonicalPractice: { practice, canonicalContent: id, contentDigest },
+      },
+    ],
+  };
+}
+
+describe("retrievePractice", () => {
+  test("resolves exactly one id and projects the canonical Practice plus sources", () => {
+    const result = retrievePractice(
+      [
+        effectivePractice("react.api", {
+          title: "Layer React API access",
+          severity: "critical",
+          body: "Keep transport behind a feature boundary.",
+          anti_patterns: [
+            {
+              id: "react.direct-http",
+              name: "Direct HTTP client in component",
+              description: "Calling axios from a component couples UI to transport.",
+              severity: "critical",
+            },
+          ],
+        }),
+      ],
+      "react.api",
+    );
+
+    expect(result).toEqual({
+      practice: {
+        id: "react.api",
+        title: "Layer React API access",
+        stage: "test",
+        tech_stack: ["typescript"],
+        applies_when: "testing get retrieval",
+        severity: "critical",
+        body: "Keep transport behind a feature boundary.",
+        anti_patterns: [
+          {
+            id: "react.direct-http",
+            name: "Direct HTTP client in component",
+            description: "Calling axios from a component couples UI to transport.",
+            severity: "critical",
+          },
+        ],
+      },
+      sources: [
+        {
+          pack: "pack-react-api",
+          sourcePath: "practices/react.api.md",
+        },
+      ],
+    });
+  });
+
+  test("returns null when no effective Practice matches the id", () => {
+    expect(retrievePractice([effectivePractice("react.api")], "react.state")).toBeNull();
+  });
+
+  test("preserves canonical defaults and sorts source claims deterministically", () => {
+    const effective = effectivePractice("react.api");
+    const result = retrievePractice([effective], "react.api");
+
+    expect(result?.practice).toMatchObject({
+      severity: "warn",
+      body: "Guidance for react.api.",
+      anti_patterns: [],
+    });
+    expect(result?.sources).toEqual([
+      { pack: "pack-react-api", sourcePath: "practices/react.api.md" },
+    ]);
+  });
+});

--- a/packages/engine/src/get/retrieve.ts
+++ b/packages/engine/src/get/retrieve.ts
@@ -1,0 +1,34 @@
+import type { EffectivePractice } from "../local-store/model/types.js";
+import { compareSourceResults, projectSourceResult } from "../retrieval/source-projection.js";
+import type { GetPracticeResult } from "./types.js";
+
+/**
+ * Resolve exactly one Practice id against LocalStore Effective Practices.
+ * Pure and deterministic: source claims are projected to `PracticeSourceResult`
+ * and sorted by `(pack, sourcePath)` (ADR 0011). Returns `null` when no
+ * Practice matches; the service boundary owns converting that to a typed
+ * `UnknownPracticeError`.
+ */
+export function retrievePractice(
+  effectivePractices: readonly EffectivePractice[],
+  practiceId: string,
+): GetPracticeResult | null {
+  const effective = effectivePractices.find((candidate) => candidate.practiceId === practiceId);
+  if (effective === undefined) return null;
+
+  return {
+    practice: {
+      id: effective.practice.id,
+      title: effective.practice.title,
+      stage: effective.practice.stage,
+      tech_stack: [...effective.practice.tech_stack],
+      applies_when: effective.practice.applies_when,
+      severity: effective.practice.severity,
+      body: effective.practice.body,
+      anti_patterns: effective.practice.anti_patterns.map((antiPattern) => ({
+        ...antiPattern,
+      })),
+    },
+    sources: effective.sources.map(projectSourceResult).sort(compareSourceResults),
+  };
+}

--- a/packages/engine/src/get/retrieve.ts
+++ b/packages/engine/src/get/retrieve.ts
@@ -16,6 +16,8 @@ export function retrievePractice(
   const effective = effectivePractices.find((candidate) => candidate.practiceId === practiceId);
   if (effective === undefined) return null;
 
+  // Copy mutable array fields so service results cannot alias LocalStore
+  // snapshots and later callers cannot mutate the frozen store model.
   return {
     practice: {
       id: effective.practice.id,
@@ -29,6 +31,8 @@ export function retrievePractice(
         ...antiPattern,
       })),
     },
+    // Project before sorting so the shared projection is the only source
+    // shape exposed; LocalStore storage fields stay behind the boundary.
     sources: effective.sources.map(projectSourceResult).sort(compareSourceResults),
   };
 }

--- a/packages/engine/src/get/service.test.ts
+++ b/packages/engine/src/get/service.test.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createLocalStore, decodePackDirectory, type StorageRoot } from "../local-store/index.js";
+import { UnknownPracticeError } from "./errors.js";
+import { createGetService } from "./service.js";
+
+async function removeStoreRoot(rootPath: string): Promise<void> {
+  /* eslint-disable no-await-in-loop -- Windows may release SQLite handles asynchronously. */
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      await rm(rootPath, { force: true, recursive: true });
+      return;
+    } catch (error) {
+      if (attempt === 9) throw error;
+      await Bun.sleep(50);
+    }
+  }
+  /* eslint-enable no-await-in-loop */
+}
+
+async function writeLocalGetPack(directory: string): Promise<string> {
+  const packRoot = join(directory, "local-get-pack");
+  const practices = join(packRoot, "practices", "react");
+  await mkdir(practices, { recursive: true });
+  await writeFile(join(packRoot, "pack.yaml"), "name: local-get-fixture\nversion: 0.1.0\n");
+  await writeFile(
+    join(practices, "api-client.md"),
+    [
+      "---",
+      "id: react.api-client",
+      "title: Layer React API access",
+      "stage: api-layer",
+      "tech_stack: [react, typescript]",
+      "applies_when: adding remote requests to a React interface",
+      "severity: warn",
+      "anti_patterns:",
+      "  - id: react.direct-http-in-component",
+      "    name: Direct HTTP client in component",
+      "    description: Calling axios or fetch directly from a component couples UI to transport.",
+      "    severity: critical",
+      "---",
+      "Keep transport, DTO translation, and expected failures behind a feature API boundary.",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    join(practices, "resource-state.md"),
+    [
+      "---",
+      "id: react.resource-state",
+      "title: Separate resource and UI state",
+      "stage: state",
+      "tech_stack: [react, typescript]",
+      "applies_when: storing remote resource data used by a React interface",
+      "severity: warn",
+      "---",
+      "Model resource data separately from view state and transform DTOs at the boundary.",
+      "",
+    ].join("\n"),
+  );
+  return packRoot;
+}
+
+test("GetService reads a simple installed Pack through LocalStore", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-get-service-"));
+  const storageRoot: StorageRoot = { rootPath: join(directory, "store") };
+  try {
+    const packRoot = await writeLocalGetPack(directory);
+    const decoded = await decodePackDirectory(packRoot);
+    const store = createLocalStore();
+    await store.install(storageRoot, decoded.candidate, decoded.diagnostics);
+    const service = createGetService({ store, storageRoot });
+
+    const result = await service.get({ practiceId: "react.api-client" });
+    expect(result).toMatchObject({
+      generation: 1,
+      effectiveRevision: 1,
+      sources: [
+        {
+          pack: "local-get-fixture",
+          sourcePath: "practices/react/api-client.md",
+        },
+      ],
+    });
+    expect(result.practice).toMatchObject({
+      id: "react.api-client",
+      title: "Layer React API access",
+      stage: "api-layer",
+      tech_stack: ["react", "typescript"],
+      applies_when: "adding remote requests to a React interface",
+      severity: "warn",
+      body: "Keep transport, DTO translation, and expected failures behind a feature API boundary.\n",
+    });
+    expect(result.practice.anti_patterns).toEqual([
+      {
+        id: "react.direct-http-in-component",
+        name: "Direct HTTP client in component",
+        description: "Calling axios or fetch directly from a component couples UI to transport.",
+        severity: "critical",
+      },
+    ]);
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});
+
+test("GetService honors a per-call storageRoot override", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-get-override-"));
+  const defaultRoot: StorageRoot = { rootPath: join(directory, "default-store") };
+  const overrideRoot: StorageRoot = { rootPath: join(directory, "override-store") };
+  try {
+    const packRoot = await writeLocalGetPack(directory);
+    const decoded = await decodePackDirectory(packRoot);
+    const store = createLocalStore();
+    await store.install(overrideRoot, decoded.candidate, decoded.diagnostics);
+    const service = createGetService({ store, storageRoot: defaultRoot });
+
+    const overridden = await service.get({
+      practiceId: "react.api-client",
+      storageRoot: overrideRoot,
+    });
+    expect(overridden).toMatchObject({
+      generation: 1,
+      effectiveRevision: 1,
+      practice: { id: "react.api-client" },
+    });
+
+    await expect(service.get({ practiceId: "react.api-client" })).rejects.toThrow(
+      UnknownPracticeError,
+    );
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});
+
+test("GetService succeeds with an empty fresh LocalStore", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-get-empty-"));
+  const storageRoot: StorageRoot = { rootPath: join(directory, "store") };
+  try {
+    const service = createGetService({ storageRoot });
+    await expect(service.get({ practiceId: "react.api-client" })).rejects.toThrow(
+      UnknownPracticeError,
+    );
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});
+
+test("GetService maps a blank id to UnknownPracticeError before store access", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-get-blank-"));
+  const storageRoot: StorageRoot = { rootPath: join(directory, "store") };
+  try {
+    const service = createGetService({ storageRoot });
+    await expect(service.get({ practiceId: "   " })).rejects.toThrow(UnknownPracticeError);
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});

--- a/packages/engine/src/get/service.ts
+++ b/packages/engine/src/get/service.ts
@@ -1,0 +1,48 @@
+import {
+  createLocalStore,
+  defaultStorageRoot,
+  type LocalStore,
+  type StorageRoot,
+} from "../local-store/lifecycle/local-store.js";
+import { UnknownPracticeError } from "./errors.js";
+import { retrievePractice } from "./retrieve.js";
+import type { GetRequest, GetResult } from "./types.js";
+
+export interface GetService {
+  get(request: GetRequest): Promise<GetResult>;
+}
+
+export interface GetServiceOptions {
+  readonly store?: LocalStore;
+  readonly storageRoot?: StorageRoot;
+}
+
+/**
+ * Application boundary shared by CLI and future MCP adapters. It cold-opens
+ * the selected LocalStore (per-call root override or the service default),
+ * resolves exactly one Practice id, and converts the pure retrieval layer's
+ * `null` into `UnknownPracticeError`. The CLI never inspects `null` and never
+ * constructs that error itself (ADR 0011).
+ */
+export function createGetService(options: GetServiceOptions = {}): GetService {
+  const store = options.store ?? createLocalStore();
+  const fallbackStorageRoot = options.storageRoot ?? defaultStorageRoot();
+
+  return Object.freeze({
+    async get(request: GetRequest): Promise<GetResult> {
+      const practiceId = request.practiceId;
+      if (typeof practiceId !== "string" || practiceId.trim().length === 0) {
+        throw new UnknownPracticeError(practiceId);
+      }
+
+      const opened = await store.open(request.storageRoot ?? fallbackStorageRoot);
+      const retrieved = retrievePractice(opened.effectivePractices, practiceId);
+      if (retrieved === null) throw new UnknownPracticeError(practiceId);
+      return {
+        ...retrieved,
+        generation: opened.generation,
+        effectiveRevision: opened.effectiveRevision,
+      };
+    },
+  });
+}

--- a/packages/engine/src/get/service.ts
+++ b/packages/engine/src/get/service.ts
@@ -32,6 +32,8 @@ export function createGetService(options: GetServiceOptions = {}): GetService {
     async get(request: GetRequest): Promise<GetResult> {
       const practiceId = request.practiceId;
       if (typeof practiceId !== "string" || practiceId.trim().length === 0) {
+        // The service accepts valid-format ids and treats an unknown id as a
+        // domain error; syntax-only rejection is owned by the CLI adapter.
         throw new UnknownPracticeError(practiceId);
       }
 

--- a/packages/engine/src/get/types.ts
+++ b/packages/engine/src/get/types.ts
@@ -1,0 +1,30 @@
+import type { StorageRoot } from "../local-store/lifecycle/local-store.js";
+import type { EffectivePractice } from "../local-store/model/types.js";
+import type { PracticeSourceResult } from "../retrieval/types.js";
+
+/** Practice fields returned by `get`, matching the canonical LocalStore snapshot. */
+export type GetPractice = Readonly<
+  Pick<
+    EffectivePractice["practice"],
+    "id" | "title" | "stage" | "tech_stack" | "applies_when" | "severity" | "body" | "anti_patterns"
+  >
+>;
+
+/** The get-specific projection of one resolved Practice. */
+export interface GetPracticeResult {
+  readonly practice: GetPractice;
+  /** Every active LocalStore source claim, in deterministic source order. */
+  readonly sources: readonly PracticeSourceResult[];
+}
+
+export interface GetRequest {
+  /** Dotted Practice id (ADR 0003 §5); `lore get` resolves exactly one id. */
+  readonly practiceId: string;
+  /** Per-call LocalStore root override; omitted uses the service default. */
+  readonly storageRoot?: StorageRoot;
+}
+
+export interface GetResult extends GetPracticeResult {
+  readonly generation: number;
+  readonly effectiveRevision: number;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -11,3 +11,5 @@ export const PACKAGE_NAME = "@lorelum/engine";
 // vector layer and CLI/MCP consumers take their entry point from this
 // boundary, never from package-internal directories.
 export * from "./local-store";
+export * from "./query";
+export * from "./get";

--- a/packages/engine/src/local-store/model/types.ts
+++ b/packages/engine/src/local-store/model/types.ts
@@ -2,9 +2,15 @@ import type { DecisionNode, Pack, Practice } from "@lorelum/format";
 
 /** Deeply frozen snapshot retained after canonicalization. */
 export type PracticeSnapshot = Readonly<
-  Omit<Practice, "tech_stack" | "anti_patterns"> & {
+  Omit<Practice, "tech_stack" | "severity" | "body" | "anti_patterns"> & {
     tech_stack: readonly string[];
-    anti_patterns?: readonly Readonly<NonNullable<Practice["anti_patterns"]>[number]>[];
+    severity: NonNullable<Practice["severity"]>;
+    body: string;
+    anti_patterns: readonly Readonly<
+      Omit<NonNullable<Practice["anti_patterns"]>[number], "severity"> & {
+        severity: NonNullable<NonNullable<Practice["anti_patterns"]>[number]["severity"]>;
+      }
+    >[];
   }
 >;
 

--- a/packages/engine/src/local-store/storage/artifacts/snapshot-writer.ts
+++ b/packages/engine/src/local-store/storage/artifacts/snapshot-writer.ts
@@ -29,7 +29,7 @@ function frontmatterFields(
     stage,
     tech_stack,
     applies_when,
-    ...(severity === undefined ? {} : { severity }),
+    severity,
     ...(anti_patterns === undefined || anti_patterns.length === 0 ? {} : { anti_patterns }),
   };
 }
@@ -75,7 +75,7 @@ export async function writeSnapshotFromCandidate(
       try {
         await mkdir(join(markdownPath, ".."), { recursive: true });
         const frontmatter = JSON.stringify(frontmatterFields(practice));
-        const body = practice.body ?? "";
+        const body = practice.body;
         await writeFile(markdownPath, `---\n${frontmatter}\n---\n${body}`, "utf8");
       } catch (error) {
         throw new ArtifactIntegrityError(

--- a/packages/engine/src/local-store/storage/sqlite/state-writer.ts
+++ b/packages/engine/src/local-store/storage/sqlite/state-writer.ts
@@ -104,7 +104,7 @@ export function writeDerivedState(database: Database, state: DerivedStoreState):
           practice.stage,
           JSON.stringify(practice.tech_stack),
           practice.applies_when,
-          practice.severity ?? "warn",
+          practice.severity,
           state.effectiveRevision,
         );
         for (const source of effective.sources) {

--- a/packages/engine/src/query/errors.ts
+++ b/packages/engine/src/query/errors.ts
@@ -1,0 +1,7 @@
+/** Thrown when a runtime Query request has no usable query text. */
+export class InvalidQueryError extends Error {
+  constructor() {
+    super("The query must be a non-empty string.");
+    this.name = "InvalidQueryError";
+  }
+}

--- a/packages/engine/src/query/index.ts
+++ b/packages/engine/src/query/index.ts
@@ -1,0 +1,15 @@
+export { InvalidQueryError } from "./errors.js";
+export { retrievePractices } from "./retrieve.js";
+export { createQueryService, type QueryService, type QueryServiceOptions } from "./service.js";
+export {
+  DEFAULT_TOP_K as DEFAULT_QUERY_TOP_K,
+  MAX_TOP_K as MAX_QUERY_TOP_K,
+  MIN_TOP_K as MIN_QUERY_TOP_K,
+} from "../retrieval/top-k.js";
+export type {
+  QueryRequest,
+  QueryResult,
+  RetrievedPractice,
+  RetrievedPractices,
+  RetrievePracticesInput,
+} from "./types.js";

--- a/packages/engine/src/query/retrieve.test.ts
+++ b/packages/engine/src/query/retrieve.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+
+import type { EffectivePractice } from "../local-store/model/types.js";
+import { retrievePractices } from "./retrieve.js";
+
+function effectivePractice(
+  id: string,
+  overrides: Partial<EffectivePractice["practice"]> = {},
+): EffectivePractice {
+  const practice: EffectivePractice["practice"] = {
+    id,
+    title: `Practice ${id}`,
+    stage: "test",
+    tech_stack: ["typescript"],
+    applies_when: "testing query retrieval",
+    severity: "warn",
+    body: `Guidance for ${id}.`,
+    anti_patterns: [],
+    ...overrides,
+  };
+  return {
+    practiceId: id,
+    contentDigest: `${id}-digest`,
+    canonicalContent: id,
+    practice,
+    sources: [
+      {
+        packName: `pack-${id.replaceAll(".", "-")}`,
+        practiceId: id,
+        contentDigest: `${id}-digest`,
+        sourcePath: `practices/${id}.md`,
+        canonicalPractice: { practice, canonicalContent: id, contentDigest: `${id}-digest` },
+      },
+    ],
+  };
+}
+
+const layeredApi = effectivePractice("react.api-client", {
+  title: "Layer React API access",
+  stage: "api-layer",
+  tech_stack: ["react", "typescript"],
+  applies_when: "adding remote requests to a React interface",
+  body: "Keep transport behind a feature API boundary.",
+});
+
+const resourceState = effectivePractice("react.resource-state", {
+  title: "Separate resource and UI state",
+  stage: "state",
+  tech_stack: ["react", "typescript"],
+  applies_when: "storing remote resource data used by a React interface",
+  body: "Model resource data separately from view state.",
+});
+
+describe("retrievePractices", () => {
+  test("ranks title and applies_when matches above body-only matches", () => {
+    const result = retrievePractices({
+      effectivePractices: [layeredApi, resourceState],
+      query: "remote requests React interface",
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.results[0]?.id).toBe("react.api-client");
+  });
+
+  test("breaks equal-score ties by ascending Practice id", () => {
+    const tiedA = effectivePractice("react.b-tied", { applies_when: "same wording" });
+    const tiedB = effectivePractice("react.a-tied", { applies_when: "same wording" });
+
+    const result = retrievePractices({
+      effectivePractices: [tiedA, tiedB],
+      query: "same wording",
+    });
+    expect(result.results.map((practice) => practice.id)).toEqual(["react.a-tied", "react.b-tied"]);
+  });
+
+  test("caps results while total counts every match and repeated tokens count once", () => {
+    const third = effectivePractice("react.modal", {
+      title: "Modal focus management",
+      applies_when: "rendering an accessible modal",
+    });
+    const result = retrievePractices({
+      effectivePractices: [layeredApi, resourceState, third],
+      query: "react react interface modal",
+      topK: 2,
+    });
+
+    expect(result.k).toBe(2);
+    expect(result.total).toBe(3);
+    expect(result.results.map((practice) => practice.id)).toEqual([
+      "react.api-client",
+      "react.modal",
+    ]);
+  });
+
+  test("returns a successful empty result for queries without tokens", () => {
+    const result = retrievePractices({
+      effectivePractices: [layeredApi],
+      query: "   ",
+    });
+
+    expect(result).toEqual({ query: "   ", k: 5, total: 0, results: [] });
+  });
+
+  test("returns summary metadata without the Practice body", () => {
+    const result = retrievePractices({
+      effectivePractices: [layeredApi],
+      query: "API client",
+    });
+
+    expect(result.results[0]).toEqual({
+      id: "react.api-client",
+      title: "Layer React API access",
+      stage: "api-layer",
+      tech_stack: ["react", "typescript"],
+      applies_when: "adding remote requests to a React interface",
+    });
+    expect("body" in result.results[0]!).toBe(false);
+  });
+
+  test("matches contiguous Chinese text with overlapping bigrams", () => {
+    const chinese = effectivePractice("react.chinese", {
+      title: "组件内直接请求的分层方案",
+      applies_when: "在 React 组件内新增远程请求",
+    });
+
+    const result = retrievePractices({
+      effectivePractices: [chinese],
+      query: "在组件内新增请求",
+    });
+    expect(result.total).toBe(1);
+    expect(result.results[0]?.id).toBe("react.chinese");
+  });
+});

--- a/packages/engine/src/query/retrieve.test.ts
+++ b/packages/engine/src/query/retrieve.test.ts
@@ -130,4 +130,18 @@ describe("retrievePractices", () => {
     expect(result.total).toBe(1);
     expect(result.results[0]?.id).toBe("react.chinese");
   });
+
+  test("matches CJK pieces inside mixed-script Practice text", () => {
+    const mixed = effectivePractice("react.mixed", {
+      title: "Add remote 接口请求",
+      applies_when: "adding remote 接口请求 through a feature API boundary",
+    });
+
+    const result = retrievePractices({
+      effectivePractices: [mixed],
+      query: "remote 接口请求",
+    });
+    expect(result.total).toBe(1);
+    expect(result.results[0]?.id).toBe("react.mixed");
+  });
 });

--- a/packages/engine/src/query/retrieve.ts
+++ b/packages/engine/src/query/retrieve.ts
@@ -1,0 +1,82 @@
+import type { EffectivePractice } from "../local-store/model/types.js";
+import { normalizeTokens } from "../retrieval/tokenize.js";
+import { normalizeTopK } from "../retrieval/top-k.js";
+import type { RetrievedPractice, RetrievePracticesInput, RetrievedPractices } from "./types.js";
+
+interface PracticeMatch {
+  readonly effectivePractice: EffectivePractice;
+  readonly score: number;
+}
+
+/**
+ * Minimal deterministic retrieval over LocalStore Effective Practices:
+ * metadata and text token matching with no embeddings or external services.
+ * Ties break by Practice id ascending.
+ */
+export function retrievePractices(input: RetrievePracticesInput): RetrievedPractices {
+  const topK = normalizeTopK(input.topK);
+  const tokens = normalizeTokens(input.query);
+  if (tokens.length === 0) {
+    return { query: input.query, k: topK, total: 0, results: [] };
+  }
+
+  const matches = input.effectivePractices
+    .map((effectivePractice) => ({
+      effectivePractice,
+      score: scorePractice(effectivePractice.practice, tokens),
+    }))
+    .filter((match) => match.score > 0)
+    .sort(compareMatches);
+
+  return {
+    query: input.query,
+    k: topK,
+    total: matches.length,
+    results: matches.slice(0, topK).map(toRetrievedPractice),
+  };
+}
+
+/** Field weights: title and applies_when are the recall core. */
+const scoredFields = [
+  { weight: 3, text: (practice: EffectivePractice["practice"]) => practice.title },
+  { weight: 2, text: (practice: EffectivePractice["practice"]) => practice.applies_when },
+  { weight: 1, text: (practice: EffectivePractice["practice"]) => practice.stage },
+  {
+    weight: 1,
+    text: (practice: EffectivePractice["practice"]) => practice.tech_stack.join(" "),
+  },
+  {
+    weight: 1,
+    text: (practice: EffectivePractice["practice"]) => practice.body,
+  },
+] as const;
+
+function scorePractice(practice: EffectivePractice["practice"], tokens: readonly string[]): number {
+  const distinct = new Set(tokens);
+  let score = 0;
+  for (const field of scoredFields) {
+    const haystack = new Set(normalizeTokens(field.text(practice)));
+    for (const token of distinct) {
+      if (haystack.has(token)) score += field.weight;
+    }
+  }
+  return score;
+}
+
+function compareMatches(left: PracticeMatch, right: PracticeMatch): number {
+  if (left.score !== right.score) return right.score - left.score;
+  if (left.effectivePractice.practiceId < right.effectivePractice.practiceId) return -1;
+  if (left.effectivePractice.practiceId > right.effectivePractice.practiceId) return 1;
+  return 0;
+}
+
+function toRetrievedPractice(match: PracticeMatch): RetrievedPractice {
+  const practice = match.effectivePractice.practice;
+  return {
+    id: match.effectivePractice.practiceId,
+    title: practice.title,
+    stage: practice.stage,
+    tech_stack: [...practice.tech_stack],
+    applies_when: practice.applies_when,
+  };
+}

--- a/packages/engine/src/query/retrieve.ts
+++ b/packages/engine/src/query/retrieve.ts
@@ -17,6 +17,8 @@ export function retrievePractices(input: RetrievePracticesInput): RetrievedPract
   const topK = normalizeTopK(input.topK);
   const tokens = normalizeTokens(input.query);
   if (tokens.length === 0) {
+    // A query with no tokenizable content is still a valid call; unmatched
+    // retrieval is an empty success result, not an invocation error.
     return { query: input.query, k: topK, total: 0, results: [] };
   }
 
@@ -31,6 +33,8 @@ export function retrievePractices(input: RetrievePracticesInput): RetrievedPract
   return {
     query: input.query,
     k: topK,
+    // `total` counts every match before the `k` slice; callers must not treat
+    // the omitted tail as "not present" (ADR 0010).
     total: matches.length,
     results: matches.slice(0, topK).map(toRetrievedPractice),
   };
@@ -52,6 +56,8 @@ const scoredFields = [
 ] as const;
 
 function scorePractice(practice: EffectivePractice["practice"], tokens: readonly string[]): number {
+  // Score a field once per distinct token; repeated query words must not
+  // inflate a Practice's rank.
   const distinct = new Set(tokens);
   let score = 0;
   for (const field of scoredFields) {
@@ -72,6 +78,8 @@ function compareMatches(left: PracticeMatch, right: PracticeMatch): number {
 
 function toRetrievedPractice(match: PracticeMatch): RetrievedPractice {
   const practice = match.effectivePractice.practice;
+  // Body is intentionally excluded here; query remains a cheap summary slice
+  // and full evidence is served by `lore get` (ADR 0010/0011).
   return {
     id: match.effectivePractice.practiceId,
     title: practice.title,

--- a/packages/engine/src/query/service.test.ts
+++ b/packages/engine/src/query/service.test.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createLocalStore, decodePackDirectory, type StorageRoot } from "../local-store/index.js";
+import { InvalidQueryError } from "./errors.js";
+import { createQueryService } from "./service.js";
+
+async function removeStoreRoot(rootPath: string): Promise<void> {
+  /* eslint-disable no-await-in-loop -- Windows may release SQLite handles asynchronously. */
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      await rm(rootPath, { force: true, recursive: true });
+      return;
+    } catch (error) {
+      if (attempt === 9) throw error;
+      await Bun.sleep(50);
+    }
+  }
+  /* eslint-enable no-await-in-loop */
+}
+
+async function writeLocalQueryPack(directory: string): Promise<string> {
+  const packRoot = join(directory, "local-query-pack");
+  const practices = join(packRoot, "practices", "react");
+  await mkdir(practices, { recursive: true });
+  await writeFile(join(packRoot, "pack.yaml"), "name: local-query-fixture\nversion: 0.1.0\n");
+  await writeFile(
+    join(practices, "api-client.md"),
+    [
+      "---",
+      "id: react.api-client",
+      "title: Layer React API access",
+      "stage: api-layer",
+      "tech_stack: [react, typescript]",
+      "applies_when: adding remote requests to a React interface",
+      "severity: warn",
+      "---",
+      "Keep transport, DTO translation, and expected failures behind a feature API boundary.",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    join(practices, "resource-state.md"),
+    [
+      "---",
+      "id: react.resource-state",
+      "title: Separate resource and UI state",
+      "stage: state",
+      "tech_stack: [react, typescript]",
+      "applies_when: storing remote resource data used by a React interface",
+      "severity: warn",
+      "---",
+      "Model resource data separately from view state and transform DTOs at the boundary.",
+      "",
+    ].join("\n"),
+  );
+  return packRoot;
+}
+
+test("QueryService reads a simple installed Pack through LocalStore", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-query-service-"));
+  const storageRoot: StorageRoot = { rootPath: join(directory, "store") };
+  try {
+    const packRoot = await writeLocalQueryPack(directory);
+    const decoded = await decodePackDirectory(packRoot);
+    const store = createLocalStore();
+    await store.install(storageRoot, decoded.candidate, decoded.diagnostics);
+    const service = createQueryService({ store, storageRoot });
+
+    const result = await service.query({ query: "remote requests interface" });
+    expect(result).toMatchObject({
+      query: "remote requests interface",
+      k: 5,
+      total: 2,
+      generation: 1,
+      effectiveRevision: 1,
+    });
+    expect(result.results[0]).toEqual({
+      id: "react.api-client",
+      title: "Layer React API access",
+      stage: "api-layer",
+      tech_stack: ["react", "typescript"],
+      applies_when: "adding remote requests to a React interface",
+    });
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});
+
+test("QueryService honors a per-call storageRoot override", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-query-override-"));
+  const defaultRoot: StorageRoot = { rootPath: join(directory, "default-store") };
+  const overrideRoot: StorageRoot = { rootPath: join(directory, "override-store") };
+  try {
+    const packRoot = await writeLocalQueryPack(directory);
+    const decoded = await decodePackDirectory(packRoot);
+    const store = createLocalStore();
+    await store.install(overrideRoot, decoded.candidate, decoded.diagnostics);
+    const service = createQueryService({ store, storageRoot: defaultRoot });
+
+    const overridden = await service.query({ query: "remote requests", storageRoot: overrideRoot });
+    expect(overridden).toMatchObject({ generation: 1, total: 2 });
+
+    const fallback = await service.query({ query: "remote requests" });
+    expect(fallback).toMatchObject({ generation: 0, total: 0, results: [] });
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});
+test("QueryService succeeds with an empty fresh LocalStore", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-query-empty-"));
+  const storageRoot: StorageRoot = { rootPath: join(directory, "store") };
+  try {
+    const result = await createQueryService({ storageRoot }).query({ query: "axios component" });
+    expect(result).toMatchObject({
+      generation: 0,
+      effectiveRevision: 0,
+      total: 0,
+      results: [],
+    });
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});
+
+test("QueryService rejects blank query text with a typed error", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-query-blank-"));
+  const storageRoot: StorageRoot = { rootPath: join(directory, "store") };
+  try {
+    const service = createQueryService({ storageRoot });
+    expect(service.query({ query: "   " })).rejects.toThrow(InvalidQueryError);
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});

--- a/packages/engine/src/query/service.ts
+++ b/packages/engine/src/query/service.ts
@@ -33,6 +33,8 @@ export function createQueryService(options: QueryServiceOptions = {}): QueryServ
         throw new InvalidQueryError();
       }
 
+      // One cold open per CLI invocation is an intentional policy tradeoff:
+      // it preserves LocalStore integrity checks without a long-lived process.
       const opened = await store.open(request.storageRoot ?? fallbackStorageRoot);
       return {
         ...retrievePractices({

--- a/packages/engine/src/query/service.ts
+++ b/packages/engine/src/query/service.ts
@@ -1,0 +1,48 @@
+import {
+  createLocalStore,
+  defaultStorageRoot,
+  type LocalStore,
+  type StorageRoot,
+} from "../local-store/lifecycle/local-store.js";
+import { InvalidQueryError } from "./errors.js";
+import { retrievePractices } from "./retrieve.js";
+import type { QueryRequest, QueryResult } from "./types.js";
+
+export interface QueryService {
+  query(request: QueryRequest): Promise<QueryResult>;
+}
+
+export interface QueryServiceOptions {
+  readonly store?: LocalStore;
+  readonly storageRoot?: StorageRoot;
+}
+
+/**
+ * Application boundary shared by CLI and future MCP adapters. It cold-opens
+ * the selected LocalStore (per-call root override or the service default), then
+ * delegates ranking to the pure retrieval function. The command never accepts
+ * or decodes a caller-selected Pack path.
+ */
+export function createQueryService(options: QueryServiceOptions = {}): QueryService {
+  const store = options.store ?? createLocalStore();
+  const fallbackStorageRoot = options.storageRoot ?? defaultStorageRoot();
+
+  return Object.freeze({
+    async query(request: QueryRequest): Promise<QueryResult> {
+      if (typeof request.query !== "string" || request.query.trim().length === 0) {
+        throw new InvalidQueryError();
+      }
+
+      const opened = await store.open(request.storageRoot ?? fallbackStorageRoot);
+      return {
+        ...retrievePractices({
+          effectivePractices: opened.effectivePractices,
+          query: request.query,
+          ...(request.topK === undefined ? {} : { topK: request.topK }),
+        }),
+        generation: opened.generation,
+        effectiveRevision: opened.effectiveRevision,
+      };
+    },
+  });
+}

--- a/packages/engine/src/query/types.ts
+++ b/packages/engine/src/query/types.ts
@@ -7,6 +7,7 @@ export type RetrievedPractice = Readonly<
   Pick<QueryPracticeSnapshot, "id" | "title" | "stage" | "tech_stack" | "applies_when">
 >;
 
+/** Pure retrieval input; no filesystem, Store, or CLI concerns. */
 export interface RetrievePracticesInput {
   readonly effectivePractices: readonly EffectivePractice[];
   readonly query: string;
@@ -17,6 +18,7 @@ export interface RetrievePracticesInput {
 export interface RetrievedPractices {
   readonly query: string;
   readonly k: number;
+  /** Count of all matches before `k` truncation; v1 does not paginate. */
   readonly total: number;
   readonly results: readonly RetrievedPractice[];
 }

--- a/packages/engine/src/query/types.ts
+++ b/packages/engine/src/query/types.ts
@@ -1,0 +1,35 @@
+import type { StorageRoot } from "../local-store/lifecycle/local-store.js";
+import type { EffectivePractice } from "../local-store/model/types.js";
+
+type QueryPracticeSnapshot = EffectivePractice["practice"];
+
+export type RetrievedPractice = Readonly<
+  Pick<QueryPracticeSnapshot, "id" | "title" | "stage" | "tech_stack" | "applies_when">
+>;
+
+export interface RetrievePracticesInput {
+  readonly effectivePractices: readonly EffectivePractice[];
+  readonly query: string;
+  /** Result cap; default 5, defensively clamped to 1..50. */
+  readonly topK?: number;
+}
+
+export interface RetrievedPractices {
+  readonly query: string;
+  readonly k: number;
+  readonly total: number;
+  readonly results: readonly RetrievedPractice[];
+}
+
+export interface QueryRequest {
+  readonly query: string;
+  /** Result cap; default 5, defensively clamped to 1..50. */
+  readonly topK?: number;
+  /** Per-call LocalStore root override; omitted uses the service default. */
+  readonly storageRoot?: StorageRoot;
+}
+
+export interface QueryResult extends RetrievedPractices {
+  readonly generation: number;
+  readonly effectiveRevision: number;
+}

--- a/packages/engine/src/retrieval/index.ts
+++ b/packages/engine/src/retrieval/index.ts
@@ -1,0 +1,2 @@
+export type { PracticeSourceResult } from "./types.js";
+export { compareSourceResults, projectSourceResult } from "./source-projection.js";

--- a/packages/engine/src/retrieval/source-projection.test.ts
+++ b/packages/engine/src/retrieval/source-projection.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { compareSourceResults, projectSourceResult } from "./source-projection.js";
+
+const sampleSource = {
+  packName: "react-fullstack",
+  practiceId: "react.api-client",
+  contentDigest: "digest",
+  sourcePath: "practices/react/api-client.md",
+  canonicalPractice: {
+    practice: {
+      id: "react.api-client",
+      title: "Layer React API access",
+      stage: "api-layer",
+      tech_stack: ["react"],
+      applies_when: "adding remote requests",
+      severity: "warn" as const,
+      body: "Guidance.",
+      anti_patterns: [],
+    },
+    canonicalContent: "{}",
+    contentDigest: "digest",
+  },
+};
+
+describe("source projection helpers", () => {
+  test("projects LocalStore source claims to the shared retrieval shape", () => {
+    expect(projectSourceResult(sampleSource)).toEqual({
+      pack: "react-fullstack",
+      sourcePath: "practices/react/api-client.md",
+    });
+  });
+
+  test("orders projected sources deterministically by pack then source path", () => {
+    const unsorted = [
+      { pack: "z-pack", sourcePath: "practices/a.md" },
+      { pack: "a-pack", sourcePath: "practices/z.md" },
+      { pack: "a-pack", sourcePath: "practices/a.md" },
+    ];
+
+    expect([...unsorted].sort(compareSourceResults)).toEqual([
+      { pack: "a-pack", sourcePath: "practices/a.md" },
+      { pack: "a-pack", sourcePath: "practices/z.md" },
+      { pack: "z-pack", sourcePath: "practices/a.md" },
+    ]);
+  });
+});

--- a/packages/engine/src/retrieval/source-projection.ts
+++ b/packages/engine/src/retrieval/source-projection.ts
@@ -1,0 +1,23 @@
+import type { EffectivePractice } from "../local-store/model/types.js";
+import type { PracticeSourceResult } from "./types.js";
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/** Project one LocalStore source claim to the shared retrieval shape. */
+export function projectSourceResult(
+  source: EffectivePractice["sources"][number],
+): PracticeSourceResult {
+  return { pack: source.packName, sourcePath: source.sourcePath };
+}
+
+/** Deterministic `(pack, sourcePath)` ordering for projected source claims. */
+export function compareSourceResults(
+  left: PracticeSourceResult,
+  right: PracticeSourceResult,
+): number {
+  return (
+    compareCodeUnits(left.pack, right.pack) || compareCodeUnits(left.sourcePath, right.sourcePath)
+  );
+}

--- a/packages/engine/src/retrieval/tokenize.test.ts
+++ b/packages/engine/src/retrieval/tokenize.test.ts
@@ -22,4 +22,15 @@ describe("normalizeTokens", () => {
   test("splits Han, Hiragana, and Katakana runs", () => {
     expect(normalizeTokens("依頼コンポ")).toEqual(["依頼", "頼コ", "コン", "ンポ"]);
   });
+
+  test("segments CJK pieces inside mixed Latin and CJK runs", () => {
+    expect(normalizeTokens("remote接口请求")).toEqual(["remote", "接口", "口请", "请求"]);
+    expect(normalizeTokens("Add remote 接口请求")).toEqual([
+      "add",
+      "remote",
+      "接口",
+      "口请",
+      "请求",
+    ]);
+  });
 });

--- a/packages/engine/src/retrieval/tokenize.test.ts
+++ b/packages/engine/src/retrieval/tokenize.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeTokens } from "./tokenize.js";
+
+describe("normalizeTokens", () => {
+  test("lowercases Latin and numeric runs and splits on non-word characters", () => {
+    expect(normalizeTokens("React 18, API-client!")).toEqual(["react", "18", "api", "client"]);
+  });
+
+  test("returns an empty list when the text has no letter or number runs", () => {
+    expect(normalizeTokens("--- !!! ???")).toEqual([]);
+  });
+
+  test("segments contiguous Han text into overlapping bigrams", () => {
+    expect(normalizeTokens("组件请求")).toEqual(["组件", "件请", "请求"]);
+  });
+
+  test("keeps a single CJK character as its own token", () => {
+    expect(normalizeTokens("端")).toEqual(["端"]);
+  });
+
+  test("splits Han, Hiragana, and Katakana runs", () => {
+    expect(normalizeTokens("依頼コンポ")).toEqual(["依頼", "頼コ", "コン", "ンポ"]);
+  });
+});

--- a/packages/engine/src/retrieval/tokenize.ts
+++ b/packages/engine/src/retrieval/tokenize.ts
@@ -8,19 +8,50 @@
 export function normalizeTokens(text: string): string[] {
   const tokens: string[] = [];
   for (const run of text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []) {
-    if (isCjkRun(run)) {
-      if (run.length === 1) tokens.push(run);
-      for (let index = 0; index < run.length - 1; index += 1) {
-        tokens.push(run.slice(index, index + 2));
-      }
-    } else {
-      tokens.push(run);
+    for (const piece of splitScriptRuns(run)) {
+      if (isCjkPiece(piece)) tokens.push(...segmentCjk(piece));
+      else tokens.push(piece);
     }
   }
   return tokens;
 }
 
+/**
+ * Split a mixed-script run into contiguous Latin/numeric and CJK pieces, so a
+ * title such as `Add remote 接口请求` contributes CJK bigrams without dropping
+ * the Latin words. Words that cross the script boundary are treated as
+ * separate tokens on both sides.
+ */
+function splitScriptRuns(text: string): string[] {
+  const pieces: string[] = [];
+  let start = 0;
+  for (let index = 1; index < text.length; index += 1) {
+    const boundary = isCjk(text[index - 1]!) !== isCjk(text[index]!);
+    if (boundary) {
+      pieces.push(text.slice(start, index));
+      start = index;
+    }
+  }
+  pieces.push(text.slice(start));
+  return pieces;
+}
+
+const CJK_CODE_POINT = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u;
+
 /** Han, Hiragana, and Katakana runs are bigram-segmented. */
-function isCjkRun(text: string): boolean {
-  return /^[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]+$/u.test(text);
+function isCjkPiece(text: string): boolean {
+  return [...text].every((codePoint) => CJK_CODE_POINT.test(codePoint));
+}
+
+function isCjk(codePoint: string): boolean {
+  return CJK_CODE_POINT.test(codePoint);
+}
+
+function segmentCjk(text: string): string[] {
+  if (text.length === 1) return [text];
+  const tokens: string[] = [];
+  for (let index = 0; index < text.length - 1; index += 1) {
+    tokens.push(text.slice(index, index + 2));
+  }
+  return tokens;
 }

--- a/packages/engine/src/retrieval/tokenize.ts
+++ b/packages/engine/src/retrieval/tokenize.ts
@@ -1,0 +1,26 @@
+/**
+ * Deterministic tokenization shared by retrieval modules.
+ *
+ * Latin and numeric runs stay whole words. CJK runs become overlapping
+ * bigrams so Chinese tasks can match contiguous Chinese Practice text without
+ * a segmentation dependency.
+ */
+export function normalizeTokens(text: string): string[] {
+  const tokens: string[] = [];
+  for (const run of text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []) {
+    if (isCjkRun(run)) {
+      if (run.length === 1) tokens.push(run);
+      for (let index = 0; index < run.length - 1; index += 1) {
+        tokens.push(run.slice(index, index + 2));
+      }
+    } else {
+      tokens.push(run);
+    }
+  }
+  return tokens;
+}
+
+/** Han, Hiragana, and Katakana runs are bigram-segmented. */
+function isCjkRun(text: string): boolean {
+  return /^[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]+$/u.test(text);
+}

--- a/packages/engine/src/retrieval/top-k.test.ts
+++ b/packages/engine/src/retrieval/top-k.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_TOP_K, MAX_TOP_K, MIN_TOP_K, normalizeTopK } from "./top-k.js";
+
+describe("normalizeTopK", () => {
+  test("keeps integers inside the supported range", () => {
+    expect(normalizeTopK(1)).toBe(MIN_TOP_K);
+    expect(normalizeTopK(5)).toBe(DEFAULT_TOP_K);
+    expect(normalizeTopK(50)).toBe(MAX_TOP_K);
+  });
+
+  test("falls back to the default for non-integer values", () => {
+    expect(normalizeTopK(undefined)).toBe(5);
+    expect(normalizeTopK(Number.NaN)).toBe(5);
+    expect(normalizeTopK(2.5)).toBe(5);
+  });
+
+  test("defensively clamps out-of-range integers", () => {
+    expect(normalizeTopK(0)).toBe(1);
+    expect(normalizeTopK(-3)).toBe(1);
+    expect(normalizeTopK(51)).toBe(50);
+    expect(normalizeTopK(500)).toBe(50);
+  });
+});

--- a/packages/engine/src/retrieval/top-k.ts
+++ b/packages/engine/src/retrieval/top-k.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_TOP_K = 5;
+export const MIN_TOP_K = 1;
+export const MAX_TOP_K = 50;
+
+/** Normalize a retrieval result cap without turning malformed input into an error. */
+export function normalizeTopK(value: number | undefined): number {
+  const topK = Number.isInteger(value) ? (value as number) : DEFAULT_TOP_K;
+  return Math.min(Math.max(topK, MIN_TOP_K), MAX_TOP_K);
+}

--- a/packages/engine/src/retrieval/types.ts
+++ b/packages/engine/src/retrieval/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared projection types for retrieval features.
+ *
+ * The retrieval layer is the neutral home for shape reuse; feature modules do
+ * not import one another just to share a result type.
+ */
+
+/** One source claim projected for consumers; deliberately decoupled from LocalStore's `PracticeSource` storage model. */
+export interface PracticeSourceResult {
+  readonly pack: string;
+  readonly sourcePath: string;
+}


### PR DESCRIPTION
## Summary

本次为官方 CLI 补齐基于 LocalStore 的 `lore query` 与 `lore get` 两个检索命令，使 agent 在安装 Knowledge Pack 后可以直接按任务检索 Practice，或按 Practice id 取回完整内容与来源信息。

实现上遵循 issue #45 已冻结的产品边界：两个命令都以 LocalStore 的 Effective Practice 为唯一运行时来源，不自行发现 Pack、不解析 Practice 文件、不回退到 Pack path 调试模式。query 返回轻量 summary 并按确定性 token-match 排序，get 返回完整 canonical Practice 与确定性排序后的 source claims。

同时补上对应契约与工程质量：ADR 0010/0011 记录 retrieval 契约，engine 层提供可复用纯函数与 service，CLI 只负责参数解码、Store resolution 和错误映射；并补充单测、真实进程 integration 和 CI Integration 步骤。

## Linked issue

Closes #45

## Type of change

- [x] ✨ New feature (non-breaking)

## Why this change

- 契约缺口：官方 main 的 LocalStore lifecycle、Pack install 和 ADR 0007 已经完成，但 CLI 仍只有 `install` 一个 LocalStore consumer。agent 安装 Knowledge Pack 后，没有可执行的 `lore query` 按任务检索，也没有 `lore get` 按 id 取回完整 Practice 与 source claims。
- 复用 LocalStore 语义：两个命令直接消费 LocalStore 已合并的 Effective Practice，避免 CLI 层重新发现 Pack 或重复解析文件，与 ADR 0007 的运行时来源保持一致。
- 分层复用而非命令内实现：tokenizer、ranking、top-k、source projection 和 service 放在 engine 层，CLI 作为薄 adapter；未来 MCP 或其他 adapter 可以复用同一套检索语义，不会复制 LocalStore 冷开逻辑。
- 范围先由 issue/ADR 收住：本 PR 只落地 query/get，不夹带 `lore check`、MCP wiring 或语义/向量检索，避免把相邻能力混入一个实现变更。

## How was this tested?

- `bun run typecheck`：通过
- `bun run lint`：通过
- query/get/retrieval 相关单测：62 pass / 0 fail
- `bun run test:integration`：通过
- `git diff --check`：通过，仅有 LF/CRLF 警告

## Checklist

- [x] Linked the issue this closes (`Closes #45`)
- [x] 产品行为已由 Issue #45 与 ADR 0010/0011 约定
- [x] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

## AI assistance

- [x] Parts of this PR were generated or assisted by an AI tool
- [x] I have reviewed every line of the AI-generated code and take full responsibility for it

## Notes for reviewers

全量 `bun test` 在当前 Windows 本机仍有 3 个既有失败，均为本 PR diff 未触碰的既有测试：Git NUL stdin、symlink 和 POSIX 路径断言；本次改动相关测试、typecheck、lint 与 integration 均通过。

本 PR 不包含 `lore check`、MCP、语义/向量检索或其他未在 Issue #45 范围内的事项。
