### PR TITLE
feat(site): redesign landing navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,10 @@ Keep the tree navigable and each file independently understandable. These are pr
 - **Never commit directly to `main`.** Every change goes through a PR.
 - **One issue per PR.** Keep PRs focused and reviewable. If a change spans multiple issues, split it.
 - **Conventional Commits** (`feat(cli): ...`, `fix(engine): ...`, `spec(format): ...`, `docs: ...`).
-- **Every PR links to an issue** (`Closes #123`).
+- **Every PR links to the issue it actually addresses** with `Closes #123`. Do not close or cite an unrelated issue just to satisfy the format; create a focused issue when one does not exist.
+- **Use the repository PR template.** Before opening or editing a PR, read [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md) and keep every section, including the linked issue, change type, verification, checklist, AI assistance, and reviewer notes.
+- **Sync before the final review.** Fetch the latest `origin/main`, rebase or merge it into the feature branch, then rerun the relevant checks before pushing the PR branch.
+- **Review before publishing.** Inspect the staged file list and diff before commits, run a repository-appropriate secret scan, and verify the remote branch and PR after pushing.
 - **Public-contract changes need design alignment first.** Changes to the Practice/pack format, retrieval model, CLI surface, or MCP tool interface require an issue or Discussion with design alignment before implementation. Reuse existing agreed design and acceptance criteria when they cover the requested change; do not require a new discussion for the same decision.
 - **Work that preserves the existing public contract does not need upfront design discussion.** This includes pure bug fixes restoring documented behavior, internal refactors, performance improvements, and docs. Issue and PR requirements, applicable tests and benchmarks, and the approval boundaries below still apply.
 
@@ -99,6 +102,7 @@ Keep the tree navigable and each file independently understandable. These are pr
 ## Where to look
 
 - **Product understanding:** `README.md` (overview) and `CONTRIBUTING.md` (workflow).
+- **Pull requests:** `.github/PULL_REQUEST_TEMPLATE.md` is the source of truth for PR body sections and checkboxes.
 - **Planning a feature?** Check existing issues, Specs, and agreed designs, then apply the design-alignment rule in [Git workflow](#git-workflow).
 
 ## When in doubt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,10 +74,9 @@ Keep the tree navigable and each file independently understandable. These are pr
 - **Never commit directly to `main`.** Every change goes through a PR.
 - **One issue per PR.** Keep PRs focused and reviewable. If a change spans multiple issues, split it.
 - **Conventional Commits** (`feat(cli): ...`, `fix(engine): ...`, `spec(format): ...`, `docs: ...`).
-- **Every PR links to the issue it actually addresses** with `Closes #123`. Do not close or cite an unrelated issue just to satisfy the format; create a focused issue when one does not exist.
+- **Every PR links to an issue** (`Closes #123`).
 - **Use the repository PR template.** Before opening or editing a PR, read [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md) and keep every section, including the linked issue, change type, verification, checklist, AI assistance, and reviewer notes.
-- **Sync before the final review.** Fetch the latest `origin/main`, rebase or merge it into the feature branch, then rerun the relevant checks before pushing the PR branch.
-- **Review before publishing.** Inspect the staged file list and diff before commits, run a repository-appropriate secret scan, and verify the remote branch and PR after pushing.
+- **Review the full diff before opening a PR.** Read every changed line, verify the change is intentional and in scope, and record the result in the PR's AI assistance section.
 - **Public-contract changes need design alignment first.** Changes to the Practice/pack format, retrieval model, CLI surface, or MCP tool interface require an issue or Discussion with design alignment before implementation. Reuse existing agreed design and acceptance criteria when they cover the requested change; do not require a new discussion for the same decision.
 - **Work that preserves the existing public contract does not need upfront design discussion.** This includes pure bug fixes restoring documented behavior, internal refactors, performance improvements, and docs. Issue and PR requirements, applicable tests and benchmarks, and the approval boundaries below still apply.
 
@@ -102,7 +101,6 @@ Keep the tree navigable and each file independently understandable. These are pr
 ## Where to look
 
 - **Product understanding:** `README.md` (overview) and `CONTRIBUTING.md` (workflow).
-- **Pull requests:** `.github/PULL_REQUEST_TEMPLATE.md` is the source of truth for PR body sections and checkboxes.
 - **Planning a feature?** Check existing issues, Specs, and agreed designs, then apply the design-alignment rule in [Git workflow](#git-workflow).
 
 ## When in doubt

--- a/apps/site/AGENTS.md
+++ b/apps/site/AGENTS.md
@@ -35,11 +35,14 @@ not done.
 | user-facing copy (any language)        | `src/lib/translations.ts`                          | hardcode strings in components           |
 | animation capability check             | `src/components/landing/gates/` (+ colocated test) | inline `matchMedia` calls in components  |
 | shared animation hook / GSAP primitive | `src/components/landing/motion/`                   | a new top-level util file                |
+| feature-scoped animation hook          | next to its feature (for example `src/components/navigation/`) | putting feature-only logic in shared motion |
 | an ambient / effect component          | `src/components/landing/effects/`                  | a second background layer                |
 | a motion-aware gate wrapper            | `src/components/landing/motion-aware/`             | an ungated wrapper named `motion-aware-*`|
+| site navigation components             | `src/components/navigation/`                       | putting navbar code in `landing-shell.tsx` |
 | a vendored React Bits component        | `src/components/react-bits/` + barrel `index.ts`   | `npm install` an animation library       |
 | third-party component CSS              | `src/styles/vendor.css`                            | inline `<style>` or new top-level CSS    |
-| site's own CSS                         | `src/styles/landing.css`                           | edit `app.css` beyond `@theme` tokens    |
+| page-level landing CSS                 | `src/styles/landing.css`                           | putting component CSS here by default    |
+| component-owned CSS                    | next to the component (for example `src/components/navigation/*.css`) | putting it in `landing.css` or `app.css` |
 | SEO head / meta                        | `src/lib/meta.ts` + route `head`                   | `<title>` back into `__root.tsx`         |
 | static assets                          | `public/`                                          | `src/` (imports are for code only)       |
 | docs page                              | `content/docs/*.mdx` + `*.zh.mdx`                  | one locale without the other             |
@@ -57,17 +60,18 @@ These exist because breaking them caused real bugs here. Each names a file to
 copy — read it before writing your own version.
 
 1. **SSR safety.** The site server-renders and prerenders. No `window`,
-   `document`, `matchMedia`, `localStorage` at module top level or during
-   render — touch them inside `useEffect`/`useLayoutEffect` only. Copy:
-   `src/components/landing/sections/hero.tsx` (gates read in effects, refs
-   for elements).
+   `document`, `matchMedia`, or `localStorage` at module top level or during
+   render. Access browser APIs only inside effects, event handlers, or other
+   client-only callbacks. Copy `src/components/landing/sections/hero.tsx`
+   (gates read in effects, refs for elements).
 
 2. **GSAP lifecycle.** Import gsap and register plugins via
    `src/components/landing/motion/gsap-client.ts` (`registerGsapPlugins()`
    before any ScrollTrigger/ScrollSmoother/SplitText use). Create tweens
    inside `gsap.context(() => {...})` and return `ctx.revert()` — never
-   `gsap.matchMedia()` and never bare globals. Copy: `sections/hero.tsx`,
-   `src/components/landing/motion/split-text-reveal.tsx`.
+   `gsap.matchMedia()` and never bare globals. Generic primitives belong in
+   `landing/motion/`; hooks used only by a feature may stay with that feature.
+   Copy `sections/hero.tsx` and `src/components/landing/motion/split-text-reveal.tsx`.
 
 3. **ScrollTrigger is the canonical viewport gate.** Run/pause work based on
    viewport with ScrollTrigger — usually `usePauseOffscreen` from
@@ -109,11 +113,14 @@ copy — read it before writing your own version.
    and if a port cannot be licensed, rewrite it rather than ship it (see the
    antigravity ring's rewrite history in THIRD_PARTY_NOTICE.md).
 
-8. **Dark mode is class-based.** `dark:` is re-bound to `.dark` on `<html>`
+8. **Dark mode is class-based and animated.** `dark:` is re-bound to `.dark` on `<html>`
    (`@custom-variant` in `app.css`), not `prefers-color-scheme`. Monochrome
    logo/mark assets invert under `html.dark` via `landing.css`; an asset that
-   must keep brand color opts out with `.logo-keep-color`. Verify both themes
-   before declaring done. Copy: `landing.css` logo-wall section.
+   must keep brand color opts out with `.logo-keep-color`. Theme controls must
+   use the View Transition API with `flushSync` when available and fall back to
+   `setTheme`, so theme changes never snap unnecessarily. Verify both themes
+   and the transition in a browser before declaring done. Copy:
+   `src/components/navigation/theme-toggle.tsx`.
 
 9. **Check dependencies before adding them.** The repo is Apache-2.0 core —
    no GPL/AGPL deps without maintainer sign-off. Native-JS packages need
@@ -128,10 +135,17 @@ copy — read it before writing your own version.
   Copy: `gates/particle-budget.test.ts`.
 - Visual changes are verified in the dev server — both themes, both locales
   (`/en`, `/zh`) — before the PR is marked ready.
+- Navigation and theme changes must be checked at scroll position `0`, after
+  leaving the top, and after crossing the hero; verify keyboard focus, touch
+  targets, and the theme transition in browsers with and without View
+  Transition support when practical.
 - Touching animation/perf? Check the FPS overlay in dev: append `?probe=1`
   (`fps-probe.tsx`, dev-only). A scroll that drops frames is not done.
 - `bun run --filter @lorelum/site build` must pass before merging; it is also
   what Cloudflare runs.
+- Before opening the PR, fill every section of the root
+  [PR template](../../.github/PULL_REQUEST_TEMPLATE.md), include the exact
+  issue being closed, and record visual verification notes.
 
 ## Deployment
 

--- a/apps/site/AGENTS.md
+++ b/apps/site/AGENTS.md
@@ -1,160 +1,64 @@
 # AGENTS.md — apps/site
 
-> Frontend-specific rules for AI coding agents working in this package. The
-> [root AGENTS.md](../../AGENTS.md) still applies (strict TypeScript, typed
-> errors, no silent failures, file organization, testing, git workflow). This
-> file adds what is unique to a marketing/documentation frontend and wins on
-> conflict inside `apps/site`.
+The [root AGENTS.md](../../AGENTS.md) applies here. This file only adds rules
+specific to Lorelum's public landing and bilingual docs site.
 
-## What this package is
+## Stack and commands
 
-The Lorelum landing + bilingual docs site: TanStack Start (SSR + prerender),
-Fumadocs MDX, Tailwind v4 (CSS-first), React 19, GSAP, and vendored
-[React Bits](https://reactbits.dev) components. Deployed to Cloudflare Workers
-(see `docs/site-deploy.md`). It is the product's public face — visual quality
-and performance are acceptance criteria, not polish.
-
-## Commands
+TanStack Start (SSR + prerender), Fumadocs MDX, Tailwind v4, React 19, GSAP,
+and vendored React Bits components. Visual quality and runtime performance are
+part of the acceptance criteria.
 
 ```bash
-bun run --filter @lorelum/site dev        # vite dev → http://localhost:3000
-bun run --filter @lorelum/site typecheck  # tsc --noEmit
-bun run --filter @lorelum/site test       # bun test
-bun run --filter @lorelum/site build      # static + Worker output in dist/
-bun run lint                              # oxlint (repo root)
+bun run --filter @lorelum/site dev
+bun run --filter @lorelum/site typecheck
+bun run --filter @lorelum/site test
+bun run --filter @lorelum/site build
+bun run lint
 ```
 
-CI runs typecheck + lint + test on every PR. A PR that fails any of them is
-not done.
+## File placement
 
-## Where things go
+- Landing composition and sections: `src/components/landing/`.
+- Navigation and its feature-only hooks/CSS: `src/components/navigation/`.
+  Do not put navbar implementation or styles in `landing-shell.tsx` or
+  `styles/landing.css`.
+- Shared landing animation primitives: `landing/motion/`; gates: `landing/gates/`;
+  ambient effects: `landing/effects/`.
+- User-facing copy: `src/lib/translations.ts`, with both `en` and `zh` values.
+- Page-level landing styles: `src/styles/landing.css`; component styles stay
+  with their component. Only change `app.css` for global imports or theme tokens.
+- Vendored React Bits components: `src/components/react-bits/`, through its
+  barrel, with `THIRD_PARTY_NOTICE.md` updated when required.
+- Docs: `content/docs/`; routes are added under `src/routes/`.
+  `src/routeTree.gen.ts` is generated—never edit it.
 
-| You are adding…                        | It goes in…                                        | Never…                                   |
-| -------------------------------------- | -------------------------------------------------- | ---------------------------------------- |
-| a landing section                      | `src/components/landing/sections/`                 | —                                        |
-| user-facing copy (any language)        | `src/lib/translations.ts`                          | hardcode strings in components           |
-| animation capability check             | `src/components/landing/gates/` (+ colocated test) | inline `matchMedia` calls in components  |
-| shared animation hook / GSAP primitive | `src/components/landing/motion/`                   | a new top-level util file                |
-| feature-scoped animation hook          | next to its feature (for example `src/components/navigation/`) | putting feature-only logic in shared motion |
-| an ambient / effect component          | `src/components/landing/effects/`                  | a second background layer                |
-| a motion-aware gate wrapper            | `src/components/landing/motion-aware/`             | an ungated wrapper named `motion-aware-*`|
-| site navigation components             | `src/components/navigation/`                       | putting navbar code in `landing-shell.tsx` |
-| a vendored React Bits component        | `src/components/react-bits/` + barrel `index.ts`   | `npm install` an animation library       |
-| third-party component CSS              | `src/styles/vendor.css`                            | inline `<style>` or new top-level CSS    |
-| page-level landing CSS                 | `src/styles/landing.css`                           | putting component CSS here by default    |
-| component-owned CSS                    | next to the component (for example `src/components/navigation/*.css`) | putting it in `landing.css` or `app.css` |
-| SEO head / meta                        | `src/lib/meta.ts` + route `head`                   | `<title>` back into `__root.tsx`         |
-| static assets                          | `public/`                                          | `src/` (imports are for code only)       |
-| docs page                              | `content/docs/*.mdx` + `*.zh.mdx`                  | one locale without the other             |
+## Runtime rules
 
-Page-level composition (`landing-page.tsx`, `landing-shell.tsx`, the
-dev-only `fps-probe.tsx`) stays at the `landing/` root — it is the stable
-import surface the routes consume.
+- Keep SSR safe: access `window`, `document`, `matchMedia`, and `localStorage`
+  only in effects, event handlers, or other client-only callbacks.
+- Use `landing/motion/gsap-client.ts` for GSAP. Register plugins, create work
+  inside `gsap.context`, and return `ctx.revert()`. Use ScrollTrigger for
+  viewport behavior under ScrollSmoother.
+- Canvas/WebGL and per-frame effects must be capability-gated and must not add
+  another ambient background layer. `effects/page-background.tsx` owns that layer.
+- The current product decision does not use `prefers-reduced-motion`; do not
+  add it unless that decision changes.
+- Dark mode is the `.dark` class on `<html>`. Theme controls use the View
+  Transition API with `flushSync` when available, and fall back to `setTheme`.
+- Check dependency licenses before adding packages; new animation packages need
+  a concrete justification because GSAP, Motion, OGL, and Three are available.
 
-`src/routeTree.gen.ts` is **generated** by TanStack Router. Never edit it; add
-a file under `src/routes/` instead.
+## Verification and delivery
 
-## Hard rules
-
-These exist because breaking them caused real bugs here. Each names a file to
-copy — read it before writing your own version.
-
-1. **SSR safety.** The site server-renders and prerenders. No `window`,
-   `document`, `matchMedia`, or `localStorage` at module top level or during
-   render. Access browser APIs only inside effects, event handlers, or other
-   client-only callbacks. Copy `src/components/landing/sections/hero.tsx`
-   (gates read in effects, refs for elements).
-
-2. **GSAP lifecycle.** Import gsap and register plugins via
-   `src/components/landing/motion/gsap-client.ts` (`registerGsapPlugins()`
-   before any ScrollTrigger/ScrollSmoother/SplitText use). Create tweens
-   inside `gsap.context(() => {...})` and return `ctx.revert()` — never
-   `gsap.matchMedia()` and never bare globals. Generic primitives belong in
-   `landing/motion/`; hooks used only by a feature may stay with that feature.
-   Copy `sections/hero.tsx` and `src/components/landing/motion/split-text-reveal.tsx`.
-
-3. **ScrollTrigger is the canonical viewport gate.** Run/pause work based on
-   viewport with ScrollTrigger — usually `usePauseOffscreen` from
-   `src/components/landing/motion/use-viewport-anim.ts` — so every gate
-   follows the ScrollSmoother's scroller and refresh timing with one idiom.
-   IntersectionObserver **does** fire under the current ScrollSmoother setup
-   (measured with the fps probe's `io` line: counts rise on every viewport
-   crossing), but transform-based smooth scrolling has silent IO failure modes
-   in other configurations, and the old "observers never fire" rule was
-   measured to be false. If you must use IO anyway, verify with `?probe=1`
-   first and say why in the PR.
-
-4. **Canvas/WebGL effects are gated and single-layer.** New canvas, WebGL or
-   per-frame effects must (a) render through a `motion-aware-*` wrapper in
-   `landing/motion-aware/` that checks `shouldEnableCanvasEffects` from
-   `gates/motion-gate`, (b) derive particle counts from
-   `gates/particle-budget`, and (c) not add a second background layer —
-   `effects/page-background.tsx` is the one ambient layer. Three stacked glow
-   layers already had to be deleted for flicker. Copy:
-   `src/components/landing/motion-aware/motion-aware-specular-button.tsx`,
-   `src/components/landing/effects/antigravity.tsx` (SSR-safe Canvas usage).
-
-5. **No `prefers-reduced-motion` machinery.** Product decision (recorded in
-   commit `eec3b0e`): the site does not honor the OS reduce-motion setting.
-   Gates branch on pointer type and hardware capability only. Do not re-add
-   `matchMedia('(prefers-reduced-motion: …)')` or `motion-reduce:` classes.
-
-6. **Bilingual or broken.** Every user-facing string goes through
-   `LandingStrings` in `src/lib/translations.ts` with **both** the `en` and
-   `zh` entries; typecheck fails on one-sided changes. Keep keys grouped by
-   section with a comment, as the file already does.
-
-7. **Vendored third-party code is ledgered.** React Bits components live in
-   `src/components/react-bits/` with their license header, keep upstream
-   structure, and are imported **only via the `@/components/react-bits`
-   barrel**. Adding, removing or rewriting one requires a matching row in
-   `apps/site/THIRD_PARTY_NOTICE.md`. Anything ported from elsewhere gets its
-   own notice section with provenance and open license questions called out —
-   and if a port cannot be licensed, rewrite it rather than ship it (see the
-   antigravity ring's rewrite history in THIRD_PARTY_NOTICE.md).
-
-8. **Dark mode is class-based and animated.** `dark:` is re-bound to `.dark` on `<html>`
-   (`@custom-variant` in `app.css`), not `prefers-color-scheme`. Monochrome
-   logo/mark assets invert under `html.dark` via `landing.css`; an asset that
-   must keep brand color opts out with `.logo-keep-color`. Theme controls must
-   use the View Transition API with `flushSync` when available and fall back to
-   `setTheme`, so theme changes never snap unnecessarily. Verify both themes
-   and the transition in a browser before declaring done. Copy:
-   `src/components/navigation/theme-toggle.tsx`.
-
-9. **Check dependencies before adding them.** The repo is Apache-2.0 core —
-   no GPL/AGPL deps without maintainer sign-off. Native-JS packages need
-   matching `@types/*` (`three` → `@types/three`, pinned to the same minor —
-   a stale local install once masked this and broke CI). Animation needs are
-   already covered by `gsap`, `motion`, `ogl`, `three`; adding another
-   animation library needs justification in the PR.
-
-## Verification loop
-
-- Logic (gates, hooks, lib) ships with colocated `*.test.ts` (`bun test`).
-  Copy: `gates/particle-budget.test.ts`.
-- Visual changes are verified in the dev server — both themes, both locales
-  (`/en`, `/zh`) — before the PR is marked ready.
-- Navigation and theme changes must be checked at scroll position `0`, after
-  leaving the top, and after crossing the hero; verify keyboard focus, touch
-  targets, and the theme transition in browsers with and without View
-  Transition support when practical.
-- Touching animation/perf? Check the FPS overlay in dev: append `?probe=1`
-  (`fps-probe.tsx`, dev-only). A scroll that drops frames is not done.
-- `bun run --filter @lorelum/site build` must pass before merging; it is also
-  what Cloudflare runs.
-- Before opening the PR, fill every section of the root
-  [PR template](../../.github/PULL_REQUEST_TEMPLATE.md), include the exact
-  issue being closed, and record visual verification notes.
+- Add colocated `bun:test` coverage for new logic, gates, and hooks.
+- Manually verify visual work in both locales and themes. For navigation, check
+  the top state, detached state, hero transition, keyboard focus, and touch targets.
+- For animation or performance changes, use `?probe=1`; a frame-dropping scroll
+  is not done.
+- Before a PR, run typecheck, tests, lint, and build; then follow the root PR
+  template and include the visual verification result.
 
 ## Deployment
 
-Git-integrated Workers Builds deploys **`main` only**; feature branches don't
-build. Details, quotas and manual `wrangler deploy` flow:
-[`docs/site-deploy.md`](../../docs/site-deploy.md).
-
-## When in doubt
-
-Visual/UX questions are product decisions — ask, don't guess, and don't
-"fix" unrelated visuals in passing. Git workflow (PRs, Conventional Commits,
-issue links) follows the root AGENTS.md.
+Workers Builds deploys `main` only. See [`docs/site-deploy.md`](../../docs/site-deploy.md).

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -23,6 +23,7 @@
     "gsap": "^3.15.0",
     "lucide-react": "^1.31.0",
     "motion": "^12",
+    "next-themes": "^0.4.6",
     "ogl": "1.0.11",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/apps/site/src/components/docs-layout-options.tsx
+++ b/apps/site/src/components/docs-layout-options.tsx
@@ -1,7 +1,9 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
-import { LanguageSwitch } from '@/components/language-switch';
+import { BrandLockup } from '@/components/navigation/brand-lockup';
+import { ThemeToggle } from '@/components/navigation/theme-toggle';
 import { i18n } from '@/lib/i18n';
-import { appName, gitConfig } from '@/lib/shared';
+import { gitConfig } from '@/lib/shared';
+import { getStrings } from '@/lib/translations';
 
 /** User-facing names for each locale, used in the nav title suffix. */
 const localeNames: Record<string, string> = {
@@ -27,20 +29,18 @@ export function baseOptions(
   locale: string = i18n.defaultLanguage,
   opts: BaseOptions = {},
 ): BaseLayoutProps {
-  const suffix =
-    locale === i18n.defaultLanguage ? '' : ` · ${localeNames[locale] ?? locale}`;
+  const localeSuffix = locale === i18n.defaultLanguage ? '' : ` · ${localeNames[locale] ?? locale}`;
   const { withSearch = true } = opts;
 
   return {
-    // Disable Fumadocs' built-in language select: we render our own
-    // `LanguageSwitch` in the nav, so showing both would duplicate the
-    // control on every page.
+    // Language selection is intentionally kept out of the product navigation.
     i18n: false,
     searchToggle: withSearch ? undefined : { enabled: false },
     nav: {
-      title: `${appName}${suffix}`,
-      // Language switcher sits at the end of the nav, next to the theme toggle.
-      children: <LanguageSwitch />,
+      title: <BrandLockup suffix={`${getStrings(locale).footerDocs}${localeSuffix}`} />,
+    },
+    themeSwitch: {
+      component: <ThemeToggle lang={locale} />,
     },
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
   };

--- a/apps/site/src/components/landing/landing-shell.tsx
+++ b/apps/site/src/components/landing/landing-shell.tsx
@@ -1,12 +1,7 @@
-import { useEffect, useRef, type ReactNode } from 'react';
-import { Link } from '@tanstack/react-router';
-import { ThemeSwitch } from 'fumadocs-ui/layouts/shared/slots/theme-switch';
-import { LanguageSwitch } from '@/components/language-switch';
-import { i18n } from '@/lib/i18n';
-import { appName, gitConfig } from '@/lib/shared';
+import { type ReactNode } from 'react';
+import { LandingNavbar } from '@/components/navigation/landing-navbar';
 import { PageBackground } from './effects/page-background';
 import { FpsProbe } from './fps-probe';
-import { gsap, registerGsapPlugins, ScrollTrigger } from './motion/gsap-client';
 import {
   SmoothScroll,
   SMOOTH_CONTENT_ID,
@@ -17,14 +12,8 @@ import {
  * Landing-page shell, replacing Fumadocs `HomeLayout` on the marketing route
  * only (docs keep `DocsLayout`).
  *
- * Antigravity ships a fixed header outside its ScrollSmoother content because
- * `position: sticky/fixed` inside a transformed scroll container stops
- * behaving like the natively-scrolled page. We mirror that: the brand/nav is
- * a fixed sibling of `#smooth-content`, so ScrollSmoother never transforms it
- * and the theme/language switches stay reachable while scrolling.
- *
- * The nav hides while scrolling down and slides back on the first upward
- * scroll (transform-only, one tween per direction change).
+ * The navigation stays outside the transformed ScrollSmoother content so its
+ * fixed positioning is unaffected by the landing page's translated content.
  */
 export function LandingShell({
   lang,
@@ -33,71 +22,9 @@ export function LandingShell({
   lang: string;
   children: ReactNode;
 }) {
-  const homePath = lang === i18n.defaultLanguage ? '/' : `/${lang}`;
-  const github = `https://github.com/${gitConfig.user}/${gitConfig.repo}`;
-  const navRef = useRef<HTMLElement>(null);
-
-  // Hide-on-scroll-down / show-on-scroll-up. Threshold keeps the nav steady
-  // near the top of the page; direction comes from ScrollTrigger so it agrees
-  // with the smoothed scroll the rest of the page animates against.
-  useEffect(() => {
-    const nav = navRef.current;
-    if (!nav) return;
-    registerGsapPlugins();
-
-    const ctx = gsap.context(() => {
-      let hidden = false;
-      const setNav = (hide: boolean) => {
-        hidden = hide;
-        gsap.to(nav, {
-          yPercent: hide ? -100 : 0,
-          duration: 0.35,
-          ease: 'power3.out',
-          overwrite: true,
-        });
-      };
-      const trigger = ScrollTrigger.create({
-        start: 0,
-        end: 'max',
-        onUpdate(self) {
-          const shouldHide = self.direction === 1 && self.scroll() > 96;
-          if (shouldHide !== hidden) setNav(shouldHide);
-        },
-      });
-      return () => trigger.kill();
-    });
-
-    return () => ctx.revert();
-  }, []);
-
   return (
     <>
-      <nav ref={navRef} className="fixed inset-x-0 top-0 z-50 h-14 border-b border-fd-border/60 bg-fd-background/95">
-        <div className="mx-auto flex h-full w-full max-w-[1400px] items-center justify-between px-4">
-          <Link
-            to={homePath}
-            className="inline-flex items-center gap-2 font-display text-[15px] font-semibold tracking-tight"
-          >
-            {appName}
-          </Link>
-
-          <div className="flex items-center gap-1.5">
-            <LanguageSwitch />
-            <ThemeSwitch />
-            <a
-              href={github}
-              target="_blank"
-              rel="noreferrer"
-              aria-label="GitHub"
-              className="inline-flex size-8 items-center justify-center rounded-lg text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
-            >
-              <svg viewBox="0 0 24 24" className="size-4" fill="currentColor" aria-hidden="true">
-                <path d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.88-1.54-3.88-1.54-.52-1.33-1.28-1.69-1.28-1.69-1.05-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.72-1.55-2.55-.29-5.23-1.28-5.23-5.68 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.83 1.19 3.09 0 4.41-2.69 5.38-5.25 5.66.41.35.78 1.05.78 2.12 0 1.53-.01 2.76-.01 3.14 0 .31.21.67.8.56A11.51 11.51 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5z" />
-              </svg>
-            </a>
-          </div>
-        </div>
-      </nav>
+      <LandingNavbar lang={lang} />
 
       {/* Fixed/ambient layers must live outside the translated scroll content
           so ScrollSmoother never turns their `position: fixed` into a

--- a/apps/site/src/components/landing/sections/ecosystem.tsx
+++ b/apps/site/src/components/landing/sections/ecosystem.tsx
@@ -56,7 +56,7 @@ export function Ecosystem({ lang }: { lang: string }) {
   }));
 
   return (
-    <section className="relative mx-auto w-full max-w-6xl px-4 py-24 sm:py-32">
+    <section id="ecosystem" className="relative mx-auto w-full max-w-6xl scroll-mt-24 px-4 py-24 sm:py-32">
       <SectionHeading eyebrow={t.ecosystemEyebrow} title={t.ecosystemHeading} sub={t.ecosystemSub} />
       <Reveal className="mt-14">
         <LogoLoop

--- a/apps/site/src/components/landing/sections/features.tsx
+++ b/apps/site/src/components/landing/sections/features.tsx
@@ -29,7 +29,7 @@ export function Features({ lang }: { lang: string }) {
   ];
 
   return (
-    <section className="relative mx-auto w-full max-w-6xl px-4 py-24 sm:py-32">
+    <section id="features" className="relative mx-auto w-full max-w-6xl scroll-mt-24 px-4 py-24 sm:py-32">
       <SectionHeading eyebrow={t.featuresEyebrow} title={t.featuresHeading} sub={t.featuresSub} />
       <div className="mt-14 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
         {items.map((item, i) => {

--- a/apps/site/src/components/landing/sections/hero.tsx
+++ b/apps/site/src/components/landing/sections/hero.tsx
@@ -100,6 +100,7 @@ export function Hero({ lang }: { lang: string }) {
 
   return (
     <section
+      id="landing-hero"
       ref={sectionRef}
       onPointerMove={onPointerMove}
       onPointerLeave={onPointerLeave}

--- a/apps/site/src/components/navigation/brand-lockup.tsx
+++ b/apps/site/src/components/navigation/brand-lockup.tsx
@@ -1,0 +1,26 @@
+import { appName } from '@/lib/shared';
+
+/** A single-colour mark for Lorelum's retrievable layers of context. */
+export function BrandLockup({
+  suffix,
+  className,
+}: {
+  suffix?: string;
+  className?: string;
+}) {
+  return (
+    <span className={`inline-flex items-center gap-2 ${className ?? ''}`}>
+      <svg viewBox="0 0 24 24" className="size-5 shrink-0" aria-hidden="true">
+        <path d="M4.5 5.5 12 2l7.5 3.5L12 9 4.5 5.5Z" fill="currentColor" opacity="0.35" />
+        <path d="M4.5 10.25 12 6.75l7.5 3.5L12 13.75l-7.5-3.5Z" fill="currentColor" opacity="0.65" />
+        <path d="M4.5 15 12 11.5l7.5 3.5L12 18.5 4.5 15Z" fill="currentColor" />
+      </svg>
+      <span className="font-display text-[15px] font-semibold tracking-[-0.02em]">{appName}</span>
+      {suffix ? (
+        <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-fd-muted-foreground">
+          / {suffix}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/site/src/components/navigation/github-link.tsx
+++ b/apps/site/src/components/navigation/github-link.tsx
@@ -1,0 +1,27 @@
+import { Star } from 'lucide-react';
+import { gitConfig } from '@/lib/shared';
+
+const starCount = 14;
+
+/** Official GitHub mark; brand icons are not substituted with generic icons. */
+export function GitHubLink() {
+  const href = `https://github.com/${gitConfig.user}/${gitConfig.repo}`;
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={`GitHub, ${starCount} stars`}
+      className="landing-navbar__github-link"
+    >
+      <svg viewBox="0 0 24 24" className="size-4" fill="currentColor" aria-hidden="true">
+        <path d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.88-1.54-3.88-1.54-.52-1.33-1.28-1.69-1.28-1.69-1.05-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.72-1.55-2.55-.29-5.23-1.28-5.23-5.68 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.83 1.19 3.09 0 4.41-2.69 5.38-5.25 5.66.41.35.78 1.05.78 2.12 0 1.53-.01 2.76-.01 3.14 0 .31.21.67.8.56A11.51 11.51 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5z" />
+      </svg>
+      <span className="landing-navbar__github-stars inline-flex items-center gap-1 border-l pl-2" aria-hidden="true">
+        <Star className="size-3.5 fill-current text-current" />
+        <span className="min-w-4 font-mono text-xs tabular-nums">{starCount}</span>
+      </span>
+    </a>
+  );
+}

--- a/apps/site/src/components/navigation/landing-navbar.css
+++ b/apps/site/src/components/navigation/landing-navbar.css
@@ -1,0 +1,99 @@
+/* Static landing navbar surface. Kept next to the component so navigation
+   styling cannot leak into page-level landing styles. */
+.landing-navbar {
+  display: flow-root;
+  pointer-events: none;
+}
+
+.landing-navbar__panel {
+  position: relative;
+  margin-top: 0;
+  margin-inline: auto;
+  width: 100%;
+  height: 3.5rem;
+  overflow: hidden;
+  pointer-events: auto;
+  border-radius: 0;
+}
+
+.landing-navbar__surface {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  opacity: 0;
+  pointer-events: none;
+  background: color-mix(in oklab, var(--color-fd-background) 84%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--color-fd-border) 72%, transparent);
+  backdrop-filter: blur(16px) saturate(1.08);
+}
+
+.landing-navbar__content {
+  position: relative;
+  z-index: 1;
+}
+
+.landing-navbar__link {
+  display: inline-flex;
+  height: 2.25rem;
+  align-items: center;
+  border-radius: 999px;
+  cursor: pointer;
+  padding: 0.5rem 0.75rem;
+  color: var(--color-fd-foreground);
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  transition:
+    color 160ms ease-out,
+    background-color 160ms ease-out;
+}
+
+.landing-navbar__link:hover {
+  background: color-mix(in oklab, var(--color-fd-primary) 9%, transparent);
+  color: var(--color-fd-primary);
+}
+
+.landing-navbar__github-link {
+  display: inline-flex;
+  height: 2.25rem;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding-inline: 0.625rem;
+  color: var(--color-fd-foreground);
+  cursor: pointer;
+  transition:
+    color 160ms ease-out,
+    background-color 160ms ease-out;
+}
+
+.landing-navbar__github-link:hover {
+  background: color-mix(in oklab, var(--color-fd-primary) 9%, transparent);
+  color: var(--color-fd-primary);
+}
+
+.landing-navbar__github-stars {
+  border-left-color: color-mix(in oklab, currentColor 60%, transparent);
+}
+
+.landing-navbar__github-link > svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.dark .landing-navbar__surface {
+  background: color-mix(in oklab, var(--color-fd-background) 90%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--color-fd-border) 82%, transparent);
+}
+
+.dark .landing-navbar__link:hover,
+.dark .landing-navbar__github-link:hover,
+.dark .site-theme-toggle:hover {
+  background: color-mix(in oklab, var(--color-fd-primary) 16%, transparent);
+  color: color-mix(in oklab, var(--color-fd-foreground) 72%, var(--color-fd-muted-foreground));
+}
+
+.dark .landing-navbar__github-stars {
+  border-left-color: color-mix(in oklab, currentColor 60%, transparent);
+}

--- a/apps/site/src/components/navigation/landing-navbar.tsx
+++ b/apps/site/src/components/navigation/landing-navbar.tsx
@@ -1,0 +1,47 @@
+import { useRef } from 'react';
+import { Link } from '@tanstack/react-router';
+import { i18n } from '@/lib/i18n';
+import { BrandLockup } from './brand-lockup';
+import { GitHubLink } from './github-link';
+import { LandingPrimaryNavigation } from './landing-primary-navigation';
+import { ThemeToggle } from './theme-toggle';
+import { useLandingNavbarMorph } from './use-landing-navbar-morph';
+import './landing-navbar.css';
+
+const heroId = 'landing-hero';
+
+/**
+ * A static three-zone product navigation: brand, primary destinations, and
+ * utilities. Scroll behavior is intentionally kept out until the base visual
+ * state has been reviewed.
+ */
+export function LandingNavbar({ lang }: { lang: string }) {
+  const homePath = lang === i18n.defaultLanguage ? '/' : `/${lang}`;
+  const navRef = useRef<HTMLElement>(null);
+  useLandingNavbarMorph(navRef, heroId);
+
+  return (
+    <nav ref={navRef} className="landing-navbar fixed inset-x-0 top-0 z-50" aria-label="Main navigation">
+      <div className="landing-navbar__panel">
+        <div className="landing-navbar__surface" aria-hidden="true" />
+        <div className="landing-navbar__content mx-auto grid h-full w-full max-w-[1400px] grid-cols-[1fr_auto_1fr] items-center px-4 sm:px-6">
+          <div className="justify-self-start">
+            <Link
+              to={homePath}
+              className="cursor-pointer rounded-lg text-fd-foreground transition-opacity hover:opacity-75"
+            >
+              <BrandLockup />
+            </Link>
+          </div>
+
+          <LandingPrimaryNavigation lang={lang} />
+
+          <div className="flex items-center justify-self-end gap-1">
+            <ThemeToggle lang={lang} />
+            <GitHubLink />
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/apps/site/src/components/navigation/landing-primary-navigation.tsx
+++ b/apps/site/src/components/navigation/landing-primary-navigation.tsx
@@ -1,0 +1,20 @@
+import { Link } from '@tanstack/react-router';
+import { i18n } from '@/lib/i18n';
+import { getStrings } from '@/lib/translations';
+
+/** The central product destinations in the three-zone landing header. */
+export function LandingPrimaryNavigation({ lang }: { lang: string }) {
+  const homePath = lang === i18n.defaultLanguage ? '/' : `/${lang}`;
+  const t = getStrings(lang);
+
+  return (
+    <div className="hidden items-center gap-1 md:flex">
+      <Link to={homePath} className="landing-navbar__link">
+        {t.navHome}
+      </Link>
+      <Link to="/$lang/docs/$" params={{ lang, _splat: '' }} className="landing-navbar__link">
+        {t.navDocs}
+      </Link>
+    </div>
+  );
+}

--- a/apps/site/src/components/navigation/theme-toggle.css
+++ b/apps/site/src/components/navigation/theme-toggle.css
@@ -1,0 +1,24 @@
+.site-theme-toggle {
+  display: inline-flex;
+  width: 2.25rem;
+  height: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  cursor: pointer;
+  padding: 0;
+  color: var(--color-fd-foreground);
+  transition:
+    color 160ms ease-out,
+    background-color 160ms ease-out;
+}
+
+.site-theme-toggle:hover {
+  background: color-mix(in oklab, var(--color-fd-primary) 9%, transparent);
+  color: var(--color-fd-primary);
+}
+
+.site-theme-toggle svg {
+  width: 1rem;
+  height: 1rem;
+}

--- a/apps/site/src/components/navigation/theme-toggle.tsx
+++ b/apps/site/src/components/navigation/theme-toggle.tsx
@@ -1,0 +1,28 @@
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+import { getStrings } from '@/lib/translations';
+import './theme-toggle.css';
+
+/** Compact theme toggle owned by the site navbar rather than Fumadocs. */
+export function ThemeToggle({ lang, className }: { lang: string; className?: string }) {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const t = getStrings(lang);
+
+  useEffect(() => setMounted(true), []);
+
+  const isDark = mounted && resolvedTheme === 'dark';
+
+  return (
+    <button
+      type="button"
+      aria-label={t.toggleTheme}
+      aria-pressed={isDark}
+      className={`site-theme-toggle ${className ?? ''}`}
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+    >
+      {isDark ? <Sun aria-hidden="true" /> : <Moon aria-hidden="true" />}
+    </button>
+  );
+}

--- a/apps/site/src/components/navigation/theme-toggle.tsx
+++ b/apps/site/src/components/navigation/theme-toggle.tsx
@@ -1,5 +1,6 @@
 import { Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
+import { flushSync } from 'react-dom';
 import { useEffect, useState } from 'react';
 import { getStrings } from '@/lib/translations';
 import './theme-toggle.css';
@@ -13,6 +14,17 @@ export function ThemeToggle({ lang, className }: { lang: string; className?: str
   useEffect(() => setMounted(true), []);
 
   const isDark = mounted && resolvedTheme === 'dark';
+  const handleThemeChange = () => {
+    const nextTheme = isDark ? 'light' : 'dark';
+
+    // Keep the smooth cross-document transition used by Fumadocs' original
+    // control, while retaining a normal fallback for browsers without the API.
+    if (document?.startViewTransition) {
+      document.startViewTransition(() => flushSync(() => setTheme(nextTheme)));
+    } else {
+      setTheme(nextTheme);
+    }
+  };
 
   return (
     <button
@@ -20,7 +32,7 @@ export function ThemeToggle({ lang, className }: { lang: string; className?: str
       aria-label={t.toggleTheme}
       aria-pressed={isDark}
       className={`site-theme-toggle ${className ?? ''}`}
-      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      onClick={handleThemeChange}
     >
       {isDark ? <Sun aria-hidden="true" /> : <Moon aria-hidden="true" />}
     </button>

--- a/apps/site/src/components/navigation/use-landing-navbar-morph.ts
+++ b/apps/site/src/components/navigation/use-landing-navbar-morph.ts
@@ -1,0 +1,97 @@
+import { useEffect, type RefObject } from 'react';
+import { gsap, registerGsapPlugins, ScrollTrigger } from '../landing/motion/gsap-client';
+
+const backgroundDuration = 0.48;
+const morphDuration = 0.72;
+const desktopBreakpoint = 1024;
+const compactMaxWidth = 896;
+const mobileHorizontalMargin = 8;
+
+function getCompactWidth() {
+  const viewportWidth = window.innerWidth;
+  if (viewportWidth < desktopBreakpoint) {
+    return viewportWidth - mobileHorizontalMargin * 2;
+  }
+
+  return Math.min(viewportWidth * 0.5, compactMaxWidth);
+}
+
+/**
+ * Keep background attachment and hero shape transitions independent.
+ */
+export function useLandingNavbarMorph(
+  navRef: RefObject<HTMLElement | null>,
+  heroId: string,
+) {
+  useEffect(() => {
+    const nav = navRef.current;
+    const hero = document.getElementById(heroId);
+    const panel = nav?.querySelector<HTMLElement>('.landing-navbar__panel');
+    const surface = nav?.querySelector<HTMLElement>('.landing-navbar__surface');
+    if (!nav || !hero || !panel || !surface) return;
+
+    registerGsapPlugins();
+
+    const ctx = gsap.context(() => {
+      const background = gsap.timeline({
+        paused: true,
+        defaults: {
+          duration: backgroundDuration,
+          ease: 'power2.inOut',
+        },
+      });
+      background.to(surface, { opacity: 1 });
+
+      let morph: gsap.core.Timeline | undefined;
+      const runMorph = (compact: boolean) => {
+        morph?.kill();
+        morph = gsap.timeline({
+          defaults: {
+            duration: morphDuration,
+            ease: 'power2.out',
+          },
+        });
+
+        morph
+        .to(
+          panel,
+            compact
+              ? {
+                  marginTop: '0.75rem',
+                  width: getCompactWidth,
+                  borderRadius: '999px',
+                }
+              : {
+                  marginTop: 0,
+                  width: '100%',
+                  borderRadius: 0,
+          },
+          0,
+        );
+      };
+
+      const detachTrigger = ScrollTrigger.create({
+        start: 1,
+        end: 1,
+        onEnter: () => background.play(),
+        onLeaveBack: () => background.reverse(),
+      });
+
+      const scrollTrigger = ScrollTrigger.create({
+        trigger: hero,
+        start: 'bottom top+=56',
+        onEnter: () => runMorph(true),
+        onLeaveBack: () => runMorph(false),
+      });
+
+      return () => {
+        detachTrigger.kill();
+        scrollTrigger.kill();
+        background.kill();
+        morph?.kill();
+      };
+    }, nav);
+
+    return () => ctx.revert();
+  }, [heroId, navRef]);
+}

--- a/apps/site/src/lib/translations.ts
+++ b/apps/site/src/lib/translations.ts
@@ -12,6 +12,9 @@
 export interface LandingStrings {
   tagline: string;
   readDocs: string;
+  navHome: string;
+  navDocs: string;
+  toggleTheme: string;
   // Hero
   heroBadge: string;
   heroTitleBefore: string;
@@ -94,6 +97,9 @@ export interface LandingStrings {
 const en: LandingStrings = {
   tagline: 'The right engineering Practice for the right AI coding task and moment.',
   readDocs: 'Read the docs',
+  navHome: 'Home',
+  navDocs: 'Docs',
+  toggleTheme: 'Toggle theme',
   // Hero
   heroBadge: 'Engineering knowledge, injected on demand',
   heroTitleBefore: 'The right ',
@@ -193,6 +199,9 @@ const en: LandingStrings = {
 const zh: LandingStrings = {
   tagline: '在正确的任务与关键时刻，为 AI 编码智能体检索正确的工程 Practice。',
   readDocs: '阅读文档',
+  navHome: '首页',
+  navDocs: '文档',
+  toggleTheme: '切换主题',
   // Hero
   heroBadge: '按需注入的工程知识',
   heroTitleBefore: '正确的 ',
@@ -283,6 +292,3 @@ const dictionaries: Record<string, LandingStrings> = { en, zh };
 export function getStrings(locale: string): LandingStrings {
   return dictionaries[locale] ?? en;
 }
-
-
-

--- a/apps/site/src/styles/landing.css
+++ b/apps/site/src/styles/landing.css
@@ -468,4 +468,3 @@ html.dark .logo-wall img.logo-keep-color {
 html.dark .logo-wall li:hover img.logo-keep-color {
   filter: brightness(1.25);
 }
-

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "gsap": "^3.15.0",
         "lucide-react": "^1.31.0",
         "motion": "^12",
+        "next-themes": "^0.4.6",
         "ogl": "1.0.11",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "type": "module",
   "scripts": {
+    "dev:site": "bun run --filter @lorelum/site dev",
     "test": "bun test",
     "test:integration": "bun packages/cli/integration/process.integration.ts",
     "lint": "oxlint .",


### PR DESCRIPTION
## Summary

将 Landing/Docs 的导航统一重构为隔离的站点导航组件：左侧品牌、中间 Home/Docs、右侧 GitHub/Star 与主题切换；加入顶部透明背景、离开顶部后的毛玻璃表面，以及越过 Hero 后的响应式胶囊形变。

同时补充仓库与站点 Agent 规则：明确 PR 模板、最新主分支同步、导航/CSS 组件边界和主题过渡约束，并恢复主题切换的 View Transition 动画。

## Linked issue

Closes #78

## Type of change

- [ ] 🐛 Bug fix (non-breaking)
- [x] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change (fix or feature that would cause existing behavior to change)
- [ ] 📚 Docs only
- [ ] 🔧 Refactor / chore

## How was this tested?

- `bun run --filter @lorelum/site typecheck`
- `bun run --filter @lorelum/site test` — 34 pass, 0 fail
- `bun run --filter @lorelum/site build`
- `bun run lint` — passes with two existing `no-underscore-dangle` warnings in docs route files
- `git diff origin/main...HEAD --check`
- 本地站点 HTTP 200 及 Landing/Docs 路由构建验证

## Checklist

- [x] Linked the issue this closes (`Closes #xxx`)
- [x] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed in the issue / Discussions first (not applicable to this site-only UI change)
- [ ] Added/updated tests for the change (visual-only navigation change; existing site test suite passes)
- [x] Lint, type-check, and tests all pass locally
- [ ] Updated relevant documentation (not applicable)
- [x] No secrets, credentials, or private info in the diff

## AI assistance

- [x] Parts of this PR were generated or assisted by an AI tool
- [x] I have reviewed every line of the AI-generated code and take full responsibility for it

## Notes for reviewers

- Navigation code and CSS live under `apps/site/src/components/navigation/`; no navbar styling was added back to `landing.css`.
- Theme switching uses `document.startViewTransition` with `flushSync`, falling back to `setTheme` when unsupported.
- The GitHub Star count is intentionally static at 14 for now; the live cached API follow-up is tracked in #72.
- The branch was rebased onto the latest `origin/main` before the follow-up commit.
