### PR TITLE
ci(site): require manual production deploys

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,20 +1,11 @@
 name: Deploy site
 
-# Auto-deploy only when the landing/docs site or its build inputs change.
-# Path filtering is a GitHub-native feature; Workers Builds has no equivalent,
-# which is why auto-deploy runs here instead of Cloudflare-side (see
-# docs/site-deploy.md).
+# Production deployment is an explicit release action. Merging to main does not
+# publish the site; run this workflow manually after the target ref is verified.
 on:
-  push:
-    branches: [main]
-    paths:
-      - "apps/site/**"
-      - "bun.lock" # dependency changes must reach the live site
-      - "package.json" # root workspace scripts and deps feed the build
-  workflow_dispatch: {} # manual redeploy without path filtering
+  workflow_dispatch: {}
 
-# One deploy at a time; a superseded in-progress deploy is cancelled so the
-# newest commit always wins.
+# One deploy at a time; a newer manual request supersedes an in-progress run.
 concurrency:
   group: deploy-site
   cancel-in-progress: true

--- a/apps/site/AGENTS.md
+++ b/apps/site/AGENTS.md
@@ -61,5 +61,6 @@ bun run lint
 
 ## Deployment
 
-GitHub Actions deploys `main` on `apps/site` path matches only. See
+Production deployment is manual through the `Deploy site` GitHub Actions
+workflow. Merging to `main` does not deploy automatically. See
 [`docs/development/site-deploy.md`](../../docs/development/site-deploy.md).

--- a/docs/development/site-deploy.md
+++ b/docs/development/site-deploy.md
@@ -2,8 +2,8 @@
 
 > **适用范围**：`apps/site`（Lorelum 官网：Landing + Docs）。
 > **线上地址**：https://lorelum.com
-> **部署目标**：Cloudflare **Workers**（项目名 `lorelum`），自动部署走 **GitHub Actions**（`.github/workflows/deploy-site.yml`，带路径过滤），手动部署走 `wrangler deploy` 直传。
-> **更新日期**：2026-09-09
+> **部署目标**：Cloudflare **Workers**（项目名 `lorelum`），正式发布通过 **GitHub Actions 手动触发**（`.github/workflows/deploy-site.yml`），本地应急发布可用 `wrangler deploy` 直传。
+> **更新日期**：2026-09-10
 
 ## 1. 部署形态（先搞清楚再动手）
 
@@ -13,16 +13,16 @@
 - `wrangler.jsonc` 的 `main` 指向 `@tanstack/react-start/server-entry`
 - Cloudflare 后台项目类型是 **Worker**（不是 Pages）；线上地址 `https://lorelum.com` 由后台为 Worker 绑定的自定义域提供
 
-**常见误区**：本项目不走 Cloudflare Pages，也不再用 Workers Builds 的 Git 集成自动构建。自动部署由 GitHub Actions 触发（公开仓库免费），Cloudflare 端只接收 `wrangler deploy` 直传。
+**常见误区**：本项目不走 Cloudflare Pages，也不使用 push 自动部署。Workers Builds 的 Git 集成已断开；只有明确运行 GitHub Actions 的 `Deploy site` workflow，或在本地执行 `wrangler deploy`，才会更新线上 Worker。
 
 ## 2. 两种上线方式
 
 | 方式 | 触发 | 成本 | 适用场景 |
 |---|---|---|---|
-| **自动部署** | push 到 `main` 且改动命中 `apps/site/**`、`bun.lock`、`package.json` | GitHub Actions（公开仓库免费） | 正式发布 |
-| **手动直传** | 本地 `bun run build:site && bun run deploy:site` | 无 | 日常迭代看线上效果 |
+| **Actions 手动发布** | Actions → Deploy site → Run workflow | GitHub Actions（公开仓库免费） | 已验证 commit 的正式发布 |
+| **本地直传** | 本地 `bun run build:site && bun run deploy:site` | 无 | 有明确需要的应急发布 |
 
-自动部署的路径过滤是 GitHub 原生能力（`on.push.paths`）；Workers Builds 没有等价功能（截至 2026-09：后台构建设置与 wrangler schema 均无路径过滤项），这是自动部署从 Cloudflare 端迁到 GitHub Actions 的原因。改 `packages/*` 等站点无关路径不会触发任何部署。
+合并和发布现在是两个独立动作。任何 push，包括 push 到 `main`，都不会触发生产部署；发布者必须在 Actions 中明确选择目标 ref 并运行 workflow。
 
 ## 3. 日常迭代工作流（推荐，零配额消耗）
 
@@ -42,46 +42,48 @@ cd apps/site && bun run preview             # vite preview 预览产物
 # 或验证 Worker 运行时：
 cd apps/site && npx wrangler dev --port 8788
 
-# 4) 想看线上效果 → 手动直传（不经过 Workers Builds，零配额）
-bun run build:site && bun run deploy:site
+# 4) 日常迭代到本地生产预览结束；不要把线上部署当作预览手段
 ```
 
-手动直传会立即更新线上站点（`lorelum.com`）；改动请先在本地验证（第 3 步），确认后再发布。
+正式发布按第 6 节手动运行 GitHub Actions。`bun run deploy:site` 会立即更新 `lorelum.com`，只作为有明确需要的应急路径。
 
 ## 4. 成本说明
 
-- 自动部署跑在 **GitHub Actions**：公开仓库免费，无分钟数顾虑。
+- 正式发布按需运行在 **GitHub Actions**，不会因每次合并自动消耗构建时间。
 - Workers Builds（Cloudflare 端构建）的 Git 集成已断开（见 §5），不再产生构建分钟消耗；免费档 3,000 build 分钟/月 的配额因此与本部署流程无关。
-- 手动直传同 §2，不消耗任何配额。
+- 本地直传同 §2，不消耗 GitHub Actions 或 Workers Builds 配额。
 
-## 5. 自动部署现状（GitHub Actions）
+## 5. 手动部署现状（GitHub Actions）
 
-自动部署由 `.github/workflows/deploy-site.yml` 驱动：
+正式发布由 `.github/workflows/deploy-site.yml` 驱动：
 
 | 项 | 值 | 说明 |
 |---|---|---|
-| 触发 | push 到 `main` | 仅当改动命中 `apps/site/**`、`bun.lock`、`package.json` |
-| 手动触发 | `workflow_dispatch` | GitHub 页面 Actions → Deploy site → Run workflow，可跳过路径过滤强制重部署 |
-| 并发控制 | `concurrency: deploy-site` + `cancel-in-progress` | 连续 push 时旧部署取消，最新 commit 胜出 |
+| 触发 | `workflow_dispatch` | GitHub 页面 Actions → Deploy site → Run workflow；push 不触发 |
+| 目标版本 | Run workflow 时选择的 ref | 正式发布通常选择已通过 CI 的 `main` |
+| 并发控制 | `concurrency: deploy-site` + `cancel-in-progress` | 新的手动发布请求会取消仍在执行的旧部署 |
 | 认证 | GitHub `production` Environment secrets：`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` | Token 为 Cloudflare 后台创建的专用 deploy token |
 
-> 2026-09-09 之前自动部署走 Workers Builds Git 集成，任何 push 到 `main`（无论是否涉及站点）都会触发 Cloudflare 端构建。因 Workers Builds 不支持路径过滤，改为 GitHub Actions 方案，并在 Cloudflare 后台断开了 `lorelum` Worker 的 Git 集成（Settings → Build → Git repository → Manage → 断开），避免双路径重复部署。
+> 2026-09-10 起，GitHub Actions 也不再响应 push。Workers Builds 的 Git 集成继续保持断开，避免出现绕过人工发布动作的第二条自动部署路径。
 
-### 调整方式
+### 操作方式
 
-- **改触发路径**：编辑 `deploy-site.yml` 的 `on.push.paths`。
-- **需要 Cloudflare 端自动构建时**：重新在后台连接 Git 仓库即可，但建议先停用本 workflow，避免两边同时部署。
-- **强制重部署**：Actions → Deploy site → Run workflow（不受路径过滤限制）。
+- **正式发布**：Actions → Deploy site → Run workflow，选择已经完成验证的 ref 后运行。
+- **CLI 触发**：`gh workflow run deploy-site.yml --ref main`，随后到 Actions 页面核对目标 SHA 和结果。
+- **恢复自动部署**：需要重新评审发布风险，并确保 GitHub Actions 与 Cloudflare 端只有一条自动部署路径。
 
 ## 6. 正式发布（Go Live）
 
 ```bash
-# 在 feature 分支完成开发、验证后合并到 main
+# 在 feature 分支完成开发、验证后合并到 main；此时不会自动上线
 git checkout main && git merge feat/xxx
-git push origin main        # 改动命中路径过滤时，GitHub Actions 自动构建 + 部署
+git push origin main
+
+# 明确发布已验证的 main
+gh workflow run deploy-site.yml --ref main
 ```
 
-未命中路径过滤但需要重部署时，用 Actions 页面的 `workflow_dispatch` 手动触发，或本地直传：
+发布后在 Actions 页面确认 workflow 对应的 commit SHA 与预期一致。仅在有明确应急需要时使用本地直传：
 
 ```bash
 bun run build:site && bun run deploy:site
@@ -99,10 +101,10 @@ bun run build:site && bun run deploy:site
 
 ## 8. 已知问题 / 排障
 
-- **自动部署没触发**：确认 push 的是 `main` 且改动命中 `on.push.paths`；到仓库 **Actions → Deploy site** 查看运行记录（被路径过滤跳过的 push 不会产生任何 run）。
+- **push 后没有部署**：这是预期行为；到 Actions → Deploy site 手动运行 workflow。
+- **Run workflow 不可用**：确认 workflow 已存在于默认分支且当前账号具有 Actions 运行权限。
 - **认证失败（Authentication error）**：检查 repo secrets `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` 是否有效；Token 在 Cloudflare 后台 My Profile → API Tokens 管理。
-- **需要跳过某次 push 的部署**：commit message 里加 `[skip ci]`（GitHub Actions 原生支持，会同时跳过 CI）。
-- **配额查询**：自动部署跑 GitHub Actions（公开仓库免费）；Cloudflare 端构建历史在 Workers & Pages → `lorelum` → Deployments。
+- **配额查询**：手动部署按需运行在 GitHub Actions；Cloudflare 端构建历史在 Workers & Pages → `lorelum` → Deployments。
 
 ## 关联
 


### PR DESCRIPTION
## Summary

Makes the production site deployment workflow manual-only by removing its `push` trigger and retaining `workflow_dispatch`. Updates the site agent guidance and deployment runbook so merging to `main` and publishing to Cloudflare are explicitly separate actions.

## Linked issue

Closes #89

## Type of change

- [ ] 🐛 Bug fix (non-breaking)
- [ ] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change (fix or feature that would cause existing behavior to change)
- [ ] 📚 Docs only
- [x] 🔧 Refactor / chore

## How was this tested?

- Parsed `.github/workflows/deploy-site.yml` successfully as YAML.
- Asserted that the workflow's only trigger is `workflow_dispatch` and that no `push` trigger remains.
- Confirmed the build step, `production` Environment, Cloudflare secret bindings, deploy command, and concurrency settings remain intact.
- `bun run typecheck` — all workspaces passed.
- `bun run lint` — passed with the two existing `_splat` naming warnings.
- `bun test` — 439 existing tests passed across 66 files.
- `bun run build:site` — client, SSR, and prerender build passed.
- `git diff --check` and staged secret-pattern scan passed.

No test file was added for this configuration-only change. No deployment workflow was run; this PR changes when deployment is authorized, not the deployed application.

## Checklist

- [x] Linked the issue this closes (`Closes #xxx`)
- [x] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed in the issue / Discussions first
- [ ] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

## AI assistance and review

- [x] This PR used AI assistance (workflow edit, deployment-runbook update, verification, and PR preparation).
- [x] If AI-assisted: an AI code review covered the changed behavior and edge cases; material findings are resolved or documented below

The complete three-file diff was reviewed against Issue #89. Verification covered trigger exclusivity, YAML syntax, unchanged production credential/environment boundaries, stale automatic-deployment wording, and the repository test/build gates. No material findings remain.

## Notes for reviewers

The workflow still supports selecting a ref through GitHub's Run workflow UI; the runbook recommends deploying only a `main` commit that has already passed CI. `cancel-in-progress` remains enabled, so a newer explicit deployment request supersedes an older in-progress request. Workers Builds should remain disconnected to avoid a second automatic deployment path.
