### PR TITLE
docs: make AI review checks evidence-based

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,11 +29,11 @@ Closes #
 
 ## AI assistance and review
 
-- [ ] This PR contains code or documentation generated or assisted by an AI tool
-- [ ] An AI code review covered the changed behavior and edge cases; material findings are resolved or documented below
-- [ ] For a change to public behavior, contracts, schemas, or architecture, a maintainer has approved the design, acceptance evidence, and residual risks before merge
+- [ ] This PR used AI assistance (describe the scope or tool below)
+- [ ] If AI-assisted: an AI code review covered the changed behavior and edge cases; material findings are resolved or documented below
+- [ ] Maintainer sign-off is recorded for a change to public behavior, contracts, schemas, or architecture (maintainer completes before merge)
 
-<!-- If this PR used AI assistance, link the AI CR or summarize its material findings below. "Reviewed every line" is not an acceptance criterion. -->
+<!-- Leave the first two items unchecked for a human-only PR. If AI-assisted, link the AI CR or summarize its material findings below. "Reviewed every line" is not an acceptance criterion. -->
 
 ## Notes for reviewers
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,12 +27,13 @@ Closes #
 - [ ] Updated relevant documentation
 - [ ] No secrets, credentials, or private info in the diff
 
-## AI assistance
+## AI assistance and review
 
-- [ ] Parts of this PR were generated or assisted by an AI tool
-- [ ] I have reviewed every line of the AI-generated code and take full responsibility for it
+- [ ] This PR contains code or documentation generated or assisted by an AI tool
+- [ ] An AI code review covered the changed behavior and edge cases; material findings are resolved or documented below
+- [ ] For a change to public behavior, contracts, schemas, or architecture, a maintainer has approved the design, acceptance evidence, and residual risks before merge
 
-<!-- If unchecked, both reviewer and author save time. -->
+<!-- If this PR used AI assistance, link the AI CR or summarize its material findings below. "Reviewed every line" is not an acceptance criterion. -->
 
 ## Notes for reviewers
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,6 @@ Closes #
 
 - [ ] This PR used AI assistance (describe the scope or tool below)
 - [ ] If AI-assisted: an AI code review covered the changed behavior and edge cases; material findings are resolved or documented below
-- [ ] Maintainer sign-off is recorded for a change to public behavior, contracts, schemas, or architecture (maintainer completes before merge)
 
 <!-- Leave the first two items unchecked for a human-only PR. If AI-assisted, link the AI CR or summarize its material findings below. "Reviewed every line" is not an acceptance criterion. -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,8 +250,8 @@ CI runs build, lint, typecheck, and test on every PR. A PR cannot merge until al
 We actively welcome contributions made with AI coding assistants. A few rules to keep quality high:
 
 1. **Read [AGENTS.md](./AGENTS.md)** before letting the agent write code — it contains repo-specific commands, layout, and boundaries the agent must respect.
-2. **You are responsible for the diff.** "The AI wrote it" is never a defense for bugs, broken tests, or license issues. Review every line.
-3. **Disclose AI assistance.** In the PR description, check the "AI-assisted" box and briefly note which parts were AI-generated. This helps reviewers focus.
+2. **You are responsible for merged behavior.** "The AI wrote it" is never a defense for bugs, broken tests, or license issues. Use evidence-based review: approve the architecture, public contracts, security boundaries, acceptance evidence, and residual risks. "Reviewed every line" is not an acceptance criterion.
+3. **Disclose AI assistance and its review evidence.** In the PR description, check the "AI-assisted" box, briefly note which parts used AI, and link or summarize the AI code review. This helps reviewers focus.
 4. **No large AI-generated dump PRs.** Keep PRs focused and reviewable. If an agent produces a 1000-line diff, break it into smaller PRs.
 5. **Tests still apply.** AI-generated code must pass the same lint, type-check, and test gates as hand-written code.
 


### PR DESCRIPTION
## Summary

Replace the ceremonial "reviewed every AI-generated line" attestation with evidence-based review gates. AI-assisted changes now disclose their scope and include an AI CR focused on behavior and edge cases.

`CONTRIBUTING.md` now uses the same model: contributors remain accountable for merged behavior, while the human review gate focuses on architecture, contracts, security boundaries, acceptance evidence, and residual risk.

## Linked issue

Closes #75

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Docs only
- [ ] Refactor / chore

## How was this tested?

- `bunx oxfmt --check .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md`
- `git diff --check`
- `bun run typecheck`
- `bun run lint` (two existing `apps/site` `_splat` warnings; no errors)
- `bun test` (432 passing)
- AI CR against `origin/main`: found and resolved the stale conflicting contributor guidance, the human-only PR ambiguity, and unclear maintainer-gate ownership. A follow-up AI CR found no remaining actionable issues.
- Manual review of the rendered Markdown semantics is the remaining verification boundary; template behavior is not executable code.

## Checklist

- [x] Linked the issue this closes (`Closes #xxx`)
- [x] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed in the issue / Discussions first
- [ ] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

No new executable behavior requires tests; formatting, diff validation, lint, typecheck, and the full suite passed.

## AI assistance and review

- [x] This PR used AI assistance to draft and revise the documentation
- [x] AI CR covered the changed workflow and edge cases; all material findings were resolved

## Notes for reviewers

- The new template deliberately makes AI CR conditional: human-only PRs leave the first two AI items unchecked.
- The reviewer signal is evidence, not a claim that a human read every generated line. Architecture and public-boundary approvals remain in Issues, ADRs, and GitHub Reviews rather than an author self-attestation.
