### PR TITLE
bench(engine): measure compiled LocalStore mutations

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,6 +13,7 @@ This is the index for day-to-day development topics that do not belong in the pr
 - [LocalStore Engine API](#localstore-engine-api)
 - [QueryService Engine API](#queryservice-engine-api)
 - [Point-read performance benchmark](./local-store-point-read-benchmark.md)
+- [Compiled LocalStore mutation benchmark](./local-store-mutation-benchmark.md)
 - [Keyword query quality and performance baseline](./keyword-query-benchmark.md)
 
 ## Proposed plans

--- a/docs/development/local-store-mutation-benchmark.md
+++ b/docs/development/local-store-mutation-benchmark.md
@@ -1,0 +1,42 @@
+# LocalStore mutation benchmark
+
+This is the reproducible lifecycle benchmark for [Issue #79](https://github.com/lorelum/lorelum/issues/79), following the incremental projection change in [Issue #73](https://github.com/lorelum/lorelum/issues/73). It measures one-Practice `add`, `change`, and `remove` mutations against 1,000, 5,000, and 20,000 Practice baselines.
+
+It deliberately uses a small **compiled internal runner**, not the public `lore` CLI. The public CLI has no offline upgrade or uninstall contract, while this benchmark needs deterministic fixture inputs and all three lifecycle operations without Registry or Git access. The runner imports Engine lifecycle internals only; it does not add a CLI command or change CLI JSON, MCP, or Pack contracts.
+
+Build the runner from the repository root, then pass its path explicitly:
+
+```sh
+bun build --compile packages/engine/benchmarks/local-store-mutation-runner.ts \
+  --outfile dist/lorelum-mutation-bench-runner
+LORELUM_MUTATION_BENCH_RUNNER=dist/lorelum-mutation-bench-runner \
+  bun packages/engine/benchmarks/local-store-mutation.bench.ts
+```
+
+The default run uses 20 measured samples and 3 warmups for every scale and operation. For a quicker exploratory run, override only the relevant environment variables:
+
+```sh
+LORELUM_MUTATION_BENCH_RUNNER=dist/lorelum-mutation-bench-runner \
+LORELUM_BENCH_SCALES=1000 \
+LORELUM_BENCH_ITERATIONS=5 \
+LORELUM_BENCH_WARMUP=1 \
+  bun packages/engine/benchmarks/local-store-mutation.bench.ts
+```
+
+The driver constructs one isolated source template Store for each `(scale, operation)` pair, then clones it into a new temporary root per child. Template construction, cloning, and removal are outside the measured interval. Each timed sample starts immediately before launching the compiled runner and ends after that child completes one lifecycle mutation and emits its result. Thus latency includes compiled-process startup and the mutation itself, but not baseline preparation.
+
+Each JSON result includes p50/p95/mean latency, the maximum `maxRSS` reported by Bun across the measured children, and stable internal logical counters. `logicalMetrics` count SQLite rows returned or changed by the lifecycle's bounded reads and writes, plus Effective Practice/source rows materialized for reconciliation. They are implementation counters, not SQLite page reads, WAL bytes, file-size deltas, kernel I/O, or an externally supported Engine/CLI field. The driver rejects a result set whose logical counters vary between otherwise identical samples.
+
+Record the Bun version, operating system, architecture, command, scale, warmup, and iteration count beside any comparison. These deterministic fixtures use one base Pack with one short source per Practice and a separate one-Practice target Pack. They demonstrate lifecycle work after a warm Store baseline; they do not establish cold-disk behavior, many-Pack behavior, Registry/Git installation cost, FTS delta-update cost, or a cross-platform latency/memory guarantee. FTS lifecycle measurement remains in the [keyword-query benchmark](./keyword-query-benchmark.md).
+
+## Recorded local baseline
+
+Measured on 2026-09-09 (Asia/Shanghai), macOS arm64, Bun 1.3.8. Command: `LORELUM_MUTATION_BENCH_RUNNER=dist/lorelum-mutation-bench-runner bun packages/engine/benchmarks/local-store-mutation.bench.ts`. Each cell is p50 / p95 in milliseconds; RSS is the maximum child `maxRSS` across 20 measured samples, converted from the JSON byte value to MiB.
+
+| Baseline Practices | Add | Change | Remove |
+| --- | --- | --- | --- |
+| 1,000 | 38.21 / 53.88 ms, 42.72 MiB | 37.65 / 38.69 ms, 42.34 MiB | 35.37 / 36.61 ms, 41.05 MiB |
+| 5,000 | 38.42 / 39.04 ms, 42.06 MiB | 39.74 / 51.81 ms, 42.45 MiB | 36.92 / 64.15 ms, 41.05 MiB |
+| 20,000 | 41.88 / 53.43 ms, 42.19 MiB | 41.82 / 42.66 ms, 42.28 MiB | 39.84 / 49.03 ms, 41.30 MiB |
+
+The stable logical counters are identical at all three sizes: add materializes no existing Practice/source row and writes one active-Pack, Effective Practice, source, metadata, and revision-log row. Change materializes one Effective Practice and source, then writes two Effective Practice/source rows because the target row is replaced. Remove materializes one Effective Practice and source, then writes one replacement/delete row in each affected projection table. The full JSON output preserves the exact per-table counters; the table summarizes only latency and RSS.

--- a/packages/engine/benchmarks/local-store-mutation-fixtures.ts
+++ b/packages/engine/benchmarks/local-store-mutation-fixtures.ts
@@ -1,0 +1,22 @@
+import { createPackCandidate } from "../src/local-store/model";
+
+export function createTargetCandidate(version: "1.0.0" | "1.0.1") {
+  const body = version === "1.0.0" ? "Initial target guidance.\n" : "Changed target guidance.\n";
+  return createPackCandidate(
+    {
+      pack: { name: "benchmark-target", version },
+      practices: [
+        {
+          id: "benchmark.mutation.target",
+          title: "Mutation target",
+          stage: "implementation",
+          tech_stack: ["typescript"],
+          applies_when: "Measuring one LocalStore mutation",
+          body,
+        },
+      ],
+      decisions: [],
+    },
+    { "benchmark.mutation.target": "practices/target.md" },
+  ).candidate;
+}

--- a/packages/engine/benchmarks/local-store-mutation-runner.ts
+++ b/packages/engine/benchmarks/local-store-mutation-runner.ts
@@ -1,0 +1,74 @@
+import { installOrUpgrade } from "../src/local-store/lifecycle/install";
+import { uninstallPack } from "../src/local-store/lifecycle/uninstall";
+import { createMutationMetrics } from "../src/local-store/storage/sqlite/mutation-metrics";
+import { createTargetCandidate } from "./local-store-mutation-fixtures";
+
+type Operation = "add" | "change" | "remove";
+
+function parseArgs(argv: readonly string[]): {
+  readonly rootPath: string;
+  readonly operation: Operation;
+} {
+  let rootPath: string | undefined;
+  let operation: Operation | undefined;
+  for (let index = 0; index < argv.length; index++) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (flag === "--root" && value !== undefined) {
+      rootPath = value;
+      index += 1;
+    } else if (
+      flag === "--operation" &&
+      (value === "add" || value === "change" || value === "remove")
+    ) {
+      operation = value;
+      index += 1;
+    } else {
+      throw new Error("Usage: --root <path> --operation add|change|remove");
+    }
+  }
+  if (rootPath === undefined || operation === undefined) {
+    throw new Error("Usage: --root <path> --operation add|change|remove");
+  }
+  return Object.freeze({ rootPath, operation });
+}
+
+const { rootPath, operation } = parseArgs(Bun.argv.slice(2));
+const metrics = createMutationMetrics();
+const result =
+  operation === "add"
+    ? await installOrUpgrade(
+        rootPath,
+        createTargetCandidate("1.0.0"),
+        "install",
+        undefined,
+        [],
+        metrics,
+      )
+    : operation === "change"
+      ? await installOrUpgrade(
+          rootPath,
+          createTargetCandidate("1.0.1"),
+          "upgrade",
+          undefined,
+          [],
+          metrics,
+        )
+      : await uninstallPack(rootPath, "benchmark-target", undefined, metrics);
+
+if (
+  (operation === "add" && result.delta.added.length !== 1) ||
+  (operation === "change" && result.delta.changed.length !== 1) ||
+  (operation === "remove" && result.delta.invalidated.length !== 1)
+) {
+  throw new Error("benchmark mutation did not produce its expected Effective Practice delta");
+}
+
+console.log(
+  JSON.stringify({
+    operation,
+    generation: result.generation,
+    effectiveRevision: result.effectiveRevision,
+    metrics: metrics.snapshot(),
+  }),
+);

--- a/packages/engine/benchmarks/local-store-mutation.bench.ts
+++ b/packages/engine/benchmarks/local-store-mutation.bench.ts
@@ -1,0 +1,173 @@
+import { cp, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+import { createLocalStore } from "../src/local-store";
+import { createPackCandidate } from "../src/local-store/model";
+import { summarize, type LatencySummary } from "./latency";
+import { createTargetCandidate } from "./local-store-mutation-fixtures";
+
+type Operation = "add" | "change" | "remove";
+
+const operations: readonly Operation[] = ["add", "change", "remove"];
+const scales = (process.env.LORELUM_BENCH_SCALES ?? "1000,5000,20000").split(",").map(Number);
+const iterations = Number(process.env.LORELUM_BENCH_ITERATIONS ?? 20);
+const warmup = Number(process.env.LORELUM_BENCH_WARMUP ?? 3);
+const runnerPath = process.env.LORELUM_MUTATION_BENCH_RUNNER;
+
+if (scales.some((value) => !Number.isSafeInteger(value) || value < 1)) {
+  throw new Error("LORELUM_BENCH_SCALES must contain positive integers");
+}
+if (
+  !Number.isSafeInteger(iterations) ||
+  iterations < 1 ||
+  !Number.isSafeInteger(warmup) ||
+  warmup < 0
+) {
+  throw new Error("LORELUM_BENCH_ITERATIONS and LORELUM_BENCH_WARMUP are invalid");
+}
+if (runnerPath === undefined || runnerPath.length === 0) {
+  throw new Error("LORELUM_MUTATION_BENCH_RUNNER must name the compiled mutation runner");
+}
+
+function baseCandidate(count: number) {
+  const practices = Array.from({ length: count }, (_, index) => ({
+    id: `benchmark.base.${index}`,
+    title: `Base Practice ${index}`,
+    stage: "implementation" as const,
+    tech_stack: ["typescript"],
+    applies_when: "Preparing an isolated LocalStore benchmark baseline",
+    body: `Base canonical Practice ${index}.\n`,
+  }));
+  return createPackCandidate(
+    { pack: { name: "benchmark-base", version: "1.0.0" }, practices, decisions: [] },
+    Object.fromEntries(practices.map((practice) => [practice.id, `practices/${practice.id}.md`])),
+  ).candidate;
+}
+
+async function removeRoot(rootPath: string): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      // eslint-disable-next-line no-await-in-loop -- retry only after a failed deletion
+      await rm(rootPath, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt === 9) throw error;
+      // eslint-disable-next-line no-await-in-loop -- preserve the bounded retry interval
+      await Bun.sleep(50);
+    }
+  }
+}
+
+async function prepareTemplate(
+  scale: number,
+  operation: Operation,
+  parent: string,
+): Promise<string> {
+  const rootPath = join(parent, `${scale}-${operation}`);
+  const store = createLocalStore();
+  await store.install({ rootPath }, baseCandidate(scale));
+  if (operation !== "add") {
+    await store.install({ rootPath }, createTargetCandidate("1.0.0"));
+  }
+  return rootPath;
+}
+
+interface ChildSample {
+  readonly elapsedMs: number;
+  readonly maxRssBytes: number;
+  readonly metrics: unknown;
+}
+
+async function runChild(template: string, operation: Operation): Promise<ChildSample> {
+  const sampleParent = await mkdtemp(join(tmpdir(), "lorelum-mutation-sample-"));
+  const rootPath = join(sampleParent, "store");
+  try {
+    await cp(template, rootPath, { recursive: true });
+    const executable = isAbsolute(runnerPath!) ? runnerPath! : resolve(runnerPath!);
+    // Store cloning is intentionally outside the sample. This interval is the
+    // compiled runner startup plus one lifecycle mutation and JSON result.
+    const startedAt = performance.now();
+    const child = Bun.spawn([executable, "--root", rootPath, "--operation", operation], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    if (exitCode !== 0) throw new Error(`compiled ${operation} runner failed: ${stderr || stdout}`);
+    const record: unknown = JSON.parse(stdout);
+    if (
+      typeof record !== "object" ||
+      record === null ||
+      !("metrics" in record) ||
+      !("operation" in record) ||
+      record.operation !== operation
+    ) {
+      throw new Error("compiled mutation runner did not emit a metrics record");
+    }
+    const usage = child.resourceUsage();
+    if (usage === undefined)
+      throw new Error("compiled mutation runner did not expose resource usage");
+    return Object.freeze({
+      elapsedMs: performance.now() - startedAt,
+      maxRssBytes: usage.maxRSS,
+      metrics: record.metrics,
+    });
+  } finally {
+    await removeRoot(sampleParent);
+  }
+}
+
+function report(
+  scale: number,
+  operation: Operation,
+  latency: LatencySummary,
+  samples: readonly ChildSample[],
+): void {
+  const first = samples[0];
+  if (first === undefined) throw new Error("benchmark operation has no samples");
+  const metricRecord = JSON.stringify(first.metrics);
+  if (samples.some((sample) => JSON.stringify(sample.metrics) !== metricRecord)) {
+    throw new Error(`logical metrics changed across ${scale}/${operation} samples`);
+  }
+  console.log(
+    JSON.stringify({
+      scale,
+      operation,
+      runner: "compiled-internal",
+      ...latency,
+      maxRssBytes: Math.max(...samples.map((sample) => sample.maxRssBytes)),
+      logicalMetrics: first.metrics,
+    }),
+  );
+}
+
+for (const scale of [...new Set(scales)].sort((left, right) => left - right)) {
+  // eslint-disable-next-line no-await-in-loop -- templates are intentionally isolated by scale
+  const templateParent = await mkdtemp(join(tmpdir(), "lorelum-mutation-template-"));
+  try {
+    for (const operation of operations) {
+      // eslint-disable-next-line no-await-in-loop -- operations must not compete for disk/cache resources
+      const template = await prepareTemplate(scale, operation, templateParent);
+      for (let index = 0; index < warmup; index++) {
+        // eslint-disable-next-line no-await-in-loop -- warmups use isolated serial child processes
+        await runChild(template, operation);
+      }
+      const samples: ChildSample[] = [];
+      for (let index = 0; index < iterations; index++) {
+        // Each sample has an independently cloned Store before the timer starts.
+        // eslint-disable-next-line no-await-in-loop -- concurrent samples would invalidate the measurement
+        const sample = await runChild(template, operation);
+        samples.push(sample);
+      }
+      const latency = summarize(samples.map((sample) => sample.elapsedMs));
+      report(scale, operation, latency, samples);
+    }
+  } finally {
+    // eslint-disable-next-line no-await-in-loop -- clean one scale before preparing the next
+    await removeRoot(templateParent);
+  }
+}

--- a/packages/engine/src/local-store/lifecycle/install.ts
+++ b/packages/engine/src/local-store/lifecycle/install.ts
@@ -26,6 +26,7 @@ import { applyIncrementalDerivedState } from "../storage/sqlite/state-writer";
 import { UpgradeRequiredError, PackNotInstalledError } from "./errors";
 import { nextStoreCounter } from "./counters";
 import { activeSources, deliverRevisionNotifications, withStoreMutation } from "./mutation";
+import type { MutationMetricsObserver } from "../storage/sqlite/mutation-metrics";
 import type { EffectiveRevisionHook, InstallResult } from "./types";
 
 function compareCodeUnits(left: string, right: string): number {
@@ -82,6 +83,7 @@ export async function installOrUpgrade(
   mode: "install" | "upgrade",
   hook: EffectiveRevisionHook | undefined,
   diagnostics: readonly ValidationIssue[] = [],
+  metrics?: MutationMetricsObserver,
 ): Promise<InstallResult> {
   const committed = await withStoreMutation(rootPath, async ({ database, recovery }) => {
     // `recovery.manifest` is the converged, tuple-validated manifest (fresh
@@ -138,16 +140,32 @@ export async function installOrUpgrade(
       throw new PackNotInstalledError(candidate.pack.name);
     }
 
+    const previousPackPracticeIds =
+      mode === "upgrade" ? readPracticeIdsForPack(database, candidate.pack.name) : [];
     const affectedPracticeIds = [
       ...new Set([
         ...candidate.sources.map((source) => source.practiceId),
-        ...(mode === "upgrade" ? readPracticeIdsForPack(database, candidate.pack.name) : []),
+        ...previousPackPracticeIds,
       ]),
     ].sort(compareCodeUnits);
     const effectivePractices =
       recovery.metadata === undefined
         ? []
         : materializeEffectivePracticesByIds(database, recovery.metadata, affectedPracticeIds);
+    if (metrics !== undefined) {
+      metrics.recordRead("effective_practices", effectivePractices.length);
+      const sourceRows = effectivePractices.reduce(
+        (count, practice) => count + practice.sources.length,
+        0,
+      );
+      metrics.recordRead("practice_sources", sourceRows);
+      metrics.recordMaterialization(effectivePractices.length, sourceRows);
+      if (mode === "upgrade") {
+        // The ID lookup is a separate SELECT from the bounded joined
+        // materialization above and is part of the mutation's logical reads.
+        metrics.recordRead("practice_sources", previousPackPracticeIds.length);
+      }
+    }
 
     const entry = entryForCandidate(candidate, artifactDigest);
     let reconciled: ReturnType<typeof reconcileEffectivePractices>;
@@ -198,17 +216,21 @@ export async function installOrUpgrade(
         await rm(stagingPath, { recursive: true, force: true });
       }
       await writeManifest(rootPath, targetManifest);
-      applyIncrementalDerivedState(database, {
-        generation: targetManifest.generation,
-        effectiveRevision: targetManifest.effectiveRevision,
-        activePacks: targetManifest.packs,
-        effectivePractices: reconciled.effectivePractices,
-        affectedPracticeIds,
-        activePackMutation: { kind: "upsert", entry },
-        revisionNotification:
-          advances && hook !== undefined ? { delta: reconciled.delta } : undefined,
-        revisionLogDelta: advances ? reconciled.delta : undefined,
-      });
+      applyIncrementalDerivedState(
+        database,
+        {
+          generation: targetManifest.generation,
+          effectiveRevision: targetManifest.effectiveRevision,
+          activePacks: targetManifest.packs,
+          effectivePractices: reconciled.effectivePractices,
+          affectedPracticeIds,
+          activePackMutation: { kind: "upsert", entry },
+          revisionNotification:
+            advances && hook !== undefined ? { delta: reconciled.delta } : undefined,
+          revisionLogDelta: advances ? reconciled.delta : undefined,
+        },
+        metrics,
+      );
     } catch (error) {
       await rm(stagingPath, { recursive: true, force: true });
       throw error;
@@ -242,7 +264,7 @@ export async function installOrUpgrade(
       artifactDigest,
       idempotent: false,
     });
-  });
+  }, { metrics });
   const notificationPending = await deliverRevisionNotifications(
     rootPath,
     hook,

--- a/packages/engine/src/local-store/lifecycle/mutation-metrics.test.ts
+++ b/packages/engine/src/local-store/lifecycle/mutation-metrics.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { UnvalidatedPackInput } from "@lorelum/format";
+
+import { createPackCandidate, type PackCandidate } from "../model";
+
+import { installOrUpgrade } from "./install";
+import { createMutationMetrics } from "../storage/sqlite/mutation-metrics";
+import { uninstallPack } from "./uninstall";
+
+function candidate(
+  name: string,
+  version: string,
+  practices: Record<string, string>,
+): PackCandidate {
+  const input: UnvalidatedPackInput = {
+    pack: { name, version },
+    practices: Object.entries(practices).map(([id, body]) => ({
+      id,
+      title: id,
+      stage: "api",
+      tech_stack: ["typescript"],
+      applies_when: "benchmarking mutation metrics",
+      severity: "warn",
+      body,
+    })),
+    decisions: [],
+  };
+  const sourcePaths = Object.fromEntries(
+    Object.keys(practices).map((id) => [id, `practices/${id}.md`]),
+  );
+  return createPackCandidate(input, sourcePaths).candidate;
+}
+
+async function withRoot(run: (rootPath: string) => Promise<void>): Promise<void> {
+  const rootPath = await mkdtemp(join(tmpdir(), "lorelum-mutation-metrics-"));
+  try {
+    await run(rootPath);
+  } finally {
+    await rm(rootPath, { recursive: true, force: true });
+  }
+}
+
+test("normal mutation metrics stay bounded to the affected Practice rows", async () => {
+  await withRoot(async (rootPath) => {
+    const base = candidate("base", "1.0.0", {
+      "base.api": "Keep the baseline row.",
+      "base.auth": "Keep the unrelated row.",
+    });
+    const targetV1 = candidate("target", "1.0.0", { "target.api": "Use the first rule." });
+    const targetV2 = candidate("target", "2.0.0", { "target.api": "Use the changed rule." });
+
+    await installOrUpgrade(rootPath, base, "install", undefined);
+
+    const addMetrics = createMutationMetrics();
+    const added = await installOrUpgrade(rootPath, targetV1, "install", undefined, [], addMetrics);
+    const addedSnapshot = addMetrics.snapshot();
+    expect(added).not.toHaveProperty("metrics");
+    expect(addedSnapshot.materializedEffectivePractices).toBe(0);
+    expect(addedSnapshot.materializedSourceRows).toBe(0);
+    expect(addedSnapshot.writes.effective_practices).toBe(1);
+    expect(addedSnapshot.writes.practice_sources).toBe(1);
+    expect(addedSnapshot.writes.active_packs).toBe(1);
+    expect(addedSnapshot.writes.local_store_metadata).toBe(1);
+    expect(addedSnapshot.writes.effective_revision_log).toBe(1);
+
+    const upgradeMetrics = createMutationMetrics();
+    const upgraded = await installOrUpgrade(
+      rootPath,
+      targetV2,
+      "upgrade",
+      undefined,
+      [],
+      upgradeMetrics,
+    );
+    const upgradedSnapshot = upgradeMetrics.snapshot();
+    expect(upgraded).not.toHaveProperty("metrics");
+    expect(upgradedSnapshot.materializedEffectivePractices).toBe(1);
+    expect(upgradedSnapshot.materializedSourceRows).toBe(1);
+    expect(upgradedSnapshot.writes.effective_practices).toBe(2);
+    expect(upgradedSnapshot.writes.practice_sources).toBe(2);
+    expect(upgradedSnapshot.writes.active_packs).toBe(1);
+    expect(upgradedSnapshot.writes.local_store_metadata).toBe(1);
+    expect(upgradedSnapshot.writes.effective_revision_log).toBe(1);
+
+    const uninstallMetrics = createMutationMetrics();
+    const uninstalled = await uninstallPack(rootPath, "target", undefined, uninstallMetrics);
+    const uninstalledSnapshot = uninstallMetrics.snapshot();
+    expect(uninstalled).not.toHaveProperty("metrics");
+    expect(uninstalledSnapshot.materializedEffectivePractices).toBe(1);
+    expect(uninstalledSnapshot.materializedSourceRows).toBe(1);
+    expect(uninstalledSnapshot.writes.effective_practices).toBe(1);
+    expect(uninstalledSnapshot.writes.practice_sources).toBe(1);
+    expect(uninstalledSnapshot.writes.active_packs).toBe(1);
+    expect(uninstalledSnapshot.writes.local_store_metadata).toBe(1);
+    expect(uninstalledSnapshot.writes.effective_revision_log).toBe(1);
+  });
+});

--- a/packages/engine/src/local-store/lifecycle/mutation.ts
+++ b/packages/engine/src/local-store/lifecycle/mutation.ts
@@ -14,6 +14,7 @@ import {
   readPendingRevisionNotifications,
 } from "../storage/sqlite/revision-outbox";
 import type { EffectiveRevisionHook } from "./types";
+import type { MutationMetricsObserver } from "../storage/sqlite/mutation-metrics";
 
 export interface MutationContext {
   database: Database;
@@ -25,6 +26,8 @@ export interface MutationLockOptions {
   waitMs?: number;
   /** Test seam for proving the lock is released when database open fails. */
   openDatabase?: ((rootPath: string) => Promise<Database>) | undefined;
+  /** Internal benchmark/test observer; never serialized or returned. */
+  metrics?: MutationMetricsObserver | undefined;
 }
 
 /**
@@ -75,14 +78,16 @@ export async function withStoreMutation<T>(
       throw error;
     }
     const recovery = await runStoreRecovery(rootPath, database);
-    if (
-      recovery.metadata !== undefined &&
-      !installedPackEntriesEqual(readActivePackEntries(database), recovery.manifest.packs)
-    ) {
-      throw new StoreRecoveryRequiredError(
-        "SQLite Active Pack rows differ from the active manifest",
-      );
+    if (recovery.metadata !== undefined) {
+      const activePacks = readActivePackEntries(database);
+      options.metrics?.recordRead("active_packs", activePacks.length);
+      if (!installedPackEntriesEqual(activePacks, recovery.manifest.packs)) {
+        throw new StoreRecoveryRequiredError(
+          "SQLite Active Pack rows differ from the active manifest",
+        );
+      }
     }
+    options.metrics?.recordRead("local_store_metadata", recovery.metadata === undefined ? 0 : 1);
     return await run({ database, recovery });
   } finally {
     database?.close();

--- a/packages/engine/src/local-store/lifecycle/uninstall.ts
+++ b/packages/engine/src/local-store/lifecycle/uninstall.ts
@@ -17,6 +17,7 @@ import { applyIncrementalDerivedState } from "../storage/sqlite/state-writer";
 import { PackNotInstalledError } from "./errors";
 import { nextStoreCounter } from "./counters";
 import { activeSources, deliverRevisionNotifications, withStoreMutation } from "./mutation";
+import type { MutationMetricsObserver } from "../storage/sqlite/mutation-metrics";
 import type { EffectiveRevisionHook, UninstallResult } from "./types";
 
 function withoutPack(
@@ -42,6 +43,7 @@ export async function uninstallPack(
   rootPath: string,
   packName: string,
   hook: EffectiveRevisionHook | undefined,
+  metrics?: MutationMetricsObserver,
 ): Promise<UninstallResult> {
   const committed = await withStoreMutation(rootPath, async ({ database, recovery }) => {
     const active = recovery.manifest;
@@ -53,6 +55,14 @@ export async function uninstallPack(
       recovery.metadata === undefined
         ? []
         : materializeEffectivePracticesByIds(database, recovery.metadata, affectedPracticeIds);
+    metrics?.recordRead("practice_sources", affectedPracticeIds.length);
+    metrics?.recordRead("effective_practices", effectivePractices.length);
+    const sourceRows = effectivePractices.reduce(
+      (count, practice) => count + practice.sources.length,
+      0,
+    );
+    metrics?.recordRead("practice_sources", sourceRows);
+    metrics?.recordMaterialization(effectivePractices.length, sourceRows);
     const reconciled = removePackSources(activeSources(effectivePractices), packName);
 
     const advances = reconciled.advancesEffectiveRevision;
@@ -67,17 +77,21 @@ export async function uninstallPack(
     const journal = createOperationJournalRecord("uninstall", active, targetManifest);
     await writeOperationJournal(rootPath, journal);
     await writeManifest(rootPath, targetManifest);
-    applyIncrementalDerivedState(database, {
-      generation: targetManifest.generation,
-      effectiveRevision: targetManifest.effectiveRevision,
-      activePacks: targetManifest.packs,
-      effectivePractices: reconciled.effectivePractices,
-      affectedPracticeIds,
-      activePackMutation: { kind: "remove", packName },
-      revisionNotification:
-        advances && hook !== undefined ? { delta: reconciled.delta } : undefined,
-      revisionLogDelta: advances ? reconciled.delta : undefined,
-    });
+    applyIncrementalDerivedState(
+      database,
+      {
+        generation: targetManifest.generation,
+        effectiveRevision: targetManifest.effectiveRevision,
+        activePacks: targetManifest.packs,
+        effectivePractices: reconciled.effectivePractices,
+        affectedPracticeIds,
+        activePackMutation: { kind: "remove", packName },
+        revisionNotification:
+          advances && hook !== undefined ? { delta: reconciled.delta } : undefined,
+        revisionLogDelta: advances ? reconciled.delta : undefined,
+      },
+      metrics,
+    );
 
     await clearOperationJournal(rootPath, journal.operationId);
 
@@ -99,7 +113,7 @@ export async function uninstallPack(
       diagnostics: Object.freeze([]),
       cleanupPending,
     });
-  });
+  }, { metrics });
   const notificationPending = await deliverRevisionNotifications(
     rootPath,
     hook,

--- a/packages/engine/src/local-store/storage/sqlite/mutation-metrics.ts
+++ b/packages/engine/src/local-store/storage/sqlite/mutation-metrics.ts
@@ -1,0 +1,86 @@
+/**
+ * Internal-only logical work counters for the mutation benchmark.
+ *
+ * This deliberately is not part of the LocalStore facade or a CLI result. The
+ * observer is threaded through lifecycle internals so tests and the compiled
+ * benchmark can measure bounded projection work without exposing SQLite
+ * handles or implementation counters to consumers.
+ */
+export type MutationMetricTable =
+  | "local_store_metadata"
+  | "active_packs"
+  | "practice_sources"
+  | "effective_practices"
+  | "effective_revision_outbox"
+  | "effective_revision_log";
+
+export interface MutationMetricsObserver {
+  recordRead(table: MutationMetricTable, rows: number): void;
+  recordWrite(table: MutationMetricTable, rows: number): void;
+  recordMaterialization(effectivePractices: number, sourceRows: number): void;
+}
+
+export interface MutationMetrics extends MutationMetricsObserver {
+  snapshot(): MutationMetricsSnapshot;
+}
+
+export interface MutationMetricsSnapshot {
+  readonly reads: Readonly<Record<MutationMetricTable, number>>;
+  readonly writes: Readonly<Record<MutationMetricTable, number>>;
+  readonly materializedEffectivePractices: number;
+  readonly materializedSourceRows: number;
+}
+
+const TABLES: readonly MutationMetricTable[] = [
+  "local_store_metadata",
+  "active_packs",
+  "practice_sources",
+  "effective_practices",
+  "effective_revision_outbox",
+  "effective_revision_log",
+];
+
+function emptyCounts(): Record<MutationMetricTable, number> {
+  return Object.fromEntries(TABLES.map((table) => [table, 0])) as Record<
+    MutationMetricTable,
+    number
+  >;
+}
+
+/** Create an internal logical-work collector for one lifecycle operation. */
+export function createMutationMetrics(): MutationMetrics {
+  const reads = emptyCounts();
+  const writes = emptyCounts();
+  let materializedEffectivePractices = 0;
+  let materializedSourceRows = 0;
+  const snapshot = (): MutationMetricsSnapshot =>
+    Object.freeze({
+      reads: Object.freeze({ ...reads }),
+      writes: Object.freeze({ ...writes }),
+      materializedEffectivePractices,
+      materializedSourceRows,
+    });
+  return {
+    recordRead(table, rows) {
+      if (!Number.isSafeInteger(rows) || rows < 0) throw new RangeError("invalid read count");
+      reads[table] += rows;
+    },
+    recordWrite(table, rows) {
+      if (!Number.isSafeInteger(rows) || rows < 0) throw new RangeError("invalid write count");
+      writes[table] += rows;
+    },
+    recordMaterialization(effectivePractices, sourceRows) {
+      if (
+        !Number.isSafeInteger(effectivePractices) ||
+        effectivePractices < 0 ||
+        !Number.isSafeInteger(sourceRows) ||
+        sourceRows < 0
+      ) {
+        throw new RangeError("invalid materialization count");
+      }
+      materializedEffectivePractices += effectivePractices;
+      materializedSourceRows += sourceRows;
+    },
+    snapshot,
+  };
+}

--- a/packages/engine/src/local-store/storage/sqlite/state-writer.ts
+++ b/packages/engine/src/local-store/storage/sqlite/state-writer.ts
@@ -8,6 +8,7 @@ import {
 } from "../../model";
 import type { InstalledPackManifestEntry } from "../manifest/manifest-store";
 import { SqliteStateError } from "../errors";
+import type { MutationMetricsObserver } from "./mutation-metrics";
 import { LOCAL_STORE_SCHEMA_VERSION } from "./migrations";
 import { serializeRevisionDelta } from "./revision-delta";
 import { appendEffectiveRevisionLog } from "./revision-log";
@@ -77,6 +78,7 @@ function insertEffectivePracticeRows(
   database: Database,
   practices: readonly EffectivePractice[],
   revisionFor: (practice: EffectivePractice) => number,
+  metrics?: MutationMetricsObserver,
 ): void {
   const insertEffective = database.query(
     "INSERT INTO effective_practices (practice_id, content_digest, canonical_content, title, stage, tech_stack_json, applies_when, severity, effective_revision) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -86,7 +88,7 @@ function insertEffectivePracticeRows(
   );
   for (const effective of practices) {
     const practice = effective.practice;
-    insertEffective.run(
+    const effectiveResult = insertEffective.run(
       effective.practiceId,
       effective.contentDigest,
       effective.canonicalContent,
@@ -97,18 +99,29 @@ function insertEffectivePracticeRows(
       practice.severity ?? "warn",
       revisionFor(effective),
     );
+    metrics?.recordWrite("effective_practices", effectiveResult.changes);
     for (const source of effective.sources) {
-      insertSource.run(source.packName, source.practiceId, source.contentDigest, source.sourcePath);
+      const sourceResult = insertSource.run(
+        source.packName,
+        source.practiceId,
+        source.contentDigest,
+        source.sourcePath,
+      );
+      metrics?.recordWrite("practice_sources", sourceResult.changes);
     }
   }
 }
 
-function writeRevisionRecords(database: Database, state: DerivedStoreState): void {
+function writeRevisionRecords(
+  database: Database,
+  state: DerivedStoreState,
+  metrics?: MutationMetricsObserver,
+): void {
   if (state.revisionNotification?.supersedesPending === true) {
     database.exec("DELETE FROM effective_revision_outbox");
   }
   if (state.revisionNotification !== undefined) {
-    database
+    const outboxResult = database
       .query(
         "INSERT OR REPLACE INTO effective_revision_outbox (revision, delta_json, created_at) VALUES (?, ?, ?)",
       )
@@ -117,9 +130,11 @@ function writeRevisionRecords(database: Database, state: DerivedStoreState): voi
         serializeRevisionDelta(state.revisionNotification.delta),
         new Date().toISOString(),
       );
+    metrics?.recordWrite("effective_revision_outbox", outboxResult.changes);
   }
   if (state.revisionLogDelta !== undefined) {
     appendEffectiveRevisionLog(database, state.effectiveRevision, state.revisionLogDelta);
+    metrics?.recordWrite("effective_revision_log", 1);
   }
 }
 
@@ -174,13 +189,18 @@ function uniqueSortedIds(ids: readonly string[]): readonly string[] {
   return result;
 }
 
-function rowRevisions(database: Database, ids: readonly string[]): ReadonlyMap<string, number> {
+function rowRevisions(
+  database: Database,
+  ids: readonly string[],
+  metrics?: MutationMetricsObserver,
+): ReadonlyMap<string, number> {
   if (ids.length === 0) return new Map();
   const rows = database
     .query(
       `SELECT practice_id, effective_revision FROM effective_practices WHERE practice_id IN (${ids.map(() => "?").join(", ")})`,
     )
     .all(...ids) as readonly Record<string, unknown>[];
+  metrics?.recordRead("effective_practices", rows.length);
   const revisions = new Map<string, number>();
   for (const row of rows) {
     if (
@@ -209,6 +229,7 @@ function changedPracticeIds(delta: RevisionDelta | undefined): ReadonlySet<strin
 export function applyIncrementalDerivedState(
   database: Database,
   state: IncrementalDerivedStoreState,
+  metrics?: MutationMetricsObserver,
 ): void {
   assertStateIsCoherent(state);
   const affectedIds = uniqueSortedIds(state.affectedPracticeIds);
@@ -220,10 +241,10 @@ export function applyIncrementalDerivedState(
   }
   try {
     database.transaction(() => {
-      const priorRevisions = rowRevisions(database, affectedIds);
+      const priorRevisions = rowRevisions(database, affectedIds, metrics);
       if (state.activePackMutation.kind === "upsert") {
         const entry = state.activePackMutation.entry;
-        database
+        const packResult = database
           .query(
             "INSERT INTO active_packs (pack_name, pack_version, artifact_digest, storage_key, installed_at) VALUES (?, ?, ?, ?, ?) ON CONFLICT(pack_name) DO UPDATE SET pack_version = excluded.pack_version, artifact_digest = excluded.artifact_digest, storage_key = excluded.storage_key, installed_at = excluded.installed_at",
           )
@@ -234,46 +255,56 @@ export function applyIncrementalDerivedState(
             entry.storageKey,
             entry.installedAt,
           );
+        metrics?.recordWrite("active_packs", packResult.changes);
       }
 
       if (affectedIds.length > 0) {
-        database
+        const sourceDelete = database
           .query(
             `DELETE FROM practice_sources WHERE practice_id IN (${affectedIds.map(() => "?").join(", ")})`,
           )
           .run(...affectedIds);
-        database
+        metrics?.recordWrite("practice_sources", sourceDelete.changes);
+        const effectiveDelete = database
           .query(
             `DELETE FROM effective_practices WHERE practice_id IN (${affectedIds.map(() => "?").join(", ")})`,
           )
           .run(...affectedIds);
+        metrics?.recordWrite("effective_practices", effectiveDelete.changes);
       }
 
       if (state.activePackMutation.kind === "remove") {
-        database
+        const packDelete = database
           .query("DELETE FROM active_packs WHERE pack_name = ?")
           .run(state.activePackMutation.packName);
+        metrics?.recordWrite("active_packs", packDelete.changes);
       }
 
       const changedIds = changedPracticeIds(state.revisionLogDelta);
-      insertEffectivePracticeRows(database, state.effectivePractices, (effective) => {
-        const priorRevision = priorRevisions.get(effective.practiceId);
-        const rowRevision = changedIds.has(effective.practiceId)
-          ? state.effectiveRevision
-          : priorRevision;
-        if (rowRevision === undefined) {
-          throw new SqliteStateError("unchanged Effective Practice has no prior revision");
-        }
-        return rowRevision;
-      });
+      insertEffectivePracticeRows(
+        database,
+        state.effectivePractices,
+        (effective) => {
+          const priorRevision = priorRevisions.get(effective.practiceId);
+          const rowRevision = changedIds.has(effective.practiceId)
+            ? state.effectiveRevision
+            : priorRevision;
+          if (rowRevision === undefined) {
+            throw new SqliteStateError("unchanged Effective Practice has no prior revision");
+          }
+          return rowRevision;
+        },
+        metrics,
+      );
 
-      database
+      const metadataResult = database
         .query(
           "INSERT INTO local_store_metadata (singleton, schema_version, installed_packs_generation, effective_revision) VALUES (1, ?, ?, ?) ON CONFLICT(singleton) DO UPDATE SET schema_version = excluded.schema_version, installed_packs_generation = excluded.installed_packs_generation, effective_revision = excluded.effective_revision",
         )
         .run(LOCAL_STORE_SCHEMA_VERSION, state.generation, state.effectiveRevision);
+      metrics?.recordWrite("local_store_metadata", metadataResult.changes);
 
-      writeRevisionRecords(database, state);
+      writeRevisionRecords(database, state, metrics);
     })();
   } catch (error) {
     if (error instanceof SqliteStateError) throw error;


### PR DESCRIPTION
## Summary

Adds a reproducible compiled-process benchmark for one-Practice LocalStore add, change, and remove mutations at 1k, 5k, and 20k baselines. It reports p50/p95, maximum child maxRSS, and internal logical SQLite row/materialization counters, with a documented local baseline.

The benchmark uses an intentionally internal compiled Engine runner because public `lore` install depends on Registry/Git and has no offline upgrade/uninstall command. It does not add a CLI command or change CLI JSON, MCP, Pack, or LocalStore public contracts.

## Linked issue

Closes #79

## Type of change

- [x] 🔧 Refactor / chore

## How was this tested?

- `bun test` (439 pass)
- `bun run typecheck`
- `bun run lint` (passes; two pre-existing site warnings only)
- Compiled runner: `bun build --compile packages/engine/benchmarks/local-store-mutation-runner.ts --outfile dist/lorelum-mutation-bench-runner`
- Full macOS arm64 / Bun 1.3.8 matrix: 20 measured samples plus 3 warmups for each add/change/remove at 1k, 5k, and 20k
- Re-ran a compiled 1k smoke after the final subtractive refactor

## Checklist

- [x] Linked the issue this closes (`Closes #xxx`)
- [x] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed in the issue / Discussions first
- [x] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

## AI assistance and review

- [x] This PR used AI assistance (implementation, measurement, and documentation)
- [x] If AI-assisted: an AI code review covered the changed behavior and edge cases; material findings are resolved or documented below

The independent AI CR verified template isolation, timing boundaries, post-exit maxRSS sampling, logical-counter scope, and public-contract isolation. Its non-blocking findings were addressed by removing a redundant mutation-context metrics layer, sharing the target fixture, checking runner operation identity, and moving metrics types into SQLite internals. Counters intentionally describe the bounded deterministic fixture path, not physical SQLite page/WAL/kernel I/O.

## Notes for reviewers

The driver clones an already prepared Store before each sample; cloning and cleanup are outside the timed interval. The measured interval is compiled runner startup through completion of one lifecycle mutation. FTS delta lifecycle remains deliberately separate in the keyword-query benchmark.