### PR TITLE
feat(cli): read installed practices with lore get

### DIFF
--- a/docs/cli/get.md
+++ b/docs/cli/get.md
@@ -1,0 +1,79 @@
+# Read an installed Practice
+
+`lore get <practice-id>` retrieves one complete canonical Practice by its exact
+ID from the selected LocalStore. The contract was agreed in [issue #49](https://github.com/lorelum/lorelum/issues/49).
+
+```sh
+lore get agentic-coding.testing.classify-failure-before-changing-test
+lore --store-root /path/to/isolated-store get agentic-coding.testing.classify-failure-before-changing-test
+lore describe get
+```
+
+The ID must follow the existing dotted Practice ID format. Lookup is exact:
+there is no title matching, prefix completion, or case normalization. The global
+`--store-root` option also works after the command; relative paths resolve from
+the calling process's working directory. Omitting it selects the user Store.
+
+## Result
+
+The existing protocol envelope contains `command: "get"`, `ok: true`, and:
+
+```text
+data: {
+  practice: {
+    id, title, stage, tech_stack, applies_when,
+    severity, body, anti_patterns
+  },
+  contentDigest,
+  sources: [{ packName, sourcePath }]
+}
+```
+
+`practice` is the canonical runtime representation defined by ADR 0007. It
+includes the complete Markdown body, LF-normalized text, and expanded defaults:
+`severity: "warn"`, `body: ""`, `anti_patterns: []`, and `severity: "warn"` on
+anti-patterns whose authors omitted severity. Author array order is preserved.
+The reserved, undefined anti-pattern `check` field is excluded by canonicalization.
+
+`contentDigest` is the SHA-256 digest of the canonical content, not a publisher
+signature. Identical content provided under the same ID by multiple active Packs
+returns one Practice with all sources, ordered by Pack name and source path.
+Each `sourcePath` is relative to its Pack root. Internal canonical serialization,
+duplicate source content, and machine-local absolute paths are not returned.
+
+## Store behavior
+
+Each invocation calls `LocalStore.open()` once and selects from that verified
+snapshot. It inherits normal Store initialization, schema migration, and pending
+operation-journal recovery. A healthy read does not advance generation or
+effectiveRevision or change installed content. This is not a promise of zero
+filesystem writes: opening a missing Store initializes it, and recovering a prior
+interrupted operation can write Store state.
+
+Store integrity is checked before reporting absence, including when the requested
+ID is unknown. Missing or damaged artifacts and inconsistent SQLite state are
+errors. The command does not invoke `reindex` or access a Registry/network.
+
+The current implementation verifies and materializes the full active Store.
+Separate invocations can observe different Store revisions; there is no
+cross-command snapshot or version-pinning contract.
+
+## Errors and exit codes
+
+Success exits `0`. Failures use `ok: false` with `error: { code, message }` and exit `2`.
+Both success and failure write exactly one JSON line to stdout.
+
+| Code                      | Meaning                                                               |
+| ------------------------- | --------------------------------------------------------------------- |
+| `usage.invalid`           | Missing/extra arguments, malformed ID, or invalid options.            |
+| `practice.not-found`      | Valid ID absent from a healthy Store, including an empty Store.       |
+| `store.busy`              | A stable Store snapshot could not be obtained due to concurrent work. |
+| `store.recovery-required` | The selected Store could not be opened and recovered normally.        |
+| `runtime.unexpected`      | An undeclared internal failure prevented completion.                  |
+
+Invalid IDs fail before opening the Store. Visible errors do not include raw
+arguments or internal failure details. Callers should branch on `code` rather
+than parsing `message`.
+
+This command does not implement semantic search, batch lookup, Pack/version
+selection, runtime translations, or related-Practice expansion.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -10,6 +10,7 @@ human contribution contract, then use the relevant links below.
 - [Tests and CI](../../CONTRIBUTING.md#testing--ci)
 - [Issues, branches, and PRs](../../CONTRIBUTING.md#development-workflow)
 - [Local CLI and worktrees](#local-cli-and-multiple-worktrees)
+- [Read an installed Practice with `lore get`](../cli/get.md)
 
 ## Local CLI and multiple worktrees
 
@@ -20,9 +21,8 @@ The CLI's discoverable global option is:
 ```
 
 When omitted, the Store remains `~/.lorelum`. A relative path is resolved from
-the calling process's current working directory. At present, `install` is the
-only CLI command that consumes `LocalStore`; do not infer support for other
-commands from this guide.
+the calling process's current working directory. `install` and `get` consume
+`LocalStore`; do not infer support for other commands from this guide.
 
 ### A copyable `lore-dev` function
 
@@ -59,6 +59,8 @@ not part of a commit. For example:
 
 ```zsh
 lore-dev install pack-creator --pack-version 0.1.0
+lore-dev install agentic-coding --pack-version 0.3.0
+lore-dev get agentic-coding.testing.classify-failure-before-changing-test
 ```
 
 Use the source function while iterating. To check compiled behavior for the
@@ -90,8 +92,8 @@ inspect it instead of replacing it blindly.
 Any manual Store-writing workflow (for example, future `uninstall` or
 `reindex` commands) must pass an explicitly isolated `--store-root`. These
 commands are not implemented merely because they are named here; the rule is a
-forward-looking safety constraint. Today, only `install` is implemented as a
-LocalStore consumer.
+forward-looking safety constraint. `get` also needs an isolated root during
+development: its cold open can initialize or recover the selected Store.
 
 Automated tests should continue to use temporary directories for Store data.
 They must not write to `~/.lorelum` or to a developer's shared Store.

--- a/packages/cli/integration/process.integration.ts
+++ b/packages/cli/integration/process.integration.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -66,8 +67,145 @@ try {
   });
   assert.equal(invalid.stdout.includes("private-token"), false);
   assert.equal(invalid.stderr, "");
+
+  await exerciseGet(executable, directory);
 } finally {
   await rm(directory, { force: true, recursive: true });
+}
+
+/**
+ * Install one synthetic Pack through the public engine API in a separate
+ * process, then verify the compiled CLI reads the persisted snapshot.
+ */
+async function exerciseGet(compiledBinary: string, workingDirectory: string): Promise<void> {
+  const packDirectory = join(workingDirectory, "fixture-pack");
+  const storageRoot = join(workingDirectory, "fixture-store");
+  const practiceId = "integration.retrieval.demo";
+  await mkdir(join(packDirectory, "practices"), { recursive: true });
+  await writeFile(
+    join(packDirectory, "pack.yaml"),
+    "name: integration-pack\nversion: 1.0.0\ndescription: Process integration fixture.\n",
+  );
+  await writeFile(
+    join(packDirectory, "practices", "retrieval-demo.md"),
+    `---
+id: ${practiceId}
+title: Persisted retrieval demo
+stage: integration
+tech_stack: [bun, typescript]
+applies_when: exercising the compiled get command
+anti_patterns:
+  - id: integration.retrieval.skip
+    name: Skip persisted state
+    description: Do not bypass the local snapshot.
+---
+# Persisted guidance
+
+This complete body must survive installation and retrieval.
+`,
+  );
+
+  const engineEntrypoint = join(import.meta.dir, "../../engine/src/index.ts");
+  const installer = `
+const { decodePackDirectory, createLocalStore } = await import(${JSON.stringify(engineEntrypoint)});
+const decoded = await decodePackDirectory(${JSON.stringify(packDirectory)});
+const result = await createLocalStore().install(
+  { rootPath: ${JSON.stringify(storageRoot)} },
+  decoded.candidate,
+  decoded.diagnostics,
+);
+console.log(JSON.stringify({ generation: result.generation, effectiveRevision: result.effectiveRevision }));
+`;
+  const installed = await runProcess([bunExecutable!, "-e", installer]);
+  assert.equal(installed.exitCode, 0, installed.stderr || installed.stdout);
+  assert.equal(installed.stderr, "");
+  assert.equal(installed.stdout.trim().split(/\r?\n/).length, 1);
+
+  const first = await runGet(compiledBinary, practiceId, storageRoot);
+  assert.equal(first.exitCode, 0);
+  assert.equal(first.stderr, "");
+  const firstResponse = parseSingleResponse(first.stdout);
+  assert.equal(firstResponse.command, "get");
+  assert.equal(firstResponse.ok, true);
+  assert(isRecord(firstResponse.data));
+  assert(isRecord(firstResponse.data.practice));
+  assert.deepEqual(firstResponse.data.practice, {
+    id: practiceId,
+    title: "Persisted retrieval demo",
+    stage: "integration",
+    tech_stack: ["bun", "typescript"],
+    applies_when: "exercising the compiled get command",
+    severity: "warn",
+    body: "# Persisted guidance\n\nThis complete body must survive installation and retrieval.\n",
+    anti_patterns: [
+      {
+        id: "integration.retrieval.skip",
+        name: "Skip persisted state",
+        description: "Do not bypass the local snapshot.",
+        severity: "warn",
+      },
+    ],
+  });
+  assert.equal(typeof firstResponse.data.practice.body, "string");
+  assert.match(String(firstResponse.data.contentDigest), /^[0-9a-f]{64}$/);
+  assert.deepEqual(firstResponse.data.sources, [
+    { packName: "integration-pack", sourcePath: "practices/retrieval-demo.md" },
+  ]);
+
+  const firstStdout = first.stdout;
+  const second = await runGet(compiledBinary, practiceId, storageRoot, "before");
+  assert.equal(second.exitCode, 0);
+  assert.equal(second.stdout, firstStdout);
+  const third = await runGet(compiledBinary, practiceId, storageRoot, "after");
+  assert.equal(third.exitCode, 0);
+  assert.equal(third.stdout, firstStdout);
+
+  const absent = await runGet(compiledBinary, "integration.retrieval.absent", storageRoot);
+  assert.equal(absent.exitCode, 2);
+  assert.equal(absent.stderr, "");
+  const absentResponse = parseSingleResponse(absent.stdout);
+  assert.equal(absentResponse.ok, false);
+  assert.equal(isRecord(absentResponse.error) && absentResponse.error.code, "practice.not-found");
+
+  const isolatedRoot = join(workingDirectory, "isolated-store");
+  await mkdir(isolatedRoot, { recursive: true });
+  const isolated = await runGet(compiledBinary, practiceId, isolatedRoot);
+  assert.equal(isolated.exitCode, 2);
+  const isolatedResponse = parseSingleResponse(isolated.stdout);
+  assert.equal(
+    isRecord(isolatedResponse.error) && isolatedResponse.error.code,
+    "practice.not-found",
+  );
+
+  const malformedRoot = join(workingDirectory, "malformed-store");
+  const malformed = await runGet(compiledBinary, "invalid-id", malformedRoot);
+  assert.equal(malformed.exitCode, 2);
+  assert.equal(malformed.stderr, "");
+  const malformedResponse = parseSingleResponse(malformed.stdout);
+  assert.equal(malformedResponse.ok, false);
+  assert.equal(isRecord(malformedResponse.error) && malformedResponse.error.code, "usage.invalid");
+  assert.equal(existsSync(malformedRoot), false, "malformed IDs must not create a Store root");
+}
+
+async function runGet(
+  binaryPath: string,
+  practiceId: string,
+  storageRoot: string,
+  globalPosition: "before" | "after" = "after",
+): Promise<{ exitCode: number; stderr: string; stdout: string }> {
+  const args =
+    globalPosition === "before"
+      ? [binaryPath, "--store-root", storageRoot, "get", practiceId]
+      : [binaryPath, "get", practiceId, "--store-root", storageRoot];
+  return runProcess(args);
+}
+
+function parseSingleResponse(stdout: string): Record<string, unknown> {
+  const lines = stdout.trim().split(/\r?\n/);
+  assert.equal(lines.length, 1, `expected one JSON response line, got ${lines.length}`);
+  const response: unknown = JSON.parse(lines[0]!);
+  assert(isRecord(response));
+  return response;
 }
 
 function selectProtocolFields(stdout: string): {

--- a/packages/cli/src/get/get-command.test.ts
+++ b/packages/cli/src/get/get-command.test.ts
@@ -1,0 +1,171 @@
+import { expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+import {
+  StoreBusyError,
+  StoreRecoveryRequiredError,
+  type EffectivePractice,
+} from "@lorelum/engine";
+
+import { run } from "../main.js";
+import {
+  validateJsonSchema,
+  validateProtocolSchema,
+} from "../output/protocol-schema.test-helper.js";
+import { protocolResponseSchema } from "../output/protocol.js";
+import { describeCommand, snapshotCommandDefinitions } from "../registry.js";
+import { CliError } from "../runtime/errors.js";
+import { createGetCommand, type GetCommandServices } from "./get-command.js";
+
+const practice = {
+  id: "sample.exact-id",
+  title: "Read this Practice",
+  stage: "testing",
+  tech_stack: ["typescript", "bun"],
+  applies_when: "when verifying a requested outcome",
+  severity: "warn" as const,
+  body: "## Guidance\n\nKeep the full body.\n\n```ts\nassert(outcome);\n```\n",
+  anti_patterns: [],
+};
+const canonicalContent = JSON.stringify(practice);
+const contentDigest = new Bun.CryptoHasher("sha256").update(canonicalContent).digest("hex");
+const effective: EffectivePractice = {
+  practiceId: practice.id,
+  practice,
+  canonicalContent,
+  contentDigest,
+  sources: [
+    {
+      packName: "sample",
+      practiceId: practice.id,
+      contentDigest,
+      sourcePath: "practices/exact.md",
+      canonicalPractice: { practice, canonicalContent, contentDigest },
+    },
+  ],
+};
+
+async function invoke(args: readonly string[], store: GetCommandServices["store"]) {
+  const stdout = {
+    value: "",
+    write(message: string) {
+      this.value += message;
+    },
+  };
+  const stderr = {
+    value: "",
+    write(message: string) {
+      this.value += message;
+    },
+  };
+  const definition = createGetCommand({ store, storageRoot: { rootPath: "unused-default" } });
+  const exitCode = await run([...args], {
+    registry: snapshotCommandDefinitions([definition]),
+    stdout,
+    stderr,
+  });
+  expect(stdout.value.endsWith("\n")).toBe(true);
+  expect(stdout.value.trim().split("\n")).toHaveLength(1);
+  expect(stderr.value).toBe("");
+  const response = JSON.parse(stdout.value);
+  expect(validateProtocolSchema(response, protocolResponseSchema)).toEqual([]);
+  return { exitCode, response, definition };
+}
+
+test("returns the verified snapshot once with complete content and compact provenance", async () => {
+  let opens = 0;
+  const result = await invoke(["get", practice.id], {
+    async open(root) {
+      opens++;
+      expect(root.rootPath).toBe("unused-default");
+      return { generation: 1, effectiveRevision: 1, effectivePractices: [effective] };
+    },
+  });
+  expect(opens).toBe(1);
+  expect(result.exitCode).toBe(0);
+  expect(result.response.data).toEqual({
+    practice,
+    contentDigest,
+    sources: [{ packName: "sample", sourcePath: "practices/exact.md" }],
+  });
+  expect(validateJsonSchema(result.response.data, result.definition.resultSchema)).toEqual([]);
+});
+
+test.each([
+  { args: ["--store-root", "relative-store", "get", practice.id] },
+  { args: ["get", practice.id, "--store-root=relative-store"] },
+])("resolves explicit Store root for %j", async ({ args }) => {
+  const result = await invoke(args, {
+    async open(root) {
+      expect(root.rootPath).toBe(resolve("relative-store"));
+      return { generation: 1, effectiveRevision: 1, effectivePractices: [effective] };
+    },
+  });
+  expect(result.exitCode).toBe(0);
+});
+
+test.each(
+  [
+    ["get"],
+    ["get", ""],
+    ["get", "sample"],
+    ["get", "Sample.id"],
+    ["get", "sample..id"],
+    ["get", "../sample.id"],
+    ["get", " sample.id"],
+    ["get", "sample.id", "extra"],
+    ["get", practice.id, "--store-root="],
+  ].map((args) => ({ args })),
+)("rejects invalid input before opening a Store: %j", async ({ args }) => {
+  let opens = 0;
+  const result = await invoke(args, {
+    async open() {
+      opens++;
+      throw new Error("must not open");
+    },
+  });
+  expect(opens).toBe(0);
+  expect(result.exitCode).toBe(2);
+  expect(result.response.error).toEqual({
+    code: "usage.invalid",
+    message: "The command invocation is invalid.",
+  });
+});
+
+test("does not match ID prefixes or titles", async () => {
+  const result = await invoke(["get", "sample.exact"], {
+    async open() {
+      return { generation: 1, effectiveRevision: 1, effectivePractices: [effective] };
+    },
+  });
+  expect(result.exitCode).toBe(2);
+  expect(result.response.error.code).toBe("practice.not-found");
+});
+
+test.each([
+  [new StoreBusyError("internal-path"), "store.busy"],
+  [new StoreRecoveryRequiredError("internal-path"), "store.recovery-required"],
+  [new Error("internal-path"), "runtime.unexpected"],
+  [new CliError("undeclared.error", "internal-path"), "runtime.unexpected"],
+] as const)("maps Store errors without exposing details: %s", async (error, code) => {
+  const result = await invoke(["get", practice.id], {
+    async open() {
+      throw error;
+    },
+  });
+  expect(result.exitCode).toBe(2);
+  expect(result.response.error.code).toBe(code);
+  expect(JSON.stringify(result.response)).not.toContain("internal-path");
+});
+
+test("publishes get arguments, schema, error allowlist, and exit codes through discovery", () => {
+  const definition = createGetCommand();
+  expect(describeCommand("get")).toMatchObject({
+    name: "get",
+    usage: "get <practice-id>",
+    positionals: [{ name: "practice-id", required: true }],
+    errorCodes: definition.errorCodes,
+    exitCodes: [0, 2],
+    resultSchema: definition.resultSchema,
+  });
+});

--- a/packages/cli/src/get/get-command.ts
+++ b/packages/cli/src/get/get-command.ts
@@ -1,0 +1,83 @@
+import {
+  createLocalStore,
+  defaultStorageRoot,
+  StoreBusyError,
+  StoreRecoveryRequiredError,
+  type LocalStore,
+  type StorageRoot,
+} from "@lorelum/engine";
+import { ID_REGEX } from "@lorelum/format";
+
+import type { CommandDefinition } from "../registry.js";
+import {
+  CliError,
+  cliErrorCodes,
+  frameworkErrorCodes,
+  invalidInvocationError,
+} from "../runtime/errors.js";
+import { resolveInvocationStorageRoot } from "../store/storage-root.js";
+import { getResultSchema } from "./result-schema.js";
+
+export interface GetCommandServices {
+  readonly store: Pick<LocalStore, "open">;
+  readonly storageRoot: StorageRoot;
+}
+
+export function createGetCommand(
+  services: GetCommandServices = {
+    store: createLocalStore(),
+    storageRoot: defaultStorageRoot(),
+  },
+): CommandDefinition {
+  return {
+    name: "get",
+    summary: "Read one installed Practice by its exact ID from the selected local Store.",
+    positionals: [{ name: "practice-id", required: true }],
+    options: [],
+    resultSchema: getResultSchema,
+    errorCodes: [
+      ...frameworkErrorCodes,
+      cliErrorCodes.practiceNotFound,
+      cliErrorCodes.storeBusy,
+      cliErrorCodes.storeRecoveryRequired,
+    ],
+    exitCodes: [0, 2],
+    async handler(invocation) {
+      const id = invocation.positionals[0];
+      if (id === undefined || !ID_REGEX.test(id)) throw invalidInvocationError();
+      const root = resolveInvocationStorageRoot(invocation.options.storeRoot, services.storageRoot);
+      try {
+        // Use the verified cold-open snapshot, including pending-journal recovery.
+        const snapshot = await services.store.open(root);
+        const effective = snapshot.effectivePractices.find((entry) => entry.practiceId === id);
+        if (effective === undefined) {
+          throw new CliError(
+            cliErrorCodes.practiceNotFound,
+            "The requested Practice was not found in the selected local Store.",
+          );
+        }
+        return {
+          data: {
+            practice: effective.practice,
+            contentDigest: effective.contentDigest,
+            sources: effective.sources.map(({ packName, sourcePath }) => ({
+              packName,
+              sourcePath,
+            })),
+          },
+        };
+      } catch (error) {
+        if (error instanceof StoreBusyError) {
+          throw new CliError(cliErrorCodes.storeBusy, "The local Pack store is busy.");
+        }
+        if (error instanceof StoreRecoveryRequiredError) {
+          throw new CliError(
+            cliErrorCodes.storeRecoveryRequired,
+            "The local Pack store requires recovery.",
+          );
+        }
+        throw error;
+      }
+    },
+  };
+}

--- a/packages/cli/src/get/result-schema.test.ts
+++ b/packages/cli/src/get/result-schema.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+
+import { validateJsonSchema } from "../output/protocol-schema.test-helper.js";
+import { getResultSchema } from "./result-schema.js";
+
+const result = {
+  practice: {
+    id: "example.read",
+    title: "Read",
+    stage: "verification",
+    tech_stack: [],
+    applies_when: "when reading installed guidance",
+    severity: "warn",
+    body: "",
+    anti_patterns: [],
+  },
+  contentDigest: "0".repeat(64),
+  sources: [{ packName: "example", sourcePath: "practices/read.md" }],
+};
+
+test("requires normalized fields even when the author omitted them", () => {
+  expect(validateJsonSchema(result, getResultSchema)).toEqual([]);
+  for (const field of ["severity", "body", "anti_patterns"]) {
+    const practice: Record<string, unknown> = { ...result.practice };
+    delete practice[field];
+    expect(validateJsonSchema({ ...result, practice }, getResultSchema)).not.toEqual([]);
+  }
+});
+
+test("rejects invalid runtime content and internal representations", () => {
+  for (const candidate of [
+    { ...result, canonicalContent: "internal" },
+    { ...result, practice: { ...result.practice, body: 42 } },
+    { ...result, practice: { ...result.practice, severity: "unknown" } },
+    {
+      ...result,
+      practice: {
+        ...result.practice,
+        anti_patterns: [{ id: "example.bad", name: "Bad", description: "Bad" }],
+      },
+    },
+    { ...result, sources: [{ ...result.sources[0], canonicalPractice: result.practice }] },
+  ]) {
+    expect(validateJsonSchema(candidate, getResultSchema)).not.toEqual([]);
+  }
+});

--- a/packages/cli/src/get/result-schema.ts
+++ b/packages/cli/src/get/result-schema.ts
@@ -1,0 +1,62 @@
+import { SeverityEnum } from "@lorelum/format";
+
+import type { JsonSchema } from "../output/protocol.js";
+
+const stringSchema: JsonSchema = { type: "string" };
+const severitySchema: JsonSchema = { enum: SeverityEnum.options };
+
+/** The canonical runtime Practice has defaults expanded by LocalStore. */
+export const getResultSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["practice", "contentDigest", "sources"],
+  properties: {
+    practice: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "id",
+        "title",
+        "stage",
+        "tech_stack",
+        "applies_when",
+        "severity",
+        "body",
+        "anti_patterns",
+      ],
+      properties: {
+        id: stringSchema,
+        title: stringSchema,
+        stage: stringSchema,
+        tech_stack: { type: "array", items: stringSchema },
+        applies_when: stringSchema,
+        severity: severitySchema,
+        body: stringSchema,
+        anti_patterns: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["id", "name", "description", "severity"],
+            properties: {
+              id: stringSchema,
+              name: stringSchema,
+              description: stringSchema,
+              severity: severitySchema,
+            },
+          },
+        },
+      },
+    },
+    contentDigest: stringSchema,
+    sources: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["packName", "sourcePath"],
+        properties: { packName: stringSchema, sourcePath: stringSchema },
+      },
+    },
+  },
+};

--- a/packages/cli/src/get/store.integration.test.ts
+++ b/packages/cli/src/get/store.integration.test.ts
@@ -1,0 +1,199 @@
+import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createLocalStore, decodePackDirectory } from "@lorelum/engine";
+
+import { run } from "../main.js";
+import { validateJsonSchema } from "../output/protocol-schema.test-helper.js";
+import { snapshotCommandDefinitions } from "../registry.js";
+import { createGetCommand } from "./get-command.js";
+
+const id = "example.read-practice";
+
+async function withDirectory(action: (directory: string) => Promise<void>) {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-get-"));
+  try {
+    await action(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function install(
+  directory: string,
+  packName = "sample",
+  rootName = "store",
+  body = "Complete guidance.\n",
+) {
+  const packPath = join(directory, packName);
+  await mkdir(join(packPath, "practices"), { recursive: true });
+  await writeFile(join(packPath, "pack.yaml"), `name: ${packName}\nversion: 1.0.0\n`);
+  await writeFile(
+    join(packPath, "practices/read.md"),
+    `---
+id: ${id}
+title: Read the requested Practice
+stage: verification
+tech_stack: [typescript, bun]
+applies_when: when reading installed guidance
+anti_patterns:
+  - id: example.ignore-evidence
+    name: Ignore evidence
+    description: Guessing without checking.
+  - id: example.invent-evidence
+    name: Invent evidence
+    description: Claiming an unobserved outcome.
+    severity: critical
+---
+${body}`,
+  );
+  const decoded = await decodePackDirectory(packPath);
+  const root = { rootPath: join(directory, rootName) };
+  await createLocalStore().install(root, decoded.candidate, decoded.diagnostics);
+  return root;
+}
+
+async function get(directory: string, rootName = "store", practiceId = id) {
+  const unusedRoot = join(directory, "unused-default");
+  const definition = createGetCommand({
+    store: createLocalStore(),
+    storageRoot: { rootPath: unusedRoot },
+  });
+  const stdout = {
+    value: "",
+    write(message: string) {
+      this.value += message;
+    },
+  };
+  const stderr = {
+    value: "",
+    write(message: string) {
+      this.value += message;
+    },
+  };
+  const exitCode = await run(["get", practiceId, "--store-root", join(directory, rootName)], {
+    registry: snapshotCommandDefinitions([definition]),
+    stdout,
+    stderr,
+  });
+  expect(existsSync(unusedRoot)).toBe(false);
+  expect(stderr.value).toBe("");
+  expect(stdout.value.trim().split("\n")).toHaveLength(1);
+  expect(stdout.value).not.toContain(directory);
+  const response = JSON.parse(stdout.value);
+  if (response.ok) expect(validateJsonSchema(response.data, definition.resultSchema)).toEqual([]);
+  return { exitCode, response, output: stdout.value };
+}
+
+test("returns canonical defaults, author order and merged sources independent of install order", async () => {
+  await withDirectory(async (directory) => {
+    const root = await install(directory, "z-pack");
+    await install(directory, "a-pack");
+    await install(directory, "a-pack", "reverse");
+    await install(directory, "z-pack", "reverse");
+    const before = await createLocalStore().open(root);
+    const manifest = await readFile(join(root.rootPath, "installed-packs.json"), "utf8");
+    const result = await get(directory);
+    expect(result.exitCode).toBe(0);
+    expect(result.response.data.practice).toMatchObject({
+      id,
+      severity: "warn",
+      body: "Complete guidance.\n",
+      tech_stack: ["typescript", "bun"],
+      anti_patterns: [
+        { id: "example.ignore-evidence", severity: "warn" },
+        { id: "example.invent-evidence", severity: "critical" },
+      ],
+    });
+    expect(result.response.data.sources).toEqual([
+      { packName: "a-pack", sourcePath: "practices/read.md" },
+      { packName: "z-pack", sourcePath: "practices/read.md" },
+    ]);
+    expect(result.output).toBe((await get(directory, "reverse")).output);
+    expect(result.output).toBe((await get(directory)).output);
+    expect(result.response.data.contentDigest).toBe(before.effectivePractices[0]!.contentDigest);
+    expect(await readFile(join(root.rootPath, "installed-packs.json"), "utf8")).toBe(manifest);
+    const after = await createLocalStore().open(root);
+    expect(after).toEqual(before);
+  });
+});
+
+test("a missing Store initializes normally and reports absence", async () => {
+  await withDirectory(async (directory) => {
+    const result = await get(directory);
+    expect(result.exitCode).toBe(2);
+    expect(result.response.error.code).toBe("practice.not-found");
+  });
+});
+
+test("Store overrides isolate content and empty guidance stays retrievable", async () => {
+  await withDirectory(async (directory) => {
+    await install(directory, "sample", "store", "");
+    expect((await get(directory)).response.data.practice.body).toBe("");
+    expect((await get(directory, "other-store")).response.error.code).toBe("practice.not-found");
+  });
+});
+
+test.each(["artifact", "sqlite"] as const)(
+  "fails on damaged %s even when the ID is absent",
+  async (damage) => {
+    await withDirectory(async (directory) => {
+      const root = await install(directory);
+      if (damage === "artifact") {
+        const artifactRoot = join(root.rootPath, "packs/p-sample");
+        const [digest] = await readdir(artifactRoot);
+        expect(digest).toBeDefined();
+        await writeFile(join(artifactRoot, digest!, "practices/read.md"), "Changed artifact.\n");
+      } else {
+        await rm(join(root.rootPath, "store.sqlite"));
+      }
+      for (const practiceId of [id, "example.absent"]) {
+        // eslint-disable-next-line no-await-in-loop -- verify the same damaged Store for both lookups
+        const result = await get(directory, "store", practiceId);
+        expect(result.exitCode).toBe(2);
+        expect(result.response.error.code).toBe("store.recovery-required");
+      }
+    });
+  },
+);
+
+test("cold open converges an interrupted manifest publication before returning guidance", async () => {
+  await withDirectory(async (directory) => {
+    const root = await install(directory);
+    const manifestPath = join(root.rootPath, "installed-packs.json");
+    const oldManifest = await readFile(manifestPath, "utf8");
+    const before = JSON.parse(oldManifest);
+    const target = {
+      ...before,
+      generation: before.generation + 1,
+      effectiveRevision: before.effectiveRevision + 1,
+    };
+    // Simulate the persisted crash window: target manifest published, SQLite still at old tuple.
+    const operationId = "00000000-0000-4000-8000-000000000001";
+    const operations = join(root.rootPath, "operations");
+    await mkdir(operations, { recursive: true });
+    await writeFile(
+      join(operations, `${operationId}.json`),
+      JSON.stringify({
+        operationId,
+        operationType: "reindex",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        oldGeneration: before.generation,
+        targetGeneration: target.generation,
+        oldEffectiveRevision: before.effectiveRevision,
+        targetEffectiveRevision: target.effectiveRevision,
+        oldManifest,
+        targetManifest: JSON.stringify(target),
+      }),
+    );
+    await writeFile(manifestPath, JSON.stringify(target));
+    const result = await get(directory);
+    expect(result.exitCode).toBe(0);
+    expect(result.response.data.practice.id).toBe(id);
+    expect(JSON.parse(await readFile(manifestPath, "utf8"))).toEqual(before);
+    expect(await readdir(operations)).toEqual([]);
+  });
+});

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -32,6 +32,7 @@ test("returns machine-readable root capability discovery", async () => {
       commands: [
         { name: "describe" },
         { name: "install" },
+        { name: "get" },
         { name: "format" },
         { name: "i18n.sync" },
         { name: "validate" },

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -212,13 +212,17 @@ test("describes registered commands from a single registry", () => {
       {
         name: "describe",
         positionals: [
-          { name: "command", values: ["describe", "install", "format", "i18n.sync", "validate"] },
+          {
+            name: "command",
+            values: ["describe", "install", "get", "format", "i18n.sync", "validate"],
+          },
         ],
       },
       {
         name: "install",
         positionals: [{ name: "pack", required: true }],
       },
+      { name: "get", positionals: [{ name: "practice-id", required: true }] },
       { name: "format" },
       { name: "i18n.sync" },
       { name: "validate" },
@@ -265,7 +269,7 @@ test("derives parser options and describe metadata from registered commands", as
     positionals: [
       {
         name: "command",
-        values: ["describe", "install", "format", "i18n.sync", "validate", "future"],
+        values: ["describe", "install", "get", "format", "i18n.sync", "validate", "future"],
       },
     ],
   });

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -7,6 +7,7 @@ import {
 import { frameworkErrorCodes, invalidInvocationError } from "./runtime/errors.js";
 import { logLevels } from "./runtime/logger.js";
 import { createInstallCommand } from "./install/install-command.js";
+import { createGetCommand } from "./get/get-command.js";
 import { createLocalizationCommands } from "./localization/index.js";
 
 export interface CommandOption {
@@ -228,6 +229,7 @@ export const rootCommand = snapshotCommandDefinition({
 export const commandRegistry = snapshotCommandDefinitions([
   discoveryCommandDefinition,
   createInstallCommand(),
+  createGetCommand(),
   ...createLocalizationCommands(),
 ]);
 

--- a/packages/cli/src/runtime/errors.ts
+++ b/packages/cli/src/runtime/errors.ts
@@ -2,6 +2,7 @@ export const cliErrorCodes = Object.freeze({
   packInvalid: "pack.invalid",
   packUpgradeRequired: "pack.upgrade-required",
   practiceConflict: "practice.conflict",
+  practiceNotFound: "practice.not-found",
   registryInvalid: "registry.invalid",
   registryPackNotFound: "registry.pack-not-found",
   registryUnavailable: "registry.unavailable",


### PR DESCRIPTION
## Summary

Agents can now run `lore get <practice-id>` after installing a Pack to receive its complete canonical Practice, content digest, and compact source list. The command selects from one verified `LocalStore.open()` snapshot, honors `--store-root`, and distinguishes an absent Practice (`practice.not-found`) from a busy or damaged Store.

Normal LocalStore initialization, migration, and pending-journal recovery still apply. The engine API and storage schema are unchanged.

## Linked issue

Closes #49

## Type of change

- [x] New feature (non-breaking)

## How was this tested?

- `bun test`: 330 passed, including 26 new get tests for exact lookup, normalized content, source ordering, isolation, corruption, recovery, schema, and error envelopes.
- `bun run typecheck`, `bun run lint`, `bun run test:integration`, and CLI compilation passed. Process integration installs a synthetic fixture in one process and reads it with the compiled CLI in another, without a live Registry.
- Manual acceptance: officially installed `agentic-coding@0.3.0` into a temporary isolated Store (30 Practices); three separate compiled get processes returned the exact expected full body, digest, and sources without changing Store state. Observed process durations were 55, 55, and 56 ms on the development machine, not a general performance guarantee.
- Changed-file formatting, diff whitespace checks, sensitive-pattern scans, and independent code review passed.
- Full-repository `fmt:check` still reports 11 unchanged baseline files outside this PR.

## Checklist

- [x] Linked the issue this closes
- [x] Product design agreed before implementation and recorded in the issue
- [x] Added/updated tests
- [x] Lint, typecheck, and tests pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private runtime data in the diff

## AI assistance

- [x] Parts of this PR were generated or assisted by an AI tool
- [ ] I have reviewed every line of the AI-generated code and take full responsibility for it

## Notes for reviewers

`get` inherits cold-open recovery writes rather than promising zero filesystem writes. Healthy reads preserve installed content and Store counters. Missing IDs are reported only after Store validation. The result intentionally omits duplicated internal canonical content, runtime translations, and cross-command snapshot/version semantics.
