### PR TITLE
ci: upgrade checkout action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       # Bun version pinned per ADR 0002 (packageManager field in package.json).
       - name: Setup Bun


### PR DESCRIPTION
Closes #69\n\n## Summary\n- upgrade `actions/checkout` from v4 to the current official v7.0.1\n- move the checkout action runtime from Node 20 to Node 24\n- retain Bun as the project command runtime\n\n## Verification\n- parsed `.github/workflows/ci.yml` as YAML\n- GitHub Actions CI pending