### PR TITLE
fix(ci): restore package manifest formatting

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@lorelum/shared": "workspace:*",
-    "@lorelum/format": "workspace:*"
+    "@lorelum/format": "workspace:*",
+    "@lorelum/shared": "workspace:*"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -12,8 +12,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@lorelum/shared": "workspace:*",
     "@lorelum/engine": "workspace:*",
+    "@lorelum/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "1.29.0"
   }
 }


### PR DESCRIPTION
Closes #67\n\n## Summary\n- sort dependencies in the two manifests flagged by CI format check\n- keep the current non-blocking formatting policy unchanged\n\n## Verification\n- `bunx oxfmt@0.59.0 --check .`