### PR TITLE
docs: add shell-neutral lore-dev setup guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Precise scripts live in each `packages/*/package.json`; the above is what the ro
 
 - Every LocalStore-consuming CLI command must use the shared Store-root resolver; do not call `defaultStorageRoot` directly when honoring the global override.
 - When manually writing Store data from a branch or worktree, use an isolated Store root. Never point it at another worktree's or the user's default Store.
+- Before exercising the current worktree's CLI source, check whether a `lore-dev` helper is available. If not, ask the developer whether they want to configure one and which shell they use; do not assume zsh or modify a shell startup file without explicit developer approval. Use that helper with its worktree-specific Store instead of rebuilding or repointing global `lore` for ordinary source-level CLI checks.
 
 ## Code style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Precise scripts live in each `packages/*/package.json`; the above is what the ro
 
 - Every LocalStore-consuming CLI command must use the shared Store-root resolver; do not call `defaultStorageRoot` directly when honoring the global override.
 - When manually writing Store data from a branch or worktree, use an isolated Store root. Never point it at another worktree's or the user's default Store.
-- Before exercising the current worktree's CLI source, check whether a `lore-dev` helper is available. If not, ask the developer whether they want to configure one and which shell they use; do not assume zsh or modify a shell startup file without explicit developer approval. Use that helper with its worktree-specific Store instead of rebuilding or repointing global `lore` for ordinary source-level CLI checks.
+- Before exercising the current worktree's CLI source, check whether a `lore-dev` helper is available. If not, ask the developer whether they want to configure one and which shell they use; do not assume zsh or modify a shell startup file without explicit developer approval. Use that helper instead of rebuilding or repointing global `lore` for ordinary source-level CLI checks, passing `--store-root` only when isolation is required.
 
 ## Code style
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -29,9 +29,9 @@ The CLI's discoverable global option is:
 
 When omitted, the Store remains `~/.lorelum`. A relative path is resolved from the calling process's current working directory. `install`, `get`, and `query` consume LocalStore; do not infer support for other commands from this guide.
 
-### A copyable `lore-dev` function
+### Source-level CLI helper
 
-Define this function in the shell where you are working (or temporarily paste it into a session):
+`lore-dev` is a developer convenience, not a CLI requirement. Configure an equivalent helper with the initialization mechanism for the developer's shell; do not assume every developer uses zsh. The following is a zsh example, which can be added to `~/.zshrc` or pasted into one zsh session:
 
 ```zsh
 lore-dev() {
@@ -55,6 +55,8 @@ lore-dev() {
 
   bun "$cli_entry" --store-root "$store_root" "$@"
 }
+
+alias ld='lore-dev'
 ```
 
 The function anchors the source entrypoint to the current worktree and derives its Store from Git administrative data. That Store is worktree-specific and is not part of a commit. For example:
@@ -64,6 +66,12 @@ lore-dev install pack-creator --pack-version 0.1.0
 lore-dev install agentic-coding --pack-version 0.3.0
 lore-dev get agentic-coding.testing.classify-failure-before-changing-test
 ```
+
+The `ld` alias above is optional and specific to the zsh example.
+
+### Agent setup check
+
+Before an Agent exercises the current worktree's CLI source, it should check whether a `lore-dev` helper is available. If not, the Agent must ask the developer whether they want to configure one and which shell they use; it must not assume zsh or modify a shell startup file without explicit developer approval. Once configured, Agents should use the helper instead of rebuilding or repointing global `lore` for ordinary source-level CLI checks.
 
 Use the source function while iterating. To check compiled behavior for the same checkout, run:
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -35,7 +35,7 @@ When omitted, the Store remains `~/.lorelum`. A relative path is resolved from t
 
 ```zsh
 lore-dev() {
-  local repo_root store_root cli_entry
+  local repo_root cli_entry
 
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
     print -u2 "lore-dev: current directory is not inside a Git worktree"
@@ -48,30 +48,25 @@ lore-dev() {
     return 1
   fi
 
-  store_root="$(git rev-parse --path-format=absolute --git-path lorelum/store 2>/dev/null)" || {
-    print -u2 "lore-dev: could not resolve the worktree-specific Git administrative Store"
-    return 1
-  }
-
-  bun "$cli_entry" --store-root "$store_root" "$@"
+  bun "$cli_entry" "$@"
 }
 
 alias ld='lore-dev'
 ```
 
-The function anchors the source entrypoint to the current worktree and derives its Store from Git administrative data. That Store is worktree-specific and is not part of a commit. For example:
+The function anchors the source entrypoint to the current worktree while leaving Store selection to the CLI. Without `--store-root`, it uses the normal default `~/.lorelum`; pass `--store-root` explicitly when a check requires an isolated Store. For example:
 
 ```zsh
-lore-dev install pack-creator --pack-version 0.1.0
-lore-dev install agentic-coding --pack-version 0.3.0
-lore-dev get agentic-coding.testing.classify-failure-before-changing-test
+lore-dev query "responsibility boundary" --top-k 2
+lore-dev --store-root "$(git rev-parse --path-format=absolute --git-path lorelum/store)" \
+  install pack-creator --pack-version 0.1.0
 ```
 
 The `ld` alias above is optional and specific to the zsh example.
 
 ### Agent setup check
 
-Before an Agent exercises the current worktree's CLI source, it should check whether a `lore-dev` helper is available. If not, the Agent must ask the developer whether they want to configure one and which shell they use; it must not assume zsh or modify a shell startup file without explicit developer approval. Once configured, Agents should use the helper instead of rebuilding or repointing global `lore` for ordinary source-level CLI checks.
+Before an Agent exercises the current worktree's CLI source, it should check whether a `lore-dev` helper is available. If not, the Agent must ask the developer whether they want to configure one and which shell they use; it must not assume zsh or modify a shell startup file without explicit developer approval. Once configured, Agents should use the helper instead of rebuilding or repointing global `lore` for ordinary source-level CLI checks, passing `--store-root` only when isolation is required.
 
 Use the source function while iterating. To check compiled behavior for the same checkout, run:
 


### PR DESCRIPTION
Closes #65\n\n## Summary\n- document a source-level `lore-dev` helper without assuming zsh\n- preserve the CLI default Store; pass `--store-root` explicitly for isolation\n- require Agents to ask about the developer shell before setup\n\n## Verification\n- `lore-dev query "responsibility boundary" --top-k 2` returned 2 default-Store results\n- the same query with the explicit worktree `--store-root` returned 0 results\n- `bunx oxfmt --check AGENTS.md docs/development/README.md`\n- `git diff --check`