### PR TITLE
feat(ui): establish shared Lorelum web design infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   verify:
-    name: typecheck · lint · test
+    name: quality · design · site
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -33,11 +33,17 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      - name: Validate design contract
+        run: bun run design:lint
+
       - name: Lint
         run: bun run lint
 
       - name: Test
         run: bun test
+
+      - name: Build site
+        run: bun run build:site
 
       # oxfmt is still alpha (ADR 0002). Run as a non-blocking signal for now;
       # promote to blocking once it stabilizes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,13 @@ The source tree is a Bun workspace monorepo (`packages/cli`, `packages/engine`, 
 - **Practice / pack format** — the public schema that packs and users depend on. Changes are high-impact; see CONTRIBUTING.md.
 - **Retrieval engine** — performance-sensitive; benchmark before changing.
 
+### UI and design system
+
+- Read [`DESIGN.md`](./DESIGN.md) before visual or component work.
+- Keep its front matter compatible with Google DESIGN.md and run `bun run design:lint` after edits.
+- Reusable Web components and production tokens belong to `packages/ui`; page composition, routes, copy, data, and page-specific motion stay with the consuming app.
+- Follow `packages/ui/AGENTS.md` for shadcn changes and `apps/site/AGENTS.md` for site integration and visual verification.
+
 ## Commands
 
 - **Runtime:** Bun ≥ 1.1 (TypeScript support is built in — no separate `tsc`/Node install needed)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,217 @@
+---
+version: alpha
+name: Lorelum
+description: A precise, luminous design system for engineering knowledge infrastructure.
+colors:
+  primary: "#35B88F"
+  brand-deep: "#137C65"
+  brand-light: "#65D5A5"
+  light-background: "#F8F9FA"
+  light-foreground: "#202326"
+  light-surface: "#FFFFFF"
+  light-surface-raised: "#F0F1F2"
+  light-surface-sunken: "#E9ECEF"
+  light-muted-foreground: "#656C73"
+  light-border: "#DFE2E5"
+  light-border-strong: "#B4BCC4"
+  light-primary: "#168263"
+  light-primary-foreground: "#FFFFFF"
+  light-primary-hover: "#127457"
+  light-primary-pressed: "#0F644C"
+  light-accent: "#EEF0F2"
+  light-accent-foreground: "#176E55"
+  light-destructive: "#B43939"
+  light-destructive-foreground: "#FFFFFF"
+  dark-background: "#141618"
+  dark-foreground: "#F0F2F4"
+  dark-surface: "#1C1F22"
+  dark-surface-raised: "#262A2E"
+  dark-surface-sunken: "#101214"
+  dark-muted-foreground: "#A4ACB4"
+  dark-border: "#363C42"
+  dark-border-strong: "#59636D"
+  dark-primary-foreground: "#10251E"
+  dark-primary-hover: "#48C39C"
+  dark-primary-pressed: "#2FAA83"
+  dark-accent: "#2A2E33"
+  dark-accent-foreground: "#F0F2F4"
+  dark-destructive: "#F29E9E"
+  dark-destructive-foreground: "#351619"
+  success-light: "#246C46"
+  success-dark: "#89D3A5"
+  warning-light: "#845615"
+  warning-dark: "#E6BC74"
+  info-light: "#355F9B"
+  info-dark: "#A6C5F2"
+typography:
+  display:
+    fontFamily: Bricolage Grotesque
+    fontSize: 3.5rem
+    fontWeight: 600
+    lineHeight: 3.75rem
+    letterSpacing: 0em
+  headline:
+    fontFamily: Bricolage Grotesque
+    fontSize: 2.5rem
+    fontWeight: 600
+    lineHeight: 2.75rem
+    letterSpacing: 0em
+  title:
+    fontFamily: Bricolage Grotesque
+    fontSize: 1.5rem
+    fontWeight: 600
+    lineHeight: 2rem
+    letterSpacing: 0em
+  title-sm:
+    fontFamily: Bricolage Grotesque
+    fontSize: 1.125rem
+    fontWeight: 600
+    lineHeight: 1.5rem
+    letterSpacing: 0em
+  body:
+    fontFamily: Manrope
+    fontSize: 1rem
+    fontWeight: 400
+    lineHeight: 1.625rem
+    letterSpacing: 0em
+  body-sm:
+    fontFamily: Manrope
+    fontSize: 0.875rem
+    fontWeight: 400
+    lineHeight: 1.25rem
+    letterSpacing: 0em
+  label:
+    fontFamily: Manrope
+    fontSize: 0.875rem
+    fontWeight: 500
+    lineHeight: 1.25rem
+    letterSpacing: 0em
+  caption:
+    fontFamily: Manrope
+    fontSize: 0.75rem
+    fontWeight: 500
+    lineHeight: 1rem
+    letterSpacing: 0em
+  code:
+    fontFamily: JetBrains Mono
+    fontSize: 0.8125rem
+    fontWeight: 400
+    lineHeight: 1.25rem
+    letterSpacing: 0em
+rounded:
+  detail: 0.375rem
+  control: 0.75rem
+  panel: 1.25rem
+  stage: 2rem
+  full: 9999px
+spacing:
+  inline: 0.5rem
+  related: 0.75rem
+  control: 1rem
+  group: 1.5rem
+  panel: 2rem
+  block: 3rem
+  section: 6rem
+  content-width: 75rem
+components:
+  button-primary:
+    backgroundColor: "{colors.light-primary}"
+    textColor: "{colors.light-primary-foreground}"
+    typography: "{typography.label}"
+    rounded: "{rounded.control}"
+    padding: 1rem
+    height: 2.5rem
+  button-primary-hover:
+    backgroundColor: "{colors.light-primary-hover}"
+  button-primary-pressed:
+    backgroundColor: "{colors.light-primary-pressed}"
+  button-primary-dark:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.dark-primary-foreground}"
+    typography: "{typography.label}"
+    rounded: "{rounded.control}"
+    padding: 1rem
+    height: 2.5rem
+  button-primary-dark-hover:
+    backgroundColor: "{colors.dark-primary-hover}"
+  button-primary-dark-pressed:
+    backgroundColor: "{colors.dark-primary-pressed}"
+  button-ghost:
+    textColor: "{colors.light-foreground}"
+    typography: "{typography.label}"
+    rounded: "{rounded.control}"
+    padding: 0.75rem
+    height: 2.5rem
+  button-ghost-hover:
+    backgroundColor: "{colors.light-accent}"
+    textColor: "{colors.light-accent-foreground}"
+  badge:
+    backgroundColor: "{colors.light-surface-raised}"
+    textColor: "{colors.light-foreground}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.full}"
+    padding: 0.5rem
+    height: 1.5rem
+  separator:
+    backgroundColor: "{colors.light-border}"
+    size: 1px
+---
+
+# Lorelum Design
+
+## Overview
+
+Lorelum should feel like serious infrastructure made visible: precise enough for repeated engineering work, yet luminous enough to make knowledge retrieval feel active rather than archival. The visual center of gravity is calm, structured, and premium. Expression comes from controlled light, directional flow, material depth, and exact alignment, not from decorative noise or generic AI motifs.
+
+The approved mark moves from lower left to upper right. That direction suggests knowledge being retrieved, assembled, and handed to an agent at the moment of action. Preserve its geometry and use the same sense of directed momentum in diagrams and motion without turning every surface into an arrow.
+
+## Colors
+
+Neutral surfaces carry reading, comparison, and dense product work. Lorelum green identifies the brand and the primary action. It must not replace success, warning, error, or information semantics.
+
+Light and dark themes are optically paired, not mechanically inverted. Light mode uses the deeper `light-primary` so white labels remain legible. Dark mode uses the brighter `primary` with a near-black green label. Hover and pressed values are explicit because changing opacity produces inconsistent contrast over different surfaces.
+
+Gradients and emitted light may use `brand-deep`, `primary`, and `brand-light`, moving along the lower-left to upper-right axis. Keep text and small controls on solid semantic colors; gradients belong to brand moments, data flow, and large atmospheric fields.
+
+## Typography
+
+**Bricolage Grotesque** gives display and title text a recognizable editorial silhouette. **Manrope** carries UI and long-form reading with open counters and restrained geometry. **JetBrains Mono** is reserved for code, identifiers, terminal output, and measurements.
+
+Use display type only where the product or a literal offer is the primary first-viewport signal. Product panels, cards, documentation, and navigation use title, body, label, and caption roles at their defined sizes. Do not shrink operational text to create density; reduce surrounding space instead.
+
+## Layout
+
+Layouts use a restrained eight-pixel rhythm with a four-pixel half-step only for optical correction. The named spacing roles describe relationships rather than arbitrary sizes: `inline` separates tightly coupled details, `related` separates siblings, `control` is control padding, `group` binds a local group, and larger roles divide panels, blocks, and sections.
+
+Content is fluid until the 75rem reading stage. Fixed-format controls, grids, and visualizations need stable dimensions or aspect ratios so state changes do not shift the layout. On small screens, preserve readable type and interaction targets before preserving multi-column composition.
+
+## Elevation & Depth
+
+Depth comes first from tonal surfaces, then from blur and restrained shadow. Contact shadow anchors a control, lift shadow separates a panel, and overlay shadow belongs to transient layers. Avoid stacking several elevation signals on one object.
+
+Glass is a presentation material, not the default container. It requires enough surface density to preserve contrast, and blur strength is independent from opacity. Lorelum glass has no decorative white rim. Gradients, texture, glow, and flowing light should strengthen hierarchy or direction; they must not compete with content.
+
+## Shapes
+
+The shape language balances engineered alignment with softened impact. Controls use the `control` radius, bounded panels use `panel`, and immersive stages may use `stage`. Pills are reserved for compact statuses, segmented choices, and truly capsule-shaped controls.
+
+Do not wrap every section in a card or place cards inside cards. Large sections are full-width bands or unframed layouts. Repeated entities, modals, and genuinely bounded tools may use cards. Logo geometry is never stretched, rounded again, redrawn, or placed on an arbitrary decorative tile.
+
+## Components
+
+Buttons use semantic variants and explicit interaction states. Primary buttons identify the main command; secondary and outline buttons preserve hierarchy; ghost buttons serve compact utilities such as navbar controls. Icon-only buttons use familiar symbols, remain circular or square according to context, and always expose an accessible name.
+
+Badges describe state or category and remain visually quieter than actions. Separators clarify structure but should not compensate for weak spacing. Components may accept layout classes from consumers, but their color, typography, radius, focus treatment, and state behavior remain system-owned.
+
+Interactive components show a visible keyboard focus ring, use a pointer cursor when enabled, and retain sufficient target size and spacing on touch screens. Motion gives feedback quickly and may use a longer emphasized curve only for meaningful layout transitions.
+
+## Do's and Don'ts
+
+- Do use neutral hierarchy for most of the interface and reserve green for brand identity, primary action, focus, and directional emphasis.
+- Do validate normal text and control labels at WCAG AA contrast in both themes.
+- Do use optical alignment when strict geometry feels visibly off-center.
+- Do keep page-specific animation and expressive materials subordinate to content and interaction.
+- Don't add eyebrow labels, floating dots, ornamental microcopy, or section numbers merely to make a composition look designed.
+- Don't use decorative white borders on glass, nested cards, gradient text for body copy, or several competing ambient backgrounds.
+- Don't mix icon families, redraw familiar interface symbols, or pair an icon with redundant text in compact utility controls.
+- Don't use raw palette values in product components when a semantic role exists.

--- a/apps/site/AGENTS.md
+++ b/apps/site/AGENTS.md
@@ -34,6 +34,9 @@ bun run lint
   Add CSS only for complex animation, material/filter effects, pseudo-elements,
   upstream adaptation, or selector relationships that utilities cannot express
   clearly. Do not put feature styles in `styles/app.css`.
+- `@lorelum/ui` owns production tokens and reusable primitives. Keep the
+  Fumadocs adapter inside the Docs feature; do not create a second
+  site-local `components/ui` tree.
 - The current handwritten locale catalog is a temporary compatibility layer in
   `src/shared/i18n/legacy-translations.ts`. Do not redesign or replace i18n as
   part of a directory-only migration.

--- a/apps/site/AGENTS.md
+++ b/apps/site/AGENTS.md
@@ -35,8 +35,9 @@ bun run lint
   upstream adaptation, or selector relationships that utilities cannot express
   clearly. Do not put feature styles in `styles/app.css`.
 - `@lorelum/ui` owns production tokens and reusable primitives. Keep the
-  Fumadocs adapter inside the Docs feature; do not create a second
-  site-local `components/ui` tree.
+  Fumadocs adapter inside the Docs feature and apply the `lorelum-ui` scope
+  only to an explicitly migrated surface. Do not create a second site-local
+  `components/ui` tree or import shared tokens from `styles/app.css`.
 - The current handwritten locale catalog is a temporary compatibility layer in
   `src/shared/i18n/legacy-translations.ts`. Do not redesign or replace i18n as
   part of a directory-only migration.

--- a/apps/site/components.json
+++ b/apps/site/components.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "../../packages/ui/src/styles/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@lorelum/ui/lib/utils",
+    "ui": "@lorelum/ui/components",
+    "lib": "@/lib"
+  }
+}

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@fumadocs/language": "0.2.2",
+    "@lorelum/ui": "workspace:*",
     "@react-three/fiber": "^9.7.0",
     "@tanstack/react-router": "1.170.27",
     "@tanstack/react-router-devtools": "1.167.1",

--- a/apps/site/src/app/root-head.ts
+++ b/apps/site/src/app/root-head.ts
@@ -7,12 +7,12 @@ export function getRootHead() {
       { name: "viewport", content: "width=device-width, initial-scale=1" },
       {
         name: "theme-color",
-        content: "#141618",
+        content: "#121212",
         media: "(prefers-color-scheme: dark)",
       },
       {
         name: "theme-color",
-        content: "#F8F9FA",
+        content: "#F5F5F5",
         media: "(prefers-color-scheme: light)",
       },
     ],

--- a/apps/site/src/app/root-head.ts
+++ b/apps/site/src/app/root-head.ts
@@ -7,12 +7,12 @@ export function getRootHead() {
       { name: "viewport", content: "width=device-width, initial-scale=1" },
       {
         name: "theme-color",
-        content: "#121212",
+        content: "#141618",
         media: "(prefers-color-scheme: dark)",
       },
       {
         name: "theme-color",
-        content: "#F5F5F5",
+        content: "#F8F9FA",
         media: "(prefers-color-scheme: light)",
       },
     ],
@@ -31,7 +31,7 @@ export function getRootHead() {
       },
       {
         rel: "stylesheet",
-        href: "https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,300..800&family=JetBrains+Mono:wght@400;500;600&display=swap",
+        href: "https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,300..800&family=JetBrains+Mono:wght@400;500;600&family=Manrope:wght@400;500;600&display=swap",
       },
     ],
   };

--- a/apps/site/src/features/docs/docs-screen.tsx
+++ b/apps/site/src/features/docs/docs-screen.tsx
@@ -49,11 +49,10 @@ function DocsContent({
 
 /** Browser screen for Fumadocs layout and compiled MDX content. */
 export function DocsScreen({ lang, pageData }: DocsScreenProps) {
-  const { path, pageTree, markdownUrl, title, description } =
-    useFumadocsLoader(pageData);
+  const { path, pageTree, markdownUrl, title, description } = useFumadocsLoader(pageData);
 
   return (
-    <DocsLayout {...baseOptions(lang)} tree={pageTree}>
+    <DocsLayout {...baseOptions(lang)} tree={pageTree} containerProps={{ className: "lorelum-ui" }}>
       <Suspense>
         <DocsContent
           path={path}

--- a/apps/site/src/features/docs/docs-screen.tsx
+++ b/apps/site/src/features/docs/docs-screen.tsx
@@ -1,6 +1,7 @@
 import { Suspense, use } from "react";
 import { useFumadocsLoader } from "fumadocs-core/source/client";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import "./styles/docs.css";
 import {
   DocsBody,
   DocsDescription,

--- a/apps/site/src/features/docs/styles/docs.css
+++ b/apps/site/src/features/docs/styles/docs.css
@@ -1,3 +1,5 @@
+@import "@lorelum/ui/tokens.css";
+
 /*
  * Fumadocs adapter for the documentation surface.
  *
@@ -5,17 +7,31 @@
  * tokens, while Fumadocs owns the generated markup and interaction behavior.
  */
 
-:root,
-.dark {
+#nd-docs-layout {
+  --color-fd-background: var(--background);
+  --color-fd-foreground: var(--foreground);
+  --color-fd-muted: var(--muted);
+  --color-fd-muted-foreground: var(--muted-foreground);
+  --color-fd-popover: var(--popover);
+  --color-fd-popover-foreground: var(--popover-foreground);
+  --color-fd-card: var(--card);
+  --color-fd-card-foreground: var(--card-foreground);
+  --color-fd-border: var(--border);
+  --color-fd-primary: var(--primary);
+  --color-fd-primary-foreground: var(--primary-foreground);
+  --color-fd-secondary: var(--secondary);
+  --color-fd-secondary-foreground: var(--secondary-foreground);
+  --color-fd-accent: var(--accent);
+  --color-fd-accent-foreground: var(--accent-foreground);
+  --color-fd-ring: var(--ring);
   --color-fd-overlay: var(--overlay);
   --color-fd-info: var(--info);
   --color-fd-warning: var(--warning);
   --color-fd-error: var(--destructive);
   --color-fd-success: var(--success);
   --color-fd-idea: var(--primary);
-}
-
-#nd-docs-layout {
+  background: var(--color-fd-background);
+  color: var(--color-fd-foreground);
   --docs-divider: color-mix(in srgb, var(--border) 72%, transparent);
   --docs-divider-soft: color-mix(in srgb, var(--border) 46%, transparent);
   --docs-control-surface: color-mix(in srgb, var(--secondary) 68%, transparent);
@@ -27,30 +43,30 @@
   --docs-control-surface: color-mix(in srgb, var(--secondary) 58%, transparent);
 }
 
-#nd-sidebar {
+#nd-docs-layout #nd-sidebar {
   border-inline-end-color: var(--docs-divider);
 }
 
-#nd-sidebar [data-search-full] {
+#nd-docs-layout #nd-sidebar [data-search-full] {
   border-color: var(--docs-divider);
   background: var(--docs-control-surface);
 }
 
-#nd-sidebar [data-search-full]:hover {
+#nd-docs-layout #nd-sidebar [data-search-full]:hover {
   background: var(--sidebar-accent);
 }
 
-#nd-sidebar [data-search-full] kbd {
+#nd-docs-layout #nd-sidebar [data-search-full] kbd {
   border-color: var(--docs-divider-soft);
   background: color-mix(in srgb, var(--sidebar) 76%, transparent);
   box-shadow: none;
 }
 
-#nd-sidebar a[data-status="active"] {
+#nd-docs-layout #nd-sidebar a[data-status="active"] {
   background: color-mix(in srgb, var(--sidebar-primary) 9%, transparent);
 }
 
-#nd-sidebar > div:last-child > div:has(> a[aria-label="GitHub"]) {
+#nd-docs-layout #nd-sidebar > div:last-child > div:has(> a[aria-label="GitHub"]) {
   align-self: flex-start;
   width: fit-content;
   gap: 0.125rem;
@@ -58,38 +74,42 @@
   background: var(--docs-control-surface);
 }
 
-#nd-sidebar a[aria-label="GitHub"] {
+#nd-docs-layout #nd-sidebar a[aria-label="GitHub"] {
   width: var(--lore-size-control-sm);
   height: var(--lore-size-control-sm);
   padding: 0;
   border-radius: var(--lore-radius-pill);
 }
 
-#nd-sidebar :is(a[aria-label="GitHub"], button[aria-label="Toggle theme"]):focus-visible,
-#nd-sidebar-mobile :is(a[aria-label="GitHub"], button[aria-label="Toggle theme"]):focus-visible {
+#nd-docs-layout
+  #nd-sidebar
+  :is(a[aria-label="GitHub"], button[aria-label="Toggle theme"]):focus-visible,
+#nd-docs-layout
+  #nd-sidebar-mobile
+  :is(a[aria-label="GitHub"], button[aria-label="Toggle theme"]):focus-visible {
   border-color: transparent;
   outline: 2px solid color-mix(in srgb, var(--sidebar-ring) 76%, transparent);
   outline-offset: 2px;
   box-shadow: none;
 }
 
-#nd-sidebar-mobile {
+#nd-docs-layout #nd-sidebar-mobile {
   border-inline-start-color: var(--docs-divider);
   box-shadow: var(--lore-shadow-overlay);
 }
 
-#nd-sidebar-mobile a[data-status="active"] {
+#nd-docs-layout #nd-sidebar-mobile a[data-status="active"] {
   background: color-mix(in srgb, var(--primary) 9%, transparent);
 }
 
-[data-sidebar-panel] {
+#nd-docs-layout [data-sidebar-panel] {
   border-color: var(--docs-divider);
   background: color-mix(in srgb, var(--muted) 88%, transparent);
   box-shadow: var(--lore-shadow-contact);
   backdrop-filter: blur(var(--lore-blur-soft));
 }
 
-[data-toc-popover] > header {
+#nd-docs-layout [data-toc-popover] > header {
   border-color: var(--docs-divider);
   background: color-mix(in srgb, var(--background) 88%, transparent);
   backdrop-filter: blur(var(--lore-blur-soft));

--- a/apps/site/src/features/docs/styles/docs.css
+++ b/apps/site/src/features/docs/styles/docs.css
@@ -1,0 +1,174 @@
+/*
+ * Fumadocs adapter for the documentation surface.
+ *
+ * Keep component-specific refinements here: the shared package owns semantic
+ * tokens, while Fumadocs owns the generated markup and interaction behavior.
+ */
+
+:root,
+.dark {
+  --color-fd-overlay: var(--overlay);
+  --color-fd-info: var(--info);
+  --color-fd-warning: var(--warning);
+  --color-fd-error: var(--destructive);
+  --color-fd-success: var(--success);
+  --color-fd-idea: var(--primary);
+}
+
+#nd-docs-layout {
+  --docs-divider: color-mix(in srgb, var(--border) 72%, transparent);
+  --docs-divider-soft: color-mix(in srgb, var(--border) 46%, transparent);
+  --docs-control-surface: color-mix(in srgb, var(--secondary) 68%, transparent);
+}
+
+.dark #nd-docs-layout {
+  --docs-divider: color-mix(in srgb, var(--border) 60%, transparent);
+  --docs-divider-soft: color-mix(in srgb, var(--border) 38%, transparent);
+  --docs-control-surface: color-mix(in srgb, var(--secondary) 58%, transparent);
+}
+
+#nd-sidebar {
+  border-inline-end-color: var(--docs-divider);
+}
+
+#nd-sidebar [data-search-full] {
+  border-color: var(--docs-divider);
+  background: var(--docs-control-surface);
+}
+
+#nd-sidebar [data-search-full]:hover {
+  background: var(--sidebar-accent);
+}
+
+#nd-sidebar [data-search-full] kbd {
+  border-color: var(--docs-divider-soft);
+  background: color-mix(in srgb, var(--sidebar) 76%, transparent);
+  box-shadow: none;
+}
+
+#nd-sidebar a[data-status="active"] {
+  background: color-mix(in srgb, var(--sidebar-primary) 9%, transparent);
+}
+
+#nd-sidebar > div:last-child > div:has(> a[aria-label="GitHub"]) {
+  align-self: flex-start;
+  width: fit-content;
+  gap: 0.125rem;
+  border-color: var(--docs-divider);
+  background: var(--docs-control-surface);
+}
+
+#nd-sidebar a[aria-label="GitHub"] {
+  width: var(--lore-size-control-sm);
+  height: var(--lore-size-control-sm);
+  padding: 0;
+  border-radius: var(--lore-radius-pill);
+}
+
+#nd-sidebar :is(a[aria-label="GitHub"], button[aria-label="Toggle theme"]):focus-visible,
+#nd-sidebar-mobile :is(a[aria-label="GitHub"], button[aria-label="Toggle theme"]):focus-visible {
+  border-color: transparent;
+  outline: 2px solid color-mix(in srgb, var(--sidebar-ring) 76%, transparent);
+  outline-offset: 2px;
+  box-shadow: none;
+}
+
+#nd-sidebar-mobile {
+  border-inline-start-color: var(--docs-divider);
+  box-shadow: var(--lore-shadow-overlay);
+}
+
+#nd-sidebar-mobile a[data-status="active"] {
+  background: color-mix(in srgb, var(--primary) 9%, transparent);
+}
+
+[data-sidebar-panel] {
+  border-color: var(--docs-divider);
+  background: color-mix(in srgb, var(--muted) 88%, transparent);
+  box-shadow: var(--lore-shadow-contact);
+  backdrop-filter: blur(var(--lore-blur-soft));
+}
+
+[data-toc-popover] > header {
+  border-color: var(--docs-divider);
+  background: color-mix(in srgb, var(--background) 88%, transparent);
+  backdrop-filter: blur(var(--lore-blur-soft));
+}
+
+#nd-page > h1,
+#nd-page .prose :is(h2, h3) {
+  font-family: var(--lore-font-display);
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+
+#nd-page > p:first-of-type {
+  max-width: var(--lore-reading-width);
+  text-wrap: pretty;
+}
+
+#nd-page > div.border-b {
+  border-color: var(--docs-divider);
+}
+
+#nd-page .prose > div[style*="--callout-color"] {
+  border-color: color-mix(in srgb, var(--callout-color) 22%, transparent);
+  background: color-mix(in srgb, var(--callout-color) 5%, var(--card));
+  box-shadow: var(--lore-shadow-contact);
+}
+
+#nd-page .prose > div:has(> [role="tablist"]) {
+  border-color: var(--docs-divider);
+  background: var(--docs-control-surface);
+  box-shadow: none;
+}
+
+#nd-page [role="tabpanel"] {
+  border-top: 1px solid var(--docs-divider-soft);
+}
+
+#nd-page :is([role="tab"], [role="tabpanel"]):focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
+#nd-page figure.shiki {
+  border-color: var(--docs-divider);
+  box-shadow: var(--lore-shadow-contact);
+}
+
+#nd-page figure.shiki > [role="region"] {
+  --padding-right: 3.5rem !important;
+  scrollbar-color: color-mix(in srgb, var(--border-strong) 58%, transparent) transparent;
+  scrollbar-width: thin;
+}
+
+#nd-page figure.shiki > [role="region"]::-webkit-scrollbar {
+  width: 0.375rem;
+  height: 0.375rem;
+}
+
+#nd-page figure.shiki > [role="region"]::-webkit-scrollbar-thumb {
+  border-radius: var(--lore-radius-pill);
+  background: color-mix(in srgb, var(--border-strong) 58%, transparent);
+}
+
+#nd-page figure.shiki > div:first-child {
+  background: color-mix(in srgb, var(--card) 82%, transparent);
+}
+
+#nd-page .prose :is(table, th, td) {
+  border-color: var(--docs-divider);
+}
+
+#nd-toc h3 {
+  font-weight: var(--lore-font-weight-medium);
+}
+
+#nd-toc a[data-active="false"] {
+  color: color-mix(in srgb, var(--muted-foreground) 90%, var(--foreground));
+}
+
+#nd-toc a:hover {
+  color: var(--foreground);
+}

--- a/apps/site/src/features/docs/styles/docs.css
+++ b/apps/site/src/features/docs/styles/docs.css
@@ -131,6 +131,11 @@
   border-color: var(--docs-divider);
 }
 
+#nd-page .fd-steps {
+  display: grid;
+  gap: var(--lore-space-inline);
+}
+
 #nd-page .prose > div[style*="--callout-color"] {
   border-color: color-mix(in srgb, var(--callout-color) 22%, transparent);
   background: color-mix(in srgb, var(--callout-color) 5%, var(--card));

--- a/apps/site/src/features/docs/styles/docs.test.ts
+++ b/apps/site/src/features/docs/styles/docs.test.ts
@@ -20,6 +20,11 @@ describe("docs style adapter", () => {
     expect(appCss).not.toContain('@import "fumadocs-ui/css/shadcn.css";');
   });
 
+  test("keeps numbered Fumadocs steps visually distinct", () => {
+    expect(docsCss).toContain("#nd-page .fd-steps {");
+    expect(docsCss).toContain("gap: var(--lore-space-inline);");
+  });
+
   test("maps every Fumadocs feedback role to a production semantic token", () => {
     const mappings = {
       overlay: "overlay",

--- a/apps/site/src/features/docs/styles/docs.test.ts
+++ b/apps/site/src/features/docs/styles/docs.test.ts
@@ -3,10 +3,21 @@ import { readFileSync } from "node:fs";
 
 const docsCss = readFileSync(new URL("./docs.css", import.meta.url), "utf8");
 const docsScreen = readFileSync(new URL("../docs-screen.tsx", import.meta.url), "utf8");
+const appCss = readFileSync(new URL("../../../styles/app.css", import.meta.url), "utf8");
 
 describe("docs style adapter", () => {
-  test("loads the docs refinements only from the Docs feature", () => {
+  test("loads scoped design tokens only from the Docs feature", () => {
     expect(docsScreen).toContain('import "./styles/docs.css";');
+    expect(docsScreen).toContain('containerProps={{ className: "lorelum-ui" }}');
+    expect(docsCss).toContain('@import "@lorelum/ui/tokens.css";');
+    expect(docsCss).toContain("#nd-docs-layout {");
+    expect(docsCss).not.toContain(":root");
+  });
+
+  test("preserves the legacy Landing's global Fumadocs theme", () => {
+    expect(appCss).toContain('@import "fumadocs-ui/css/neutral.css";');
+    expect(appCss).not.toContain('@import "@lorelum/ui/globals.css";');
+    expect(appCss).not.toContain('@import "fumadocs-ui/css/shadcn.css";');
   });
 
   test("maps every Fumadocs feedback role to a production semantic token", () => {

--- a/apps/site/src/features/docs/styles/docs.test.ts
+++ b/apps/site/src/features/docs/styles/docs.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const docsCss = readFileSync(new URL("./docs.css", import.meta.url), "utf8");
+const docsScreen = readFileSync(new URL("../docs-screen.tsx", import.meta.url), "utf8");
+
+describe("docs style adapter", () => {
+  test("loads the docs refinements only from the Docs feature", () => {
+    expect(docsScreen).toContain('import "./styles/docs.css";');
+  });
+
+  test("maps every Fumadocs feedback role to a production semantic token", () => {
+    const mappings = {
+      overlay: "overlay",
+      info: "info",
+      warning: "warning",
+      error: "destructive",
+      success: "success",
+      idea: "primary",
+    } as const;
+
+    for (const [fumadocsRole, semanticRole] of Object.entries(mappings)) {
+      expect(docsCss).toContain(`--color-fd-${fumadocsRole}: var(--${semanticRole});`);
+    }
+  });
+});

--- a/apps/site/src/shared/lib/cn.ts
+++ b/apps/site/src/shared/lib/cn.ts
@@ -1,1 +1,1 @@
-export { cn } from 'cnfast';
+export { cn } from '@lorelum/ui/lib/utils';

--- a/apps/site/src/shared/lib/cn.ts
+++ b/apps/site/src/shared/lib/cn.ts
@@ -1,1 +1,1 @@
-export { cn } from '@lorelum/ui/lib/utils';
+export { cn } from "cnfast";

--- a/apps/site/src/shared/ui/theme-toggle.tsx
+++ b/apps/site/src/shared/ui/theme-toggle.tsx
@@ -2,6 +2,8 @@ import { Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { flushSync } from 'react-dom';
 import { useEffect, useState } from 'react';
+import { Button } from '@lorelum/ui/components/button';
+import { cn } from '@lorelum/ui/lib/utils';
 import { getStrings } from '@/shared/i18n/legacy-translations';
 
 /** Compact theme toggle owned by the site navbar rather than Fumadocs. */
@@ -26,14 +28,19 @@ export function ThemeToggle({ lang, className }: { lang: string; className?: str
   };
 
   return (
-    <button
+    <Button
       type="button"
       aria-label={t.toggleTheme}
       aria-pressed={isDark}
-      className={`site-theme-toggle inline-flex size-9 cursor-pointer items-center justify-center rounded-full p-0 text-fd-foreground transition-[color,background-color] duration-[160ms] ease-out hover:bg-[color-mix(in_oklab,var(--color-fd-primary)_9%,transparent)] hover:text-fd-primary dark:hover:bg-[color-mix(in_oklab,var(--color-fd-primary)_16%,transparent)] dark:hover:text-[color-mix(in_oklab,var(--color-fd-foreground)_72%,var(--color-fd-muted-foreground))] [&_svg]:size-4 ${className ?? ''}`}
+      variant="ghost"
+      size="icon-sm"
+      className={cn(
+        'site-theme-toggle rounded-full p-0 text-fd-foreground transition-[color,background-color] duration-[160ms] ease-out hover:bg-[color-mix(in_oklab,var(--color-fd-primary)_9%,transparent)] hover:text-fd-primary dark:hover:bg-[color-mix(in_oklab,var(--color-fd-primary)_16%,transparent)] dark:hover:text-[color-mix(in_oklab,var(--color-fd-foreground)_72%,var(--color-fd-muted-foreground))] [&_svg]:size-4',
+        className,
+      )}
       onClick={handleThemeChange}
     >
       {isDark ? <Sun aria-hidden="true" /> : <Moon aria-hidden="true" />}
-    </button>
+    </Button>
   );
 }

--- a/apps/site/src/shared/ui/theme-toggle.tsx
+++ b/apps/site/src/shared/ui/theme-toggle.tsx
@@ -1,10 +1,8 @@
-import { Moon, Sun } from 'lucide-react';
-import { useTheme } from 'next-themes';
-import { flushSync } from 'react-dom';
-import { useEffect, useState } from 'react';
-import { Button } from '@lorelum/ui/components/button';
-import { cn } from '@lorelum/ui/lib/utils';
-import { getStrings } from '@/shared/i18n/legacy-translations';
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { flushSync } from "react-dom";
+import { useEffect, useState } from "react";
+import { getStrings } from "@/shared/i18n/legacy-translations";
 
 /** Compact theme toggle owned by the site navbar rather than Fumadocs. */
 export function ThemeToggle({ lang, className }: { lang: string; className?: string }) {
@@ -14,9 +12,9 @@ export function ThemeToggle({ lang, className }: { lang: string; className?: str
 
   useEffect(() => setMounted(true), []);
 
-  const isDark = mounted && resolvedTheme === 'dark';
+  const isDark = mounted && resolvedTheme === "dark";
   const handleThemeChange = () => {
-    const nextTheme = isDark ? 'light' : 'dark';
+    const nextTheme = isDark ? "light" : "dark";
 
     // Keep the smooth cross-document transition used by Fumadocs' original
     // control, while retaining a normal fallback for browsers without the API.
@@ -28,19 +26,14 @@ export function ThemeToggle({ lang, className }: { lang: string; className?: str
   };
 
   return (
-    <Button
+    <button
       type="button"
       aria-label={t.toggleTheme}
       aria-pressed={isDark}
-      variant="ghost"
-      size="icon-sm"
-      className={cn(
-        'site-theme-toggle rounded-full p-0 text-fd-foreground transition-[color,background-color] duration-[160ms] ease-out hover:bg-[color-mix(in_oklab,var(--color-fd-primary)_9%,transparent)] hover:text-fd-primary dark:hover:bg-[color-mix(in_oklab,var(--color-fd-primary)_16%,transparent)] dark:hover:text-[color-mix(in_oklab,var(--color-fd-foreground)_72%,var(--color-fd-muted-foreground))] [&_svg]:size-4',
-        className,
-      )}
+      className={`site-theme-toggle inline-flex size-9 cursor-pointer items-center justify-center rounded-full p-0 text-fd-foreground transition-[color,background-color] duration-[160ms] ease-out hover:bg-[color-mix(in_oklab,var(--color-fd-primary)_9%,transparent)] hover:text-fd-primary dark:hover:bg-[color-mix(in_oklab,var(--color-fd-primary)_16%,transparent)] dark:hover:text-[color-mix(in_oklab,var(--color-fd-foreground)_72%,var(--color-fd-muted-foreground))] [&_svg]:size-4 ${className ?? ""}`}
       onClick={handleThemeChange}
     >
       {isDark ? <Sun aria-hidden="true" /> : <Moon aria-hidden="true" />}
-    </Button>
+    </button>
   );
 }

--- a/apps/site/src/styles/app.css
+++ b/apps/site/src/styles/app.css
@@ -1,6 +1,11 @@
-@import 'tailwindcss';
-@import 'fumadocs-ui/css/neutral.css';
-@import 'fumadocs-ui/css/preset.css';
+@import "tailwindcss";
+@import "@lorelum/ui/globals.css";
+@import "fumadocs-ui/css/shadcn.css";
+@import "fumadocs-ui/css/preset.css";
+@import "./vendor.css";
+@import "./landing.css";
+
+@source '../../../../packages/ui/src';
 
 /*
  * Tailwind v4 defaults the `dark:` variant to `prefers-color-scheme`, but
@@ -9,12 +14,10 @@
  */
 @custom-variant dark (&:where(.dark, .dark *));
 
-@theme {
-  --font-display: 'Bricolage Grotesque', ui-sans-serif, system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+@theme inline {
   /* "run/success/live" accent — breaks the indigo-only palette with the
    * "code dark, run green" cue the product's terminal demo leans on. */
-  --color-run: #34d399;
+  --color-run: var(--success);
 }
 
 html {
@@ -25,6 +28,3 @@ html > body[data-scroll-locked] {
   margin-right: 0px !important;
   --removed-body-scroll-bar-size: 0px !important;
 }
-
-@import "./vendor.css";
-@import "./landing.css";

--- a/apps/site/src/styles/app.css
+++ b/apps/site/src/styles/app.css
@@ -1,11 +1,8 @@
 @import "tailwindcss";
-@import "@lorelum/ui/globals.css";
-@import "fumadocs-ui/css/shadcn.css";
+@import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 @import "./vendor.css";
 @import "./landing.css";
-
-@source '../../../../packages/ui/src';
 
 /*
  * Tailwind v4 defaults the `dark:` variant to `prefers-color-scheme`, but
@@ -14,10 +11,12 @@
  */
 @custom-variant dark (&:where(.dark, .dark *));
 
-@theme inline {
+@theme {
+  --font-display: "Bricolage Grotesque", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   /* "run/success/live" accent — breaks the indigo-only palette with the
    * "code dark, run green" cue the product's terminal demo leans on. */
-  --color-run: var(--success);
+  --color-run: #34d399;
 }
 
 html {

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -15,7 +15,9 @@
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@lorelum/ui": ["../../packages/ui/src/index.ts"],
+      "@lorelum/ui/*": ["../../packages/ui/src/*"]
     },
     "noEmit": true
   }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "lorelum",
       "devDependencies": {
+        "@google/design.md": "0.4.0",
         "@types/bun": "1.4.2",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
@@ -16,6 +17,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@fumadocs/language": "0.2.2",
+        "@lorelum/ui": "workspace:*",
         "@react-three/fiber": "^9.7.0",
         "@tanstack/react-router": "1.170.27",
         "@tanstack/react-router-devtools": "1.167.1",
@@ -121,6 +123,25 @@
     "packages/shared": {
       "name": "@lorelum/shared",
       "version": "0.0.0",
+    },
+    "packages/ui": {
+      "name": "@lorelum/ui",
+      "version": "0.0.0",
+      "dependencies": {
+        "@base-ui/react": "1.7.0",
+        "class-variance-authority": "0.7.1",
+        "cn": "0.2.6",
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+      },
+      "peerDependencies": {
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+      },
     },
   },
   "overrides": {
@@ -257,6 +278,8 @@
 
     "@fumari/image-size": ["@fumari/image-size@0.1.0", "", {}, "sha512-x2o9u6P8uKUK15B8XgEoRhR3PgLoLSbQKK6FUCd14JzumEw+e8FXZPelij/dZ4VQVMp4r61VD3DcvSo3aEhLAA=="],
 
+    "@google/design.md": ["@google/design.md@0.4.0", "", { "dependencies": { "citty": "^0.1.6", "remark-frontmatter": "^5.0.0", "remark-mdx": "^3.1.1", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "yaml": "^2.7.1", "zod": "^3.24.0" }, "bin": { "design.md": "dist/index.js", "designmd": "dist/index.js" } }, "sha512-7aNIv6hslxIZ9igXq1abbVu+ue/ft/oFMUrAuhzpVFijGr9v+l0CkkCBQsHozucNiZHIBS43XC6l8gYDZRys9Q=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
@@ -340,6 +363,8 @@
     "@lorelum/shared": ["@lorelum/shared@workspace:packages/shared"],
 
     "@lorelum/site": ["@lorelum/site@workspace:apps/site"],
+
+    "@lorelum/ui": ["@lorelum/ui@workspace:packages/ui"],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -697,9 +722,13 @@
 
     "chunk-data": ["chunk-data@0.1.0", "", {}, "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g=="],
 
+    "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
+
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cn": ["cn@0.2.6", "", { "bin": { "cn": "bin/cn.mjs" } }, "sha512-+i4L0zUGgRcEnhsxueVrP7iBGxBx5iD0WOTYg1MwFEu2ZyCmH5Ov2V1cul2Ht5UchRQQgftCf4be/RxspuW6QQ=="],
 
     "cnfast": ["cnfast@0.1.0", "", { "bin": { "cnfast": "bin/cli.js" } }, "sha512-rH0jBKeLkVrK7NsZ5Ba2l7WdMBmm1k0FMpABeXUU1PgTUxbz3261gEuCSsrYuXo4BwAe3yCcIbQ93YyS52lOGQ=="],
 
@@ -710,6 +739,8 @@
     "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "compute-scroll-into-view": ["compute-scroll-into-view@3.1.1", "", {}, "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -821,6 +852,8 @@
 
     "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
+    "fault": ["fault@2.0.1", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetchdts": ["fetchdts@0.1.7", "", {}, "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA=="],
@@ -830,6 +863,8 @@
     "file-type": ["file-type@22.0.2", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-0H8TsCUGBLx+V5adH3EY52hTAcyLKbV1D4gq5cIOJ6DnQAHeV9Z2Hhuc5CoBX4YmvB2oL+JIC84z0qO7JsCoNw=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -1003,6 +1038,8 @@
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
 
+    "mdast-util-frontmatter": ["mdast-util-frontmatter@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "escape-string-regexp": "^5.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-extension-frontmatter": "^2.0.0" } }, "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA=="],
+
     "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
 
     "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
@@ -1042,6 +1079,8 @@
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-frontmatter": ["micromark-extension-frontmatter@2.0.0", "", { "dependencies": { "fault": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg=="],
 
     "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
 
@@ -1222,6 +1261,8 @@
     "rehype-recma": ["rehype-recma@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "hast-util-to-estree": "^3.0.0" } }, "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw=="],
 
     "remark": ["remark@15.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A=="],
+
+    "remark-frontmatter": ["remark-frontmatter@5.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-frontmatter": "^2.0.0", "micromark-extension-frontmatter": "^2.0.0", "unified": "^11.0.0" } }, "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
@@ -1434,6 +1475,8 @@
     "@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@google/design.md/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 

--- a/docs/plans/design-infrastructure.md
+++ b/docs/plans/design-infrastructure.md
@@ -1,0 +1,107 @@
+# Lorelum Web Design Infrastructure
+
+> Implementation plan for [Issue #86](https://github.com/lorelum/lorelum/issues/86). This document describes the current approved stage; it does not publish a UI package or redesign the landing page.
+
+## Conclusion
+
+Create a private workspace package, `@lorelum/ui`, as the single Web UI ownership boundary. It owns production CSS tokens, Tailwind v4 mappings, and a small set of reviewed shadcn components. The site imports that contract, keeps its existing Fumadocs/next-themes provider, and retains route, locale, navigation-motion, and landing-effects behavior.
+
+This stage deliberately avoids a token compiler, Storybook, a second theme provider, and bulk component installation. CSS is already the only confirmed runtime consumer. A larger platform would add generation and release semantics without solving a current problem.
+
+## Observed starting state
+
+- The root workspace already includes `packages/*` and `apps/*`; no new monorepo runner is needed (`package.json`).
+- The site is React 19, TanStack Start, Tailwind v4, and Fumadocs (`apps/site/package.json`).
+- `fumadocs-ui` resolves to `@fumadocs/base-ui`, and `@base-ui/react` is already in the dependency graph. Base UI is therefore the lowest-friction shadcn primitive choice.
+- Fumadocs' `RootProvider` and `next-themes` own the `.dark` class. The existing theme toggle preserves hydration safety and View Transition behavior (`apps/site/src/app/root-document.tsx`, `src/shared/ui/theme-toggle.tsx`).
+- The global stylesheet currently imports Fumadocs' neutral theme, while brand and component values are distributed through `app.css`, landing styles, navigation styles, and vendored component CSS.
+- The site already uses Lucide. The current base-nova generator selects `cn@0.2.6`, so the shared package owns that helper and the site re-exports it rather than keeping a second direct utility dependency. The site retains `cnfast` while legacy landing motion utilities still consume its compatibility export.
+
+## Required result
+
+- A stable package import for shared components and tokens.
+- One production source for light/dark semantic roles, with Tailwind and Fumadocs consuming adapters.
+- A reviewed shadcn workflow that writes source into the shared package.
+- At least one real site control consuming the package while preserving its current behavior.
+- Tests that fail when theme roles drift, required component states disappear, or SSR output loses semantics.
+- No change to Practice, retrieval, CLI, MCP, persistence, or release contracts.
+
+## Responsibility and dependency direction
+
+```text
+approved brand decisions
+        |
+        v
+@lorelum/ui tokens.css  -->  theme.css  -->  Tailwind utilities
+        |                                  |
+        +--> Fumadocs shadcn adapter        +--> shared components
+                         \                       |
+                          +------ apps/site <----+
+```
+
+The root `DESIGN.md` follows Google's DESIGN.md alpha format and is the agent-readable design contract. Its YAML values are normative for the visual roles represented there. `tokens.css` is the production Web implementation and keeps those values aligned while extending them with runtime-only roles. `theme.css` maps variables into Tailwind namespaces and contains no palette. Shared components consume semantic utilities. The site owns the theme lifecycle and applies its own composition, locale, routing, data, and animation.
+
+`@lorelum/shared` remains domain-neutral and must not import React, browser primitives, Tailwind, or UI dependencies.
+
+## Package contract
+
+The first package surface is intentionally narrow:
+
+```json
+{
+  "exports": {
+    ".": "./src/index.ts",
+    "./globals.css": "./src/styles/globals.css",
+    "./tokens.css": "./src/styles/tokens.css",
+    "./components/*": "./src/components/*.tsx",
+    "./lib/utils": "./src/lib/utils.ts"
+  }
+}
+```
+
+The package is private and source-distributed inside the workspace. React is a peer dependency. Runtime dependencies belong to the UI package rather than relying on Fumadocs transitive packages. CSS is marked as a side effect; no `dist/` is built or committed in this stage.
+
+## Token layers
+
+`tokens.css` has two runtime layers in one source:
+
+- Foundations use the `--lore-*` prefix: brand palette, typography, spacing roles, radii, blur, shadow, motion, layout, and layer values.
+- Semantic roles use conventional shadcn names: `--background`, `--foreground`, `--primary`, `--accent`, `--border`, `--ring`, feedback roles, chart roles, and sidebar roles. `:root` is light; `.dark` is dark.
+
+Primary action colors preserve the approved pair: light uses `#168263` with white; dark uses brand green `#35b88f` with `#10251e`. Blur and surface alpha remain independent. Product code consumes roles, not raw palette steps.
+
+The current runtime has only a CSS consumer, so DESIGN.md-to-CSS generation is deferred. The official `designmd lint` command validates the document schema, while package tests guard theme parity, contrast, and CSS mapping. Reconsider generation when a confirmed non-CSS consumer needs the same values or repeated releases show manual drift.
+
+## shadcn ownership
+
+Both `packages/ui` and `apps/site` have `components.json` with the same `base-nova`, Base UI, Lucide, Tailwind v4, and CSS-variable decisions. The shared package configuration is the only place used to add reusable primitives. The site configuration teaches blocks and future tooling to import shared UI rather than creating a second local `components/ui` tree.
+
+The initial set is Button, Badge, and Separator. They cover commands, status labels, and structural division without pre-installing speculative forms, overlays, tables, or navigation systems. Components are added from the explicit `@shadcn` registry, reviewed after generation, and changed only through semantic variants.
+
+## Site integration
+
+The site imports `@lorelum/ui/globals.css` after Tailwind and explicitly sources the workspace package for class discovery. Fumadocs switches from its standalone neutral palette to its shadcn adapter. Its selector-level adapter stays isolated at `src/features/docs/styles/docs.css` and is loaded only by the Docs screen. No additional provider is mounted.
+
+The existing `ThemeToggle` becomes the first shared Button consumer. Its mount guard, locale label, `next-themes` state, View Transition path, and fallback stay site-owned. This proves SSR and real production consumption without rewriting the navbar or landing composition.
+
+Landing-specific raw colors and special effects are not migrated in this stage. They remain visible debt rather than being silently declared compliant with the new system.
+
+## Verification and rollback
+
+Automated evidence:
+
+- UI package typecheck and `bun:test` cover token parity/contrast and server-rendered component semantics.
+- Root typecheck, lint, and tests cover workspace integration.
+- The production site build proves package exports, Tailwind class discovery, SSR, and prerendering.
+
+Browser evidence checks the landing and docs in English/Chinese and light/dark themes, keyboard focus, theme transition, top/detached navbar states, and touch target size. If integration regresses, revert the site consumer import first; the new private package has no external consumers or stored state.
+
+## Deferred
+
+- Publishing `@lorelum/ui` or providing semantic-version guarantees.
+- A standalone token compiler, registry service, or cross-platform format.
+- Storybook or a public component gallery.
+- Bulk shadcn installation, app shells, tables, forms, and overlay systems without concrete consumers.
+- Landing redesign, Fumadocs replacement, animation-library migration, or movement of WebGL/GSAP effects into shared UI.
+
+These decisions reopen only when a real second consumer, a non-CSS export requirement, or recurring component review work provides evidence for the added lifecycle.

--- a/docs/plans/design-infrastructure.md
+++ b/docs/plans/design-infrastructure.md
@@ -4,7 +4,7 @@
 
 ## Conclusion
 
-Create a private workspace package, `@lorelum/ui`, as the single Web UI ownership boundary. It owns production CSS tokens, Tailwind v4 mappings, and a small set of reviewed shadcn components. The site imports that contract, keeps its existing Fumadocs/next-themes provider, and retains route, locale, navigation-motion, and landing-effects behavior.
+Create a private workspace package, `@lorelum/ui`, as the single Web UI ownership boundary. It owns production CSS tokens, Tailwind v4 mappings, and a small set of reviewed shadcn components. Adoption is explicit: a migrated surface receives the `lorelum-ui` scope, while the provisional Landing keeps its existing Fumadocs theme, route, locale, navigation-motion, and effects behavior.
 
 This stage deliberately avoids a token compiler, Storybook, a second theme provider, and bulk component installation. CSS is already the only confirmed runtime consumer. A larger platform would add generation and release semantics without solving a current problem.
 
@@ -15,14 +15,14 @@ This stage deliberately avoids a token compiler, Storybook, a second theme provi
 - `fumadocs-ui` resolves to `@fumadocs/base-ui`, and `@base-ui/react` is already in the dependency graph. Base UI is therefore the lowest-friction shadcn primitive choice.
 - Fumadocs' `RootProvider` and `next-themes` own the `.dark` class. The existing theme toggle preserves hydration safety and View Transition behavior (`apps/site/src/app/root-document.tsx`, `src/shared/ui/theme-toggle.tsx`).
 - The global stylesheet currently imports Fumadocs' neutral theme, while brand and component values are distributed through `app.css`, landing styles, navigation styles, and vendored component CSS.
-- The site already uses Lucide. The current base-nova generator selects `cn@0.2.6`, so the shared package owns that helper and the site re-exports it rather than keeping a second direct utility dependency. The site retains `cnfast` while legacy landing motion utilities still consume its compatibility export.
+- The site already uses Lucide. The current base-nova generator selects `cn@0.2.6`, so the shared package owns its own helper. The legacy Landing retains its independent `cnfast` compatibility export until that surface is deliberately migrated.
 
 ## Required result
 
 - A stable package import for shared components and tokens.
-- One production source for light/dark semantic roles, with Tailwind and Fumadocs consuming adapters.
+- One production source for light/dark semantic roles, with an explicitly scoped Docs adapter consuming those roles.
 - A reviewed shadcn workflow that writes source into the shared package.
-- At least one real site control consuming the package while preserving its current behavior.
+- At least one real site surface consuming the tokens without changing legacy Landing output.
 - Tests that fail when theme roles drift, required component states disappear, or SSR output loses semantics.
 - No change to Practice, retrieval, CLI, MCP, persistence, or release contracts.
 
@@ -34,7 +34,7 @@ approved brand decisions
         v
 @lorelum/ui tokens.css  -->  theme.css  -->  Tailwind utilities
         |                                  |
-        +--> Fumadocs shadcn adapter        +--> shared components
+        +--> scoped Docs adapter             +--> shared components
                          \                       |
                           +------ apps/site <----+
 ```
@@ -66,7 +66,7 @@ The package is private and source-distributed inside the workspace. React is a p
 `tokens.css` has two runtime layers in one source:
 
 - Foundations use the `--lore-*` prefix: brand palette, typography, spacing roles, radii, blur, shadow, motion, layout, and layer values.
-- Semantic roles use conventional shadcn names: `--background`, `--foreground`, `--primary`, `--accent`, `--border`, `--ring`, feedback roles, chart roles, and sidebar roles. `:root` is light; `.dark` is dark.
+- Semantic roles use conventional shadcn names: `--background`, `--foreground`, `--primary`, `--accent`, `--border`, `--ring`, feedback roles, chart roles, and sidebar roles. `.lorelum-ui` is light; `.dark .lorelum-ui` is dark. This prevents an un-migrated surface from inheriting a new palette by accident.
 
 Primary action colors preserve the approved pair: light uses `#168263` with white; dark uses brand green `#35b88f` with `#10251e`. Blur and surface alpha remain independent. Product code consumes roles, not raw palette steps.
 
@@ -80,9 +80,9 @@ The initial set is Button, Badge, and Separator. They cover commands, status lab
 
 ## Site integration
 
-The site imports `@lorelum/ui/globals.css` after Tailwind and explicitly sources the workspace package for class discovery. Fumadocs switches from its standalone neutral palette to its shadcn adapter. Its selector-level adapter stays isolated at `src/features/docs/styles/docs.css` and is loaded only by the Docs screen. No additional provider is mounted.
+The public site's global stylesheet keeps the existing Fumadocs neutral palette. The Docs feature imports `@lorelum/ui/tokens.css`, applies `lorelum-ui` through `DocsLayout.containerProps`, and maps those inherited values to Fumadocs variables only within `#nd-docs-layout`. No additional provider is mounted.
 
-The existing `ThemeToggle` becomes the first shared Button consumer. Its mount guard, locale label, `next-themes` state, View Transition path, and fallback stay site-owned. This proves SSR and real production consumption without rewriting the navbar or landing composition.
+The existing `ThemeToggle` remains site-owned because it is shared by the provisional Landing and Docs. Its mount guard, locale label, `next-themes` state, View Transition path, and fallback remain untouched. Shared Button consumption is deferred until a surface is deliberately migrated.
 
 Landing-specific raw colors and special effects are not migrated in this stage. They remain visible debt rather than being silently declared compliant with the new system.
 
@@ -94,7 +94,7 @@ Automated evidence:
 - Root typecheck, lint, and tests cover workspace integration.
 - The production site build proves package exports, Tailwind class discovery, SSR, and prerendering.
 
-Browser evidence checks the landing and docs in English/Chinese and light/dark themes, keyboard focus, theme transition, top/detached navbar states, and touch target size. If integration regresses, revert the site consumer import first; the new private package has no external consumers or stored state.
+Browser evidence checks the landing and docs in English/Chinese and light/dark themes, keyboard focus, theme transition, top/detached navbar states, and touch target size. It must also compare Landing's computed Fumadocs color roles before and after a scoped-system change. If integration regresses, remove the affected scope; the new private package has no external consumers or stored state.
 
 ## Deferred
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "oxlint .",
     "fmt": "oxfmt --write .",
     "fmt:check": "oxfmt --check .",
+    "design:lint": "designmd lint DESIGN.md",
     "typecheck": "bun run --filter '*' typecheck && tsc --noEmit -p scripts/release/tsconfig.json",
     "build:native": "bun scripts/native/build-embedding.ts",
     "build:cli": "bun build --compile packages/cli/src/main.ts --outfile dist/lore",
@@ -23,6 +24,7 @@
     "versions:site": "cd apps/site && npx wrangler versions upload"
   },
   "devDependencies": {
+    "@google/design.md": "0.4.0",
     "@types/bun": "1.4.2",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md - packages/ui
+
+The root instructions apply. This package owns reusable Web UI and production design tokens; it does not own routes, locale copy, data fetching, theme state, or page animation.
+
+- Read the root `DESIGN.md` and `docs/plans/design-infrastructure.md` before changing public package exports or token roles.
+- Use `bunx --bun shadcn@latest` from this directory. Check `info`, upstream docs, `add --dry-run`, and diffs before adding or updating an explicit `@shadcn` item.
+- Keep `style`, base, icon library, and aliases aligned with `components.json`. Do not use Radix APIs in this Base UI package.
+- Reuse semantic tokens and existing variants. Call-site `className` is for layout, not replacing component colors or typography.
+- Do not add components speculatively or use `add --all`. A new component needs a real consumer and behavior-focused tests.
+- Keep CSS values in `styles/tokens.css`; `theme.css` only maps them into Tailwind namespaces.
+- Add colocated `bun:test` coverage. Run package typecheck/tests and the site production build after changing components or styles.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -7,5 +7,5 @@ The root instructions apply. This package owns reusable Web UI and production de
 - Keep `style`, base, icon library, and aliases aligned with `components.json`. Do not use Radix APIs in this Base UI package.
 - Reuse semantic tokens and existing variants. Call-site `className` is for layout, not replacing component colors or typography.
 - Do not add components speculatively or use `add --all`. A new component needs a real consumer and behavior-focused tests.
-- Keep CSS values in `styles/tokens.css`; `theme.css` only maps them into Tailwind namespaces.
+- Keep CSS values in `styles/tokens.css`; `theme.css` only maps them into Tailwind namespaces. Tokens are scoped by `.lorelum-ui`; never widen them to `:root` without an explicit whole-app migration.
 - Add colocated `bun:test` coverage. Run package typecheck/tests and the site production build after changing components or styles.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -6,7 +6,10 @@ Private workspace package for Lorelum's reusable Web components and production d
 import { Button } from "@lorelum/ui/components/button";
 ```
 
-The consuming application imports `@lorelum/ui/globals.css` once. It must provide the `.dark` class lifecycle; this package intentionally has no ThemeProvider.
+A consuming surface imports `@lorelum/ui/globals.css` once and applies the
+`lorelum-ui` class to its root. The `.dark` class remains application-owned;
+this package intentionally has no ThemeProvider. Do not add the scope to an
+application root until that entire surface has adopted the semantic tokens.
 
 ## Ownership
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,23 @@
+# @lorelum/ui
+
+Private workspace package for Lorelum's reusable Web components and production design tokens. The root [`DESIGN.md`](../../DESIGN.md) is the agent-readable design contract; this package is its runtime implementation for Web products.
+
+```tsx
+import { Button } from "@lorelum/ui/components/button";
+```
+
+The consuming application imports `@lorelum/ui/globals.css` once. It must provide the `.dark` class lifecycle; this package intentionally has no ThemeProvider.
+
+## Ownership
+
+- `src/styles/tokens.css`: token values and light/dark semantic roles.
+- `src/styles/theme.css`: Tailwind v4 mappings only.
+- `src/styles/globals.css`: stable CSS import entry.
+- `src/components/`: reviewed shadcn source using Base UI and Lucide conventions.
+- `src/lib/utils.ts`: shared `cn` implementation.
+
+Typography roles use `type-*` utilities such as `type-label` and `type-body`. Do not expose them as `text-*`: class-merging tools treat that namespace as text color and may remove the typography role when a semantic foreground class is present.
+
+Design values represented in `DESIGN.md` and `tokens.css` must change together. Run `bun run design:lint` plus this package's tests to catch format, theme-parity, contrast, and Tailwind-mapping drift.
+
+Run `bunx --bun shadcn@latest info --json` here before component work. Add components from an explicit registry only after reading their docs and previewing `--dry-run`.

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "aliases": {
+    "components": "@lorelum/ui/components",
+    "utils": "@lorelum/ui/lib/utils",
+    "ui": "@lorelum/ui/components",
+    "lib": "@lorelum/ui/lib"
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@lorelum/ui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./globals.css": "./src/styles/globals.css",
+    "./tokens.css": "./src/styles/tokens.css",
+    "./components/*": "./src/components/*.tsx",
+    "./lib/utils": "./src/lib/utils.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@base-ui/react": "1.7.0",
+    "class-variance-authority": "0.7.1",
+    "cn": "0.2.6"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "peerDependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  }
+}

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -1,0 +1,51 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../lib/utils";
+
+const badgeVariants = cva(
+  "group/badge type-caption inline-flex h-6 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2.5 whitespace-nowrap outline-none transition-[background-color,color,border-color,box-shadow] duration-[var(--lore-motion-feedback)] ease-[var(--lore-ease-feedback)] focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/35 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-secondary text-foreground [a]:hover:bg-accent [a]:hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-accent [a]:hover:text-accent-foreground",
+        destructive:
+          "bg-destructive text-destructive-foreground focus-visible:ring-destructive/25 [a]:hover:bg-destructive-hover",
+        outline:
+          "border-border-strong text-foreground [a]:hover:bg-accent [a]:hover:text-accent-foreground",
+        ghost: "text-foreground hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:text-primary-hover hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  });
+}
+
+export { Badge, badgeVariants };

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,0 +1,58 @@
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cva, type VariantProps } from "class-variance-authority";
+import { composeClassName } from "../lib/compose-class-name";
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-control border border-transparent bg-clip-padding whitespace-nowrap outline-none select-none transition-[background-color,color,border-color,box-shadow,transform] duration-[var(--lore-motion-feedback)] ease-[var(--lore-ease-feedback)] focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/35 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-pressed",
+        outline:
+          "border-border-strong bg-background text-foreground hover:bg-accent hover:text-accent-foreground active:bg-muted aria-expanded:bg-accent aria-expanded:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-accent hover:text-accent-foreground active:bg-muted aria-expanded:bg-accent aria-expanded:text-accent-foreground",
+        ghost:
+          "text-foreground hover:bg-accent hover:text-accent-foreground active:bg-muted aria-expanded:bg-accent aria-expanded:text-accent-foreground",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive-hover active:bg-destructive-pressed focus-visible:border-destructive focus-visible:ring-destructive/25",
+        link: "text-primary underline-offset-4 hover:text-primary-hover hover:underline",
+      },
+      size: {
+        default:
+          "type-label h-10 gap-2 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+        xs: "type-caption h-8 gap-1.5 rounded-detail px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3.5",
+        sm: "type-label h-9 gap-1.5 px-3 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5",
+        lg: "type-label h-11 gap-2 px-5 has-data-[icon=inline-end]:pr-4 has-data-[icon=inline-start]:pl-4",
+        icon: "type-label size-10",
+        "icon-xs": "type-caption size-8 rounded-detail [&_svg:not([class*='size-'])]:size-3.5",
+        "icon-sm": "type-label size-9",
+        "icon-lg": "type-label size-11 [&_svg:not([class*='size-'])]:size-5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  const baseClassName = buttonVariants({ variant, size });
+
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={composeClassName<ButtonPrimitive.State>(baseClassName, className)}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/packages/ui/src/components/components.test.tsx
+++ b/packages/ui/src/components/components.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Badge } from "./badge";
+import { Button, buttonVariants } from "./button";
+import { Separator } from "./separator";
+
+describe("shared UI components", () => {
+  test("renders a semantic native button on the server", () => {
+    const html = renderToStaticMarkup(<Button type="button">Run query</Button>);
+
+    expect(html).toContain("<button");
+    expect(html).toContain('type="button"');
+    expect(html).toContain('data-slot="button"');
+    expect(html).toContain("type-label");
+    expect(html).toContain("text-primary-foreground");
+    expect(html).toContain("Run query");
+  });
+
+  test("preserves Base UI render composition for links", () => {
+    const html = renderToStaticMarkup(
+      <Button render={<a href="/docs" />} nativeButton={false} variant="link">
+        Documentation
+      </Button>,
+    );
+
+    expect(html).toContain("<a");
+    expect(html).toContain('href="/docs"');
+    expect(html).not.toContain("<button");
+    expect(html).not.toContain('type="button"');
+  });
+
+  test("preserves Base UI's stateful className contract", () => {
+    const html = renderToStaticMarkup(
+      <Button className={(state) => (state.disabled ? "is-disabled" : "is-enabled")}>
+        Callback
+      </Button>,
+    );
+
+    expect(html).toContain("is-enabled");
+    expect(html).toContain("type-label");
+    expect(html).toContain("text-primary-foreground");
+  });
+
+  test("exposes explicit hover, pressed, focus and disabled states", () => {
+    const classes = buttonVariants({ variant: "default" });
+
+    expect(classes).toContain("hover:bg-primary-hover");
+    expect(classes).toContain("active:bg-primary-pressed");
+    expect(classes).toContain("focus-visible:ring-3");
+    expect(classes).toContain("disabled:pointer-events-none");
+  });
+
+  test("assigns exactly one typography role to each button size", () => {
+    const defaultClasses = buttonVariants({ size: "default" });
+    const extraSmallClasses = buttonVariants({ size: "xs" });
+
+    expect(defaultClasses).toContain("type-label");
+    expect(defaultClasses).not.toContain("type-caption");
+    expect(extraSmallClasses).toContain("type-caption");
+    expect(extraSmallClasses).not.toContain("type-label");
+  });
+
+  test("renders badge and separator semantics on the server", () => {
+    const badge = renderToStaticMarkup(<Badge>Indexed</Badge>);
+    const separator = renderToStaticMarkup(
+      <Separator
+        orientation="vertical"
+        className={(state) => (state.orientation === "vertical" ? "is-vertical" : undefined)}
+      />,
+    );
+
+    expect(badge).toContain('data-slot="badge"');
+    expect(badge).toContain("type-caption");
+    expect(badge).toContain("bg-secondary");
+    expect(badge).toContain("Indexed");
+    expect(separator).toContain('role="separator"');
+    expect(separator).toContain('aria-orientation="vertical"');
+    expect(separator).toContain("is-vertical");
+  });
+});

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -1,0 +1,18 @@
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+import { composeClassName } from "../lib/compose-class-name";
+
+const separatorClassName =
+  "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch";
+
+function Separator({ className, orientation = "horizontal", ...props }: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={composeClassName<SeparatorPrimitive.State>(separatorClassName, className)}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,4 @@
+export { Badge, badgeVariants } from "./components/badge";
+export { Button, buttonVariants } from "./components/button";
+export { Separator } from "./components/separator";
+export { cn } from "./lib/utils";

--- a/packages/ui/src/lib/compose-class-name.ts
+++ b/packages/ui/src/lib/compose-class-name.ts
@@ -1,0 +1,11 @@
+import { cn } from "./utils";
+
+type StatefulClassName<State> = string | ((state: State) => string | undefined) | undefined;
+
+export function composeClassName<State>(base: string, className: StatefulClassName<State>) {
+  if (typeof className === "function") {
+    return (state: State) => cn(base, className(state));
+  }
+
+  return cn(base, className);
+}

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,0 +1,1 @@
+export { cn } from "cn";

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1,0 +1,2 @@
+@import "./tokens.css";
+@import "./theme.css";

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -1,0 +1,165 @@
+@theme inline {
+  --font-sans: var(--lore-font-sans);
+  --font-display: var(--lore-font-display);
+  --font-mono: var(--lore-font-mono);
+  --font-weight-normal: var(--lore-font-weight-regular);
+  --font-weight-medium: var(--lore-font-weight-medium);
+  --font-weight-semibold: var(--lore-font-weight-semibold);
+
+  --spacing-inline: var(--lore-space-inline);
+  --spacing-related: var(--lore-space-related);
+  --spacing-control: var(--lore-space-control);
+  --spacing-group: var(--lore-space-group);
+  --spacing-panel: var(--lore-space-panel);
+  --spacing-block: var(--lore-space-block);
+  --spacing-section: var(--lore-space-section);
+
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary-hover: var(--primary-hover);
+  --color-primary-pressed: var(--primary-pressed);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-destructive-hover: var(--destructive-hover);
+  --color-destructive-pressed: var(--destructive-pressed);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  --color-surface: var(--surface);
+  --color-surface-foreground: var(--surface-foreground);
+  --color-surface-raised: var(--surface-raised);
+  --color-surface-sunken: var(--surface-sunken);
+  --color-overlay: var(--overlay);
+  --color-selection: var(--selection);
+  --color-selection-foreground: var(--selection-foreground);
+
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-success-subtle: var(--success-subtle);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-warning-subtle: var(--warning-subtle);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+  --color-info-subtle: var(--info-subtle);
+
+  --color-code: var(--code);
+  --color-code-foreground: var(--code-foreground);
+  --color-code-comment: var(--code-comment);
+  --color-code-keyword: var(--code-keyword);
+  --color-code-string: var(--code-string);
+  --color-code-number: var(--code-number);
+
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-detail: var(--lore-radius-detail);
+  --radius-control: var(--radius);
+  --radius-panel: var(--lore-radius-panel);
+  --radius-stage: var(--lore-radius-stage);
+  --radius-pill: var(--lore-radius-pill);
+
+  --blur-fine: var(--lore-blur-fine);
+  --blur-soft: var(--lore-blur-soft);
+  --blur-glass: var(--lore-blur-glass);
+
+  --ease-feedback: var(--lore-ease-feedback);
+  --ease-emphasized: var(--lore-ease-emphasized);
+
+  --shadow-contact: var(--lore-shadow-contact);
+  --shadow-lift: var(--lore-shadow-lift);
+  --shadow-overlay: var(--lore-shadow-overlay);
+}
+
+@utility type-display {
+  font-family: var(--lore-font-display);
+  font-size: var(--lore-text-display);
+  font-weight: var(--lore-font-weight-semibold);
+  line-height: var(--lore-leading-display);
+}
+
+@utility type-headline {
+  font-family: var(--lore-font-display);
+  font-size: var(--lore-text-headline);
+  font-weight: var(--lore-font-weight-semibold);
+  line-height: var(--lore-leading-headline);
+}
+
+@utility type-title {
+  font-family: var(--lore-font-display);
+  font-size: var(--lore-text-title);
+  font-weight: var(--lore-font-weight-semibold);
+  line-height: var(--lore-leading-title);
+}
+
+@utility type-title-sm {
+  font-family: var(--lore-font-display);
+  font-size: var(--lore-text-title-sm);
+  font-weight: var(--lore-font-weight-semibold);
+  line-height: var(--lore-leading-title-sm);
+}
+
+@utility type-body {
+  font-family: var(--lore-font-sans);
+  font-size: var(--lore-text-body);
+  font-weight: var(--lore-font-weight-regular);
+  line-height: var(--lore-leading-body);
+}
+
+@utility type-body-sm {
+  font-family: var(--lore-font-sans);
+  font-size: var(--lore-text-body-sm);
+  font-weight: var(--lore-font-weight-regular);
+  line-height: var(--lore-leading-body-sm);
+}
+
+@utility type-label {
+  font-family: var(--lore-font-sans);
+  font-size: var(--lore-text-label);
+  font-weight: var(--lore-font-weight-medium);
+  line-height: var(--lore-leading-label);
+}
+
+@utility type-caption {
+  font-family: var(--lore-font-sans);
+  font-size: var(--lore-text-caption);
+  font-weight: var(--lore-font-weight-medium);
+  line-height: var(--lore-leading-caption);
+}
+
+@utility type-code {
+  font-family: var(--lore-font-mono);
+  font-size: var(--lore-text-code);
+  font-weight: var(--lore-font-weight-regular);
+  line-height: var(--lore-leading-code);
+}

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -1,4 +1,4 @@
-:root {
+.lorelum-ui {
   color-scheme: light;
 
   --lore-brand: #35b88f;
@@ -137,7 +137,7 @@
   --sidebar-ring: #167459;
 }
 
-.dark {
+.dark .lorelum-ui {
   color-scheme: dark;
 
   --lore-shadow-contact: 0 2px 4px rgb(0 0 0 / 22%);

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -1,0 +1,211 @@
+:root {
+  color-scheme: light;
+
+  --lore-brand: #35b88f;
+  --lore-brand-deep: #137c65;
+  --lore-brand-light: #65d5a5;
+  --lore-font-sans:
+    "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", sans-serif;
+  --lore-font-display: "Bricolage Grotesque", var(--lore-font-sans);
+  --lore-font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  --lore-font-weight-regular: 400;
+  --lore-font-weight-medium: 500;
+  --lore-font-weight-semibold: 600;
+  --lore-text-caption: 0.75rem;
+  --lore-text-body-sm: 0.875rem;
+  --lore-text-body: 1rem;
+  --lore-text-code: 0.8125rem;
+  --lore-text-label: 0.875rem;
+  --lore-text-title-sm: 1.125rem;
+  --lore-text-title: 1.5rem;
+  --lore-text-headline: 2.5rem;
+  --lore-text-display: 3.5rem;
+  --lore-leading-caption: 1rem;
+  --lore-leading-body-sm: 1.25rem;
+  --lore-leading-body: 1.625rem;
+  --lore-leading-code: 1.25rem;
+  --lore-leading-label: 1.25rem;
+  --lore-leading-title-sm: 1.5rem;
+  --lore-leading-title: 2rem;
+  --lore-leading-headline: 2.75rem;
+  --lore-leading-display: 3.75rem;
+
+  --lore-space-inline: 0.5rem;
+  --lore-space-related: 0.75rem;
+  --lore-space-control: 1rem;
+  --lore-space-group: 1.5rem;
+  --lore-space-panel: 2rem;
+  --lore-space-block: 3rem;
+  --lore-space-section: 6rem;
+
+  --radius: 0.75rem;
+  --lore-radius-detail: 0.375rem;
+  --lore-radius-panel: 1.25rem;
+  --lore-radius-stage: 2rem;
+  --lore-radius-pill: 9999px;
+
+  --lore-blur-fine: 0.5rem;
+  --lore-blur-soft: 1rem;
+  --lore-blur-glass: 1.75rem;
+  --lore-shadow-contact: 0 2px 4px rgb(16 37 30 / 7%);
+  --lore-shadow-lift: 0 2px 6px rgb(16 37 30 / 3%), 0 12px 32px -8px rgb(16 37 30 / 12%);
+  --lore-shadow-overlay: 0 16px 48px rgb(24 37 31 / 12%);
+
+  --lore-motion-feedback: 180ms;
+  --lore-motion-theme: 240ms;
+  --lore-motion-layout: 420ms;
+  --lore-ease-feedback: cubic-bezier(0.2, 0.75, 0.25, 1);
+  --lore-ease-emphasized: cubic-bezier(0.16, 1, 0.3, 1);
+
+  --lore-size-icon-sm: 1rem;
+  --lore-size-icon-md: 1.25rem;
+  --lore-size-icon-lg: 1.5rem;
+  --lore-size-control-sm: 2rem;
+  --lore-size-control-md: 2.5rem;
+  --lore-size-control-lg: 2.75rem;
+  --lore-size-touch: 2.75rem;
+  --lore-reading-width: 68ch;
+  --lore-content-width: 75rem;
+  --lore-layer-sticky: 10;
+  --lore-layer-popover: 30;
+  --lore-layer-modal: 50;
+  --lore-layer-toast: 60;
+
+  --background: #f8f9fa;
+  --foreground: #202326;
+  --card: #ffffff;
+  --card-foreground: #202326;
+  --popover: #ffffff;
+  --popover-foreground: #202326;
+  --primary: #168263;
+  --primary-foreground: #ffffff;
+  --primary-hover: #127457;
+  --primary-pressed: #0f644c;
+  --secondary: #f0f1f2;
+  --secondary-foreground: #303940;
+  --muted: #f0f1f2;
+  --muted-foreground: #656c73;
+  --accent: #eef0f2;
+  --accent-foreground: #176e55;
+  --destructive: #b43939;
+  --destructive-foreground: #ffffff;
+  --destructive-hover: #9e3030;
+  --destructive-pressed: #862727;
+  --border: #dfe2e5;
+  --border-strong: #b4bcc4;
+  --input: #7c838a;
+  --ring: #167459;
+
+  --surface: #ffffff;
+  --surface-foreground: #202326;
+  --surface-raised: #f0f1f2;
+  --surface-sunken: #e9ecef;
+  --overlay: rgb(16 24 32 / 50%);
+  --selection: #c5e9db;
+  --selection-foreground: #153e30;
+
+  --success: #246c46;
+  --success-foreground: #ffffff;
+  --success-subtle: #eaf5ed;
+  --warning: #845615;
+  --warning-foreground: #ffffff;
+  --warning-subtle: #fff3dc;
+  --info: #355f9b;
+  --info-foreground: #ffffff;
+  --info-subtle: #edf3fc;
+
+  --code: #f0f1f2;
+  --code-foreground: #303940;
+  --code-comment: #646d76;
+  --code-keyword: #73529a;
+  --code-string: #176e55;
+  --code-number: #8b561b;
+
+  --chart-1: #168263;
+  --chart-2: #355f9b;
+  --chart-3: #73529a;
+  --chart-4: #845615;
+  --chart-5: #b43939;
+
+  --sidebar: #ffffff;
+  --sidebar-foreground: #202326;
+  --sidebar-primary: #168263;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #eef0f2;
+  --sidebar-accent-foreground: #176e55;
+  --sidebar-border: #dfe2e5;
+  --sidebar-ring: #167459;
+}
+
+.dark {
+  color-scheme: dark;
+
+  --lore-shadow-contact: 0 2px 4px rgb(0 0 0 / 22%);
+  --lore-shadow-lift: 0 2px 6px rgb(0 0 0 / 16%), 0 12px 32px -8px rgb(0 0 0 / 45%);
+  --lore-shadow-overlay: 0 16px 48px rgb(0 0 0 / 28%);
+
+  --background: #141618;
+  --foreground: #f0f2f4;
+  --card: #1c1f22;
+  --card-foreground: #f0f2f4;
+  --popover: #292e33;
+  --popover-foreground: #f0f2f4;
+  --primary: #35b88f;
+  --primary-foreground: #10251e;
+  --primary-hover: #48c39c;
+  --primary-pressed: #2faa83;
+  --secondary: #262a2e;
+  --secondary-foreground: #f0f2f4;
+  --muted: #262a2e;
+  --muted-foreground: #a4acb4;
+  --accent: #2a2e33;
+  --accent-foreground: #f0f2f4;
+  --destructive: #f29e9e;
+  --destructive-foreground: #351619;
+  --destructive-hover: #ffb0b0;
+  --destructive-pressed: #dd8989;
+  --border: #363c42;
+  --border-strong: #59636d;
+  --input: #818b95;
+  --ring: #35b88f;
+
+  --surface: #1c1f22;
+  --surface-foreground: #f0f2f4;
+  --surface-raised: #262a2e;
+  --surface-sunken: #101214;
+  --overlay: rgb(0 0 0 / 65%);
+  --selection: #245542;
+  --selection-foreground: #edf9f3;
+
+  --success: #89d3a5;
+  --success-foreground: #10251e;
+  --success-subtle: #1a3225;
+  --warning: #e6bc74;
+  --warning-foreground: #2d200d;
+  --warning-subtle: #352b1c;
+  --info: #a6c5f2;
+  --info-foreground: #13253d;
+  --info-subtle: #202e42;
+
+  --code: #101214;
+  --code-foreground: #dfe5eb;
+  --code-comment: #a4acb4;
+  --code-keyword: #c4ace9;
+  --code-string: #7dd9b1;
+  --code-number: #e6bc74;
+
+  --chart-1: #35b88f;
+  --chart-2: #a6c5f2;
+  --chart-3: #c4ace9;
+  --chart-4: #e6bc74;
+  --chart-5: #f29e9e;
+
+  --sidebar: #1c1f22;
+  --sidebar-foreground: #f0f2f4;
+  --sidebar-primary: #35b88f;
+  --sidebar-primary-foreground: #10251e;
+  --sidebar-accent: #2a2e33;
+  --sidebar-accent-foreground: #f0f2f4;
+  --sidebar-border: #363c42;
+  --sidebar-ring: #35b88f;
+}

--- a/packages/ui/src/styles/tokens.test.ts
+++ b/packages/ui/src/styles/tokens.test.ts
@@ -67,8 +67,8 @@ const requiredSemanticRoles = [
   "sidebar-ring",
 ] as const;
 
-function declarations(selector: ":root" | ".dark") {
-  const escapedSelector = selector.replace(".", "\\.");
+function declarations(selector: ".lorelum-ui" | ".dark .lorelum-ui") {
+  const escapedSelector = selector.replaceAll(".", "\\.");
   const block = tokensCss.match(new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\n\\}`))?.[1];
   if (!block) throw new Error(`Missing ${selector} token block`);
 
@@ -104,9 +104,11 @@ function contrastRatio(foreground: string, background: string) {
 }
 
 describe("design tokens", () => {
-  test("keeps required semantic roles in parity across themes", () => {
-    const light = declarations(":root");
-    const dark = declarations(".dark");
+  test("keeps required semantic roles inside an explicit consumer scope", () => {
+    expect(tokensCss).not.toMatch(/:root\s*\{/);
+
+    const light = declarations(".lorelum-ui");
+    const dark = declarations(".dark .lorelum-ui");
 
     for (const role of requiredSemanticRoles) {
       expect(light.has(role), `light theme is missing --${role}`).toBe(true);
@@ -115,7 +117,7 @@ describe("design tokens", () => {
   });
 
   test("keeps action foreground pairs at WCAG AA contrast", () => {
-    for (const theme of [declarations(":root"), declarations(".dark")]) {
+    for (const theme of [declarations(".lorelum-ui"), declarations(".dark .lorelum-ui")]) {
       for (const role of ["primary", "destructive", "success", "warning", "info"] as const) {
         const background = theme.get(role);
         const foreground = theme.get(`${role}-foreground`);
@@ -141,7 +143,7 @@ describe("design tokens", () => {
   });
 
   test("keeps readable semantic text pairs at WCAG AA contrast", () => {
-    for (const theme of [declarations(":root"), declarations(".dark")]) {
+    for (const theme of [declarations(".lorelum-ui"), declarations(".dark .lorelum-ui")]) {
       for (const [backgroundRole, foregroundRole] of [
         ["background", "foreground"],
         ["card", "card-foreground"],
@@ -173,8 +175,8 @@ describe("design tokens", () => {
   });
 
   test("keeps the primary action contract aligned with DESIGN.md", () => {
-    const light = declarations(":root");
-    const dark = declarations(".dark");
+    const light = declarations(".lorelum-ui");
+    const dark = declarations(".dark .lorelum-ui");
 
     expect(light.get("primary")?.toLowerCase()).toBe(designColor("light-primary"));
     expect(light.get("primary-foreground")?.toLowerCase()).toBe(

--- a/packages/ui/src/styles/tokens.test.ts
+++ b/packages/ui/src/styles/tokens.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const tokensCss = readFileSync(new URL("./tokens.css", import.meta.url), "utf8");
+const themeCss = readFileSync(new URL("./theme.css", import.meta.url), "utf8");
+const designMd = readFileSync(new URL("../../../../DESIGN.md", import.meta.url), "utf8");
+
+const requiredSemanticRoles = [
+  "background",
+  "foreground",
+  "card",
+  "card-foreground",
+  "popover",
+  "popover-foreground",
+  "primary",
+  "primary-foreground",
+  "primary-hover",
+  "primary-pressed",
+  "secondary",
+  "secondary-foreground",
+  "muted",
+  "muted-foreground",
+  "accent",
+  "accent-foreground",
+  "destructive",
+  "destructive-foreground",
+  "destructive-hover",
+  "destructive-pressed",
+  "border",
+  "border-strong",
+  "input",
+  "ring",
+  "surface",
+  "surface-foreground",
+  "surface-raised",
+  "surface-sunken",
+  "overlay",
+  "selection",
+  "selection-foreground",
+  "success",
+  "success-foreground",
+  "success-subtle",
+  "warning",
+  "warning-foreground",
+  "warning-subtle",
+  "info",
+  "info-foreground",
+  "info-subtle",
+  "code",
+  "code-foreground",
+  "code-comment",
+  "code-keyword",
+  "code-string",
+  "code-number",
+  "chart-1",
+  "chart-2",
+  "chart-3",
+  "chart-4",
+  "chart-5",
+  "sidebar",
+  "sidebar-foreground",
+  "sidebar-primary",
+  "sidebar-primary-foreground",
+  "sidebar-accent",
+  "sidebar-accent-foreground",
+  "sidebar-border",
+  "sidebar-ring",
+] as const;
+
+function declarations(selector: ":root" | ".dark") {
+  const escapedSelector = selector.replace(".", "\\.");
+  const block = tokensCss.match(new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\n\\}`))?.[1];
+  if (!block) throw new Error(`Missing ${selector} token block`);
+
+  return new Map(
+    Array.from(block.matchAll(/--([\w-]+):\s*([^;]+);/g), (match) => [match[1]!, match[2]!.trim()]),
+  );
+}
+
+function designColor(name: string) {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const value = designMd.match(new RegExp(`^  ${escapedName}: "(#[0-9A-Fa-f]{6})"$`, "m"))?.[1];
+  if (!value) throw new Error(`Missing DESIGN.md color token: ${name}`);
+  return value.toLowerCase();
+}
+
+function relativeLuminance(hex: string) {
+  const channels = [1, 3, 5].map(
+    (offset) => Number.parseInt(hex.slice(offset, offset + 2), 16) / 255,
+  );
+  const linear = channels.map((channel) =>
+    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
+  );
+  return 0.2126 * linear[0]! + 0.7152 * linear[1]! + 0.0722 * linear[2]!;
+}
+
+function contrastRatio(foreground: string, background: string) {
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+}
+
+describe("design tokens", () => {
+  test("keeps required semantic roles in parity across themes", () => {
+    const light = declarations(":root");
+    const dark = declarations(".dark");
+
+    for (const role of requiredSemanticRoles) {
+      expect(light.has(role), `light theme is missing --${role}`).toBe(true);
+      expect(dark.has(role), `dark theme is missing --${role}`).toBe(true);
+    }
+  });
+
+  test("keeps action foreground pairs at WCAG AA contrast", () => {
+    for (const theme of [declarations(":root"), declarations(".dark")]) {
+      for (const role of ["primary", "destructive", "success", "warning", "info"] as const) {
+        const background = theme.get(role);
+        const foreground = theme.get(`${role}-foreground`);
+        expect(background).toMatch(/^#[0-9a-f]{6}$/i);
+        expect(foreground).toMatch(/^#[0-9a-f]{6}$/i);
+        expect(contrastRatio(foreground!, background!), `${role} contrast`).toBeGreaterThanOrEqual(
+          4.5,
+        );
+      }
+
+      for (const [backgroundRole, foregroundRole] of [
+        ["primary-hover", "primary-foreground"],
+        ["primary-pressed", "primary-foreground"],
+        ["destructive-hover", "destructive-foreground"],
+        ["destructive-pressed", "destructive-foreground"],
+      ] as const) {
+        expect(
+          contrastRatio(theme.get(foregroundRole)!, theme.get(backgroundRole)!),
+          `${backgroundRole} contrast`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+
+  test("keeps readable semantic text pairs at WCAG AA contrast", () => {
+    for (const theme of [declarations(":root"), declarations(".dark")]) {
+      for (const [backgroundRole, foregroundRole] of [
+        ["background", "foreground"],
+        ["card", "card-foreground"],
+        ["popover", "popover-foreground"],
+        ["secondary", "secondary-foreground"],
+        ["muted", "muted-foreground"],
+        ["accent", "accent-foreground"],
+        ["surface", "surface-foreground"],
+        ["selection", "selection-foreground"],
+        ["code", "code-foreground"],
+        ["sidebar", "sidebar-foreground"],
+        ["sidebar-primary", "sidebar-primary-foreground"],
+        ["sidebar-accent", "sidebar-accent-foreground"],
+      ] as const) {
+        expect(
+          contrastRatio(theme.get(foregroundRole)!, theme.get(backgroundRole)!),
+          `${foregroundRole} on ${backgroundRole}`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+
+  test("maps semantic roles to Tailwind without duplicating palette values", () => {
+    expect(themeCss).not.toMatch(/#[0-9a-f]{3,8}\b/i);
+
+    for (const role of requiredSemanticRoles) {
+      expect(themeCss).toContain(`--color-${role}: var(--${role});`);
+    }
+  });
+
+  test("keeps the primary action contract aligned with DESIGN.md", () => {
+    const light = declarations(":root");
+    const dark = declarations(".dark");
+
+    expect(light.get("primary")?.toLowerCase()).toBe(designColor("light-primary"));
+    expect(light.get("primary-foreground")?.toLowerCase()).toBe(
+      designColor("light-primary-foreground"),
+    );
+    expect(dark.get("primary")?.toLowerCase()).toBe(designColor("primary"));
+    expect(dark.get("primary-foreground")?.toLowerCase()).toBe(
+      designColor("dark-primary-foreground"),
+    );
+  });
+
+  test("defines each foundation needed by reusable components", () => {
+    for (const prefix of [
+      "--lore-font-",
+      "--lore-text-",
+      "--lore-leading-",
+      "--lore-space-",
+      "--lore-radius-",
+      "--lore-blur-",
+      "--lore-shadow-",
+      "--lore-motion-",
+      "--lore-ease-",
+      "--lore-size-",
+      "--lore-layer-",
+    ]) {
+      expect(tokensCss).toContain(prefix);
+    }
+  });
+});

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "paths": {
+      "@lorelum/ui/*": ["./src/*"]
+    }
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,7 +23,9 @@
       "@lorelum/format": ["./packages/format/src/index.ts"],
       "@lorelum/engine": ["./packages/engine/src/index.ts"],
       "@lorelum/mcp": ["./packages/mcp/src/index.ts"],
-      "@lorelum/cli": ["./packages/cli/src/index.ts"]
+      "@lorelum/cli": ["./packages/cli/src/index.ts"],
+      "@lorelum/ui": ["./packages/ui/src/index.ts"],
+      "@lorelum/ui/*": ["./packages/ui/src/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Establishes Lorelum-owned Web design infrastructure on top of the feature-based site architecture: a Google DESIGN.md-compatible contract, private `@lorelum/ui` workspace package, semantic light/dark tokens, and a small reviewed primitive set.

The public Landing remains on its existing neutral Fumadocs theme. Design tokens are opt-in through the `lorelum-ui` scope; the Docs layout is the first migrated surface and maps its scoped tokens to Fumadocs roles inside `#nd-docs-layout`. The Docs adapter also gives numbered Fumadocs Steps explicit vertical spacing, so adjacent markers remain visually distinct.

## Linked issue

Closes #86

## Type of change

- [ ] 🐛 Bug fix (non-breaking)
- [x] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change (fix or feature that would cause existing behavior to change)
- [ ] 📚 Docs only
- [ ] 🔧 Refactor / chore

## How was this tested?

- `bun install` — resolved against current `main`; lockfile was already current.
- `bun run design:lint` — 0 errors; 27 expected orphaned-token warnings for the intentionally broader contract.
- `bun run typecheck` — all nine workspaces and the release scripts project passed.
- `bun test` — 642 tests passed across 103 files, including regressions that reject global token imports, unscoped token declarations, and visually connected Steps markers.
- `bun run lint` — passed with the two existing `_splat` naming warnings.
- `bun run build:site` — client, SSR, and prerender build passed (`/` and `/en/docs`).
- Rebase review — `git diff --check` and a changed-lines secret-pattern scan passed; the range diff confirms that the conflict resolution retains both `design:lint` / `@google/design.md` and main's release typecheck and build scripts.

## Checklist

- [x] Linked the issue this closes (`Closes #xxx`)
- [ ] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed in the issue / Discussions first
- [x] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

## AI assistance and review

- [x] This PR used AI assistance (design-contract drafting, package/component implementation, rebase conflict resolution, regression fixes, tests, and integration review).
- [x] If AI-assisted: an AI code review covered the changed behavior and edge cases; material findings are resolved or documented below

Three read-only reviews were used for the rebase: architecture/path ownership, deployment and dependency scope, and token integration. A follow-up root-cause review found that global token import and the Fumadocs shadcn adapter recolored the legacy Landing. The fix restores the neutral global theme, returns Landing utilities to their independent compatibility path, scopes token declarations, and adds regression coverage for that boundary and Fumadocs Steps spacing.

## Notes for reviewers

Please focus on the scope contract: `tokens.css` defines values only under `.lorelum-ui`; Docs adds that class to `DocsLayout.containerProps`; and the adapter maps Fumadocs roles only inside `#nd-docs-layout`. The ThemeToggle remains site-owned until a whole consumer surface is explicitly migrated.

This branch was rebased onto `4de892f` (#108) and force-updated with lease. The package conflict intentionally preserves main's release scripts and extends them with `design:lint`; `@types/bun` remains `1.4.2`. The initial DESIGN.md intentionally defines more semantic roles than Button, Badge, and Separator consume, so `designmd lint` warns about orphaned roles without schema errors. Publishing the package, Storybook, bulk component installation, and Landing redesign remain out of scope.
