### PR TITLE
feat(cli): 新增基于 LocalStore 的 lore list 目录发现能力

### DIFF
--- a/docs/adr/0014-list-catalog-contract.md
+++ b/docs/adr/0014-list-catalog-contract.md
@@ -1,0 +1,96 @@
+# ADR 0014: LocalStore-backed lore list catalog contract
+
+- **Date:** 2026-09-08
+- **Status:** Proposed (local implementation)
+- **Related:** ADR 0003 (Practice format), ADR 0004 (agent-first CLI protocol), ADR 0007 (LocalStore), ADR 0011 (LocalStore point-read and query boundary), ADR 0012 (persistent keyword index), ADR 0013 (incremental LocalStore projection writes)
+
+## Context
+
+`install`, `query`, and `get` make an installed LocalStore useful only after the caller already knows a Pack name or Practice id. A new conversation often has neither. The owner has confirmed the missing entry point: an agent first discovers installed knowledge, then narrows to one Pack's Practice catalog, and finally uses `lore get` for the full Practice.
+
+The target workflow is:
+
+```text
+lore list                  # discover installed Packs
+lore list --pack <name>    # inspect that Pack's Practice summaries
+lore get <practice-id>     # retrieve the complete Practice
+```
+
+`list` is therefore a catalog command, not a task-retrieval command. `query` remains the entry point for finding Practices from task text. An explicit Pack path or Registry lookup would recreate discovery outside LocalStore and split the runtime source of truth.
+
+This ADR defines the CLI/engine catalog contract only. It does not define how an
+Agent learns that Lorelum exists or when a Skill, Plugin, Hook, or MCP adapter
+should invoke `lore list`; those integrations require separate contracts.
+
+## Decision
+
+### Command surface
+
+```text
+lore list [--store-root <path>]
+lore list --pack <name> [--store-root <path>]
+```
+
+Without `--pack`, the command returns every active local Pack. With `--pack`, it returns that Pack's Practice catalog. Both modes honor the global `--store-root` option through the same invocation Store resolution as `install`, `query`, and `get`.
+
+### Application boundary
+
+`@lorelum/engine` exposes a List application service and deterministic pure projections:
+
+- `LocalStore.open()` includes a minimal `InstalledPackSummary[]` (`name`, `version`) from the verified active manifest;
+- Pack version is owned by the active-manifest Pack summary. `EffectivePractice.sources[]` carries the Practice-to-Pack provenance (`packName`, source path, and digests) and intentionally does not repeat Pack version;
+- `retrievePacks()` combines those summaries with Effective Practice source claims;
+- `retrievePackPractices()` returns only Practices for which the selected Pack has a source claim, or `null` when the Pack is not active;
+- `createListService()` cold-opens the selected Store once, projects one of the two catalogs, and converts a missing Pack to `UnknownPackError`.
+
+The CLI adapter performs Pack-name syntax validation, Store-root resolution, service dispatch, and error mapping. It never reads `installed-packs.json`, queries SQLite, scans artifacts, or computes the domain catalog itself. A future MCP tool must validate its own input shape before calling the service.
+
+### Result
+
+Pack-list mode returns LocalStore `generation`, `effectiveRevision`, and `packs[]`. Each Pack contains only:
+
+- `name`;
+- `version`;
+- `practiceCount`.
+
+`practiceCount` counts effective Practices for which that Pack has at least one source claim. Multiple Packs may claim the same effective Practice; each Pack counts it, so Pack counts do not necessarily sum to the global deduplicated Practice total.
+
+Practice-catalog mode returns `generation`, `effectiveRevision`, `pack`, and `practices[]`. The Pack summary contains `name` and `version`. Each Practice contains only:
+
+- `id`;
+- `title`;
+- `applies_when`.
+
+The id can be passed directly to `lore get`. Body and anti-pattern content remains intentionally deferred to `get`.
+
+Pack entries sort by `name`; Practice entries sort by `id`. Both comparisons use UTF-16 code units and do not depend on process locale.
+
+### Errors and empty state
+
+A fresh Store is a successful Pack-list result with `packs: []`. A format-valid but uninstalled Pack raises `UnknownPackError`, which the CLI maps to `list.pack-not-found` with exit code 2. This distinguishes an uninstalled Pack from an installed Pack with zero Practices, whose catalog is successful and empty.
+
+The CLI validates `--pack` against `PACK_NAME_REGEX` before Store dispatch and returns `usage.invalid` for malformed input. Engine ListService does not duplicate that format-schema validation. The CLI's `list.pack-not-found` message is generic and does not echo the supplied Pack name; `registry.pack-not-found` remains the separate Registry-install error.
+
+LocalStore `StoreBusyError` and `StoreRecoveryRequiredError` keep their existing CLI mappings.
+
+### Non-goals
+
+Registry search, remote installable Pack discovery, semantic retrieval, ranking, fuzzy matching, pagination, filters, full Practice bodies, MCP wiring, and new Store tables or derived indexes are deferred. Cross-command snapshot consistency is not promised: `list`, `list --pack`, and `get` are separate invocations and may observe different Store revisions.
+
+## Consequences
+
+Once the caller knows the Lorelum CLI entry point, Agents can discover local
+knowledge without prior Pack knowledge while keeping LocalStore as the sole
+runtime source. This ADR does not claim automatic discovery of Lorelum itself.
+The `OpenResult` extension is additive for readers but requires implementations
+and test doubles that construct it to provide `packs`; the minimal summary
+avoids making artifact digests, storage keys, or install timestamps public
+contract fields.
+
+Source-claim counting preserves provenance but means counts are not a global uniqueness metric. The catalog keeps each item to three fields, so an unpaginated Pack can remain useful until observed catalog sizes justify a pagination contract.
+
+**Follow-ups:**
+
+- CLI registration, schema publication, and process integration land with the list implementation.
+- User documentation must distinguish browsing (`list`) from task retrieval (`query`).
+- A future MCP adapter must define its own input schema and error mapping before exposing this service.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ docs/adr/
 ├── 0011-local-store-point-read-and-query-boundary.md # proposed point-read and keyword query foundation
 ├── 0012-persistent-keyword-index.md            # cross-process keyword index reuse (#63)
 ├── 0013-incremental-local-store-projection-writes.md # affected-ID canonical projection writes (#73)
+├── 0014-list-catalog-contract.md                # LocalStore-backed lore list catalog
 └── 0000-template.md                           # copy this to start a new ADR
 ```
 

--- a/docs/cli/get.md
+++ b/docs/cli/get.md
@@ -3,10 +3,15 @@
 `lore get <practice-id>` retrieves one complete canonical Practice by its exact ID from the selected LocalStore. The public command contract was agreed in [issue #49](https://github.com/lorelum/lorelum/issues/49); the Engine point-read path and its consistency boundary are described in [ADR 0011](../adr/0011-local-store-point-read-and-query-boundary.md).
 
 ```sh
+lore list
+lore list --pack agentic-coding
 lore get agentic-coding.testing.classify-failure-before-changing-test
 lore --store-root /path/to/isolated-store get agentic-coding.testing.classify-failure-before-changing-test
 lore describe get
 ```
+
+For discovery, use `lore list` first, then `lore list --pack <name>` and pass
+one returned Practice ID to `lore get`.
 
 The ID must follow the existing dotted Practice ID format. Lookup is exact: there is no title matching, prefix completion, or case normalization. The global `--store-root` option also works after the command; relative paths resolve from the calling process's working directory. Omitting it selects the user Store.
 

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -1,0 +1,88 @@
+# Discover installed Packs with `lore list`
+
+`lore list` discovers the active Packs in the selected LocalStore. Use
+`lore list --pack <name>` to inspect the Practice summaries provided by one
+installed Pack, then pass a returned Practice ID to `lore get`. The contract is
+defined in [ADR 0014](../adr/0014-list-catalog-contract.md).
+
+This page documents the CLI/engine catalog contract. It assumes the caller
+already knows the Lorelum CLI entry point; it does not define automatic
+discovery of Lorelum or invocation by a Skill, Plugin, Hook, or MCP adapter.
+
+```sh
+lore list
+lore list --pack agentic-coding
+lore get agentic-coding.testing.classify-failure-before-changing-test
+lore --store-root /path/to/isolated-store list
+lore describe list
+```
+
+The global `--store-root` option can appear before or after the command. Relative
+paths resolve from the calling process's working directory. Omitting it selects
+the user Store. The CLI rejects a missing or empty value; other non-empty path
+strings are passed to LocalStore without a platform-specific path pre-check.
+
+## Pack list
+
+Without `--pack`, the protocol envelope contains `command: "list"`, `ok: true`,
+and:
+
+```text
+data: {
+  generation,
+  effectiveRevision,
+  packs: [
+    { name, version, practiceCount }
+  ]
+}
+```
+
+Pack entries are sorted by `name`. `version` comes from the selected
+Store's verified active manifest. `practiceCount` counts effective Practices
+for which that Pack has a source claim. If multiple Packs provide the same
+Practice, each Pack counts it; the values therefore are not a global
+deduplicated Practice total.
+
+A fresh Store is a successful response with `packs: []`.
+
+## Pack catalog
+
+With `--pack`, the response contains:
+
+```text
+data: {
+  generation,
+  effectiveRevision,
+  pack: { name, version },
+  practices: [
+    { id, title, applies_when }
+  ]
+}
+```
+
+Practice entries are limited to the summaries needed for discovery and are
+sorted by exact `id`. The returned `id` can be passed directly to `lore get`.
+Full Practice bodies, anti-patterns, and source details remain part of `get`.
+An installed Pack with zero Practices is successful and returns an empty
+`practices` array.
+
+## Errors and exit codes
+
+Success exits `0`. Failures use `ok: false` with `error: { code, message }` and
+exit `2`. Both success and failure write exactly one JSON line to stdout.
+
+| Code | Meaning |
+| --- | --- |
+| `usage.invalid` | Missing/extra arguments, malformed Pack name, or invalid options. |
+| `list.pack-not-found` | The requested Pack is not active in the selected Store. |
+| `store.busy` | A stable Store snapshot could not be obtained due to concurrent work. |
+| `store.recovery-required` | The selected Store could not be opened and recovered normally. |
+| `runtime.unexpected` | An undeclared internal failure prevented completion. |
+
+Pack names are validated against the existing Pack format before the Store is
+opened. The `list.pack-not-found` message does not echo the supplied Pack name.
+Callers should branch on `error.code` rather than parsing `message`.
+
+`list` does not search remote Registries, perform semantic ranking, paginate,
+filter, or return complete Practice bodies. Use `lore query` for task-oriented
+retrieval and `lore get` for one complete Practice.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -8,6 +8,7 @@ This is the index for day-to-day development topics that do not belong in the pr
 - [Tests and CI](../../CONTRIBUTING.md#testing--ci)
 - [Issues, branches, and PRs](../../CONTRIBUTING.md#development-workflow)
 - [Local CLI and worktrees](#local-cli-and-multiple-worktrees)
+- [Discover installed Packs with `lore list`](../cli/list.md)
 - [Read an installed Practice with `lore get`](../cli/get.md)
 - [Query installed Practices with `lore query`](../cli/query.md)
 - [LocalStore Engine API](#localstore-engine-api)
@@ -29,7 +30,7 @@ The CLI's discoverable global option is:
 --store-root <path>
 ```
 
-When omitted, the Store remains `~/.lorelum`. A relative path is resolved from the calling process's current working directory. `install`, `get`, and `query` consume LocalStore; do not infer support for other commands from this guide.
+When omitted, the Store remains `~/.lorelum`. A relative path is resolved from the calling process's current working directory. `install`, `list`, `get`, and `query` consume LocalStore; do not infer support for other commands from this guide.
 
 ### Source-level CLI helper
 

--- a/packages/cli/integration/process.integration.ts
+++ b/packages/cli/integration/process.integration.ts
@@ -135,7 +135,36 @@ console.log(JSON.stringify({ generation: result.generation, effectiveRevision: r
   assert.equal(installed.stderr, "");
   assert.equal(installed.stdout.trim().split(/\r?\n/).length, 1);
 
-  const first = await runGet(compiledBinary, practiceId, storageRoot);
+  const listed = await runList(compiledBinary, storageRoot);
+  assert.equal(listed.exitCode, 0);
+  assert.equal(listed.stderr, "");
+  const listedResponse = parseSingleResponse(listed.stdout);
+  assert.equal(listedResponse.command, "list");
+  assert.equal(listedResponse.ok, true);
+  assert(isRecord(listedResponse.data));
+  assert.deepEqual(listedResponse.data.packs, [
+    { name: "integration-pack", version: "1.0.0", practiceCount: 2 },
+  ]);
+
+  const listedPack = await runList(compiledBinary, storageRoot, "integration-pack");
+  assert.equal(listedPack.exitCode, 0);
+  assert.equal(listedPack.stderr, "");
+  const listedPackResponse = parseSingleResponse(listedPack.stdout);
+  assert.equal(listedPackResponse.command, "list");
+  assert.equal(listedPackResponse.ok, true);
+  assert(isRecord(listedPackResponse.data));
+  assert.deepEqual(listedPackResponse.data.pack, {
+    name: "integration-pack",
+    version: "1.0.0",
+  });
+  assert(Array.isArray(listedPackResponse.data.practices));
+  const listedPractice = listedPackResponse.data.practices.find(
+    (value) => isRecord(value) && value.id === practiceId,
+  );
+  assert(isRecord(listedPractice));
+  const listedPracticeId = String(listedPractice.id);
+
+  const first = await runGet(compiledBinary, listedPracticeId, storageRoot);
   assert.equal(first.exitCode, 0);
   assert.equal(first.stderr, "");
   const firstResponse = parseSingleResponse(first.stdout);
@@ -241,6 +270,22 @@ console.log(JSON.stringify({ generation: result.generation, effectiveRevision: r
   assert.equal(malformedResponse.ok, false);
   assert.equal(isRecord(malformedResponse.error) && malformedResponse.error.code, "usage.invalid");
   assert.equal(existsSync(malformedRoot), false, "malformed IDs must not create a Store root");
+
+  const emptyList = await runList(compiledBinary, join(workingDirectory, "empty-list-store"));
+  assert.equal(emptyList.exitCode, 0);
+  const emptyListResponse = parseSingleResponse(emptyList.stdout);
+  assert.equal(emptyListResponse.ok, true);
+  assert(isRecord(emptyListResponse.data));
+  assert.deepEqual(emptyListResponse.data.packs, []);
+
+  const missingPack = await runList(compiledBinary, storageRoot, "missing-pack");
+  assert.equal(missingPack.exitCode, 2);
+  const missingPackResponse = parseSingleResponse(missingPack.stdout);
+  assert.equal(missingPackResponse.ok, false);
+  assert.equal(
+    isRecord(missingPackResponse.error) && missingPackResponse.error.code,
+    "list.pack-not-found",
+  );
 }
 
 async function runGet(
@@ -264,6 +309,17 @@ async function runQuery(
 ): Promise<{ exitCode: number; stderr: string; stdout: string }> {
   const args = [binaryPath, "query", text, "--store-root", storageRoot];
   if (topK !== undefined) args.push("--top-k", String(topK));
+  return runProcess(args);
+}
+
+async function runList(
+  binaryPath: string,
+  storageRoot: string,
+  packName?: string,
+): Promise<{ exitCode: number; stderr: string; stdout: string }> {
+  const args = [binaryPath, "list"];
+  if (packName !== undefined) args.push("--pack", packName);
+  args.push("--store-root", storageRoot);
   return runProcess(args);
 }
 

--- a/packages/cli/src/list/errors.ts
+++ b/packages/cli/src/list/errors.ts
@@ -1,0 +1,40 @@
+import {
+  StoreBusyError,
+  StoreRecoveryRequiredError,
+  UnknownPackError,
+} from "@lorelum/engine";
+
+import { CliError, cliErrorCodes, frameworkErrorCodes } from "../runtime/errors.js";
+
+/** Error allowlist for the LocalStore-backed catalog command (`lore list`). */
+export const listErrorCodes = Object.freeze([
+  ...frameworkErrorCodes,
+  cliErrorCodes.storeBusy,
+  cliErrorCodes.storeRecoveryRequired,
+  cliErrorCodes.listPackNotFound,
+]);
+
+/** Convert engine domain errors to visible CLI errors; returns undefined when not one. */
+export function toListCliError(error: unknown): CliError | undefined {
+  if (error instanceof UnknownPackError) {
+    return new CliError(cliErrorCodes.listPackNotFound, "The requested Pack is not installed.");
+  }
+  return undefined;
+}
+
+/** Re-throw a mapped CliError, a list domain error, or a Store error verbatim. */
+export function throwListVisibleError(error: unknown): never {
+  if (error instanceof CliError) throw error;
+  const listError = toListCliError(error);
+  if (listError !== undefined) throw listError;
+  if (error instanceof StoreBusyError) {
+    throw new CliError(cliErrorCodes.storeBusy, "The local Pack store is busy.");
+  }
+  if (error instanceof StoreRecoveryRequiredError) {
+    throw new CliError(
+      cliErrorCodes.storeRecoveryRequired,
+      "The local Pack store requires recovery.",
+    );
+  }
+  throw error;
+}

--- a/packages/cli/src/list/list-command.test.ts
+++ b/packages/cli/src/list/list-command.test.ts
@@ -1,0 +1,350 @@
+import { expect, test } from "bun:test";
+
+import {
+  StoreBusyError,
+  StoreRecoveryRequiredError,
+  UnknownPackError,
+  defaultStorageRoot,
+  type ListPackRequest,
+  type ListRequest,
+  type ListService,
+} from "@lorelum/engine";
+import { resolve } from "node:path";
+
+import { run } from "../main.js";
+import { validateJsonSchema } from "../output/protocol-schema.test-helper.js";
+import type { JsonSchema } from "../output/protocol.js";
+import { commandRegistry, describeCommand, snapshotCommandDefinitions } from "../registry.js";
+import type { CommandDefinition } from "../registry.js";
+import { CliError, cliErrorCodes } from "../runtime/errors.js";
+import { createListCommand } from "./list-command.js";
+
+class MemoryWriter {
+  value = "";
+
+  write(message: string): void {
+    this.value += message;
+  }
+}
+
+const packsResult = {
+  generation: 1,
+  effectiveRevision: 2,
+  packs: [
+    { name: "agentic-coding", version: "0.3.0", practiceCount: 31 },
+    { name: "platform", version: "1.0.0", practiceCount: 0 },
+  ],
+};
+
+const packResult = {
+  generation: 1,
+  effectiveRevision: 2,
+  pack: { name: "agentic-coding", version: "0.3.0" },
+  practices: [
+    {
+      id: "agentic-coding.testing.classify-failure-before-changing-test",
+      title: "Classify the Failure Before Changing the Test",
+      applies_when: "a focused test fails and the next action would modify the test",
+    },
+  ],
+};
+
+function service(): ListService {
+  return {
+    async list() {
+      return packsResult;
+    },
+    async listPack() {
+      return packResult;
+    },
+  };
+}
+
+test("describes the LocalStore-backed list command contract", () => {
+  expect(describeCommand("list")).toMatchObject({
+    name: "list",
+    usage: "list",
+    positionals: [],
+    options: [
+      { name: "-h, --help", required: false },
+      { name: "--log-level <level>", required: false },
+      { name: "--store-root <path>", required: false },
+      { name: "--pack <name>", required: false },
+    ],
+    errorCodes: [
+      "usage.invalid",
+      "runtime.unexpected",
+      "store.busy",
+      "store.recovery-required",
+      "list.pack-not-found",
+    ],
+    exitCodes: [0, 2],
+  });
+});
+
+test("returns both list modes through their oneOf result schema", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createListCommand({ list: service(), storageRoot: defaultStorageRoot() }),
+  ]);
+
+  expect(await run(["list"], { registry: definitions, stdout })).toBe(0);
+  let response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({ command: "list", ok: true, data: packsResult });
+  let description = describeCommand("list") as { resultSchema: JsonSchema };
+  expect(validateJsonSchema(response.data, description.resultSchema)).toEqual([]);
+
+  stdout.value = "";
+  expect(await run(["list", "--pack", "agentic-coding"], { registry: definitions, stdout })).toBe(
+    0,
+  );
+  response = JSON.parse(stdout.value);
+  expect(response).toMatchObject({ command: "list", ok: true, data: packResult });
+  description = describeCommand("list") as { resultSchema: JsonSchema };
+  expect(validateJsonSchema(response.data, description.resultSchema)).toEqual([]);
+
+  expect(
+    validateJsonSchema({ ...packsResult, pack: packResult.pack }, description.resultSchema),
+  ).not.toEqual([]);
+  expect(
+    validateJsonSchema({ ...packResult, packs: packsResult.packs }, description.resultSchema),
+  ).not.toEqual([]);
+});
+
+test("rejects malformed Pack names before service dispatch", async () => {
+  const calls: string[] = [];
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createListCommand({
+      list: {
+        async list(request = {}) {
+          calls.push(`list:${request.storageRoot?.rootPath ?? "default"}`);
+          return packsResult;
+        },
+        async listPack(request) {
+          calls.push(`listPack:${request.packName}`);
+          return packResult;
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  const results = await Promise.all(
+    ["", "   ", "Agentic", "agentic_coding", "agentic--coding"].map(async (packName) => {
+      const stdout = new MemoryWriter();
+      const exitCode = await run(["list", "--pack", packName], { registry: definitions, stdout });
+      return { exitCode, response: JSON.parse(stdout.value) };
+    }),
+  );
+  for (const { exitCode, response } of results) {
+    expect(exitCode).toBe(2);
+    expect(response).toMatchObject({
+      command: "list",
+      ok: false,
+      error: { code: "usage.invalid" },
+    });
+  }
+  expect(calls).toEqual([]);
+});
+
+test("rejects an empty --store-root value before service dispatch", async () => {
+  const calls: string[] = [];
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createListCommand({
+      list: {
+        async list(request = {}) {
+          calls.push(`list:${request.storageRoot?.rootPath}`);
+          return packsResult;
+        },
+        async listPack() {
+          calls.push("listPack");
+          return packResult;
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  const stdout = new MemoryWriter();
+  expect(await run(["list", "--store-root", ""], { registry: definitions, stdout })).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "list",
+    ok: false,
+    error: { code: "usage.invalid" },
+  });
+  expect(calls).toEqual([]);
+});
+
+test("maps an unknown Pack without echoing the supplied name", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createListCommand({
+      list: {
+        async list() {
+          return packsResult;
+        },
+        async listPack() {
+          throw new UnknownPackError("private-pack-name");
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  expect(
+    await run(["list", "--pack", "private-pack-name"], { registry: definitions, stdout }),
+  ).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "list",
+    ok: false,
+    error: {
+      code: "list.pack-not-found",
+      message: "The requested Pack is not installed.",
+    },
+  });
+  expect(stdout.value).not.toContain("private-pack-name");
+});
+
+test("maps LocalStore recovery failures to the declared public error", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createListCommand({
+      list: {
+        async list() {
+          throw new StoreRecoveryRequiredError("test recovery failure");
+        },
+        async listPack() {
+          throw new StoreRecoveryRequiredError("test recovery failure");
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  expect(await run(["list"], { registry: definitions, stdout })).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "list",
+    ok: false,
+    error: { code: "store.recovery-required" },
+  });
+});
+
+test("maps LocalStore busy failures to the declared public error", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createListCommand({
+      list: {
+        async list() {
+          throw new StoreBusyError("test busy failure");
+        },
+        async listPack() {
+          throw new StoreBusyError("test busy failure");
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  expect(await run(["list"], { registry: definitions, stdout })).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "list",
+    ok: false,
+    error: { code: "store.busy" },
+  });
+});
+
+test("normalizes an undeclared list failure to runtime.unexpected", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createListCommand({
+      list: {
+        async list() {
+          throw new Error("private list implementation detail");
+        },
+        async listPack() {
+          throw new Error("private list implementation detail");
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  expect(await run(["list"], { registry: definitions, stdout })).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "list",
+    ok: false,
+    error: {
+      code: "runtime.unexpected",
+      message: "The command could not be completed.",
+    },
+  });
+  expect(stdout.value).not.toContain("private list implementation detail");
+});
+
+test("passes through a declared CliError from the list service", async () => {
+  const stdout = new MemoryWriter();
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createListCommand({
+      list: {
+        async list() {
+          throw new CliError(cliErrorCodes.usageInvalid, "The list request was rejected.");
+        },
+        async listPack() {
+          throw new CliError(cliErrorCodes.usageInvalid, "The list request was rejected.");
+        },
+      },
+      storageRoot: defaultStorageRoot(),
+    }),
+  ]);
+
+  expect(await run(["list"], { registry: definitions, stdout })).toBe(2);
+  expect(JSON.parse(stdout.value)).toMatchObject({
+    command: "list",
+    ok: false,
+    error: {
+      code: "usage.invalid",
+      message: "The list request was rejected.",
+    },
+  });
+});
+
+test("resolves --store-root and forwards the selected Store to both modes", async () => {
+  const listRequests: ListRequest[] = [];
+  const listPackRequests: ListPackRequest[] = [];
+  const definitions: readonly CommandDefinition[] = snapshotCommandDefinitions([
+    createListCommand({
+      list: {
+        async list(request = {}) {
+          listRequests.push(request);
+          return packsResult;
+        },
+        async listPack(request) {
+          listPackRequests.push(request);
+          return packResult;
+        },
+      },
+      storageRoot: { rootPath: "default-user-store" },
+    }),
+  ]);
+
+  const stdout = new MemoryWriter();
+  expect(
+    await run(["list", "--store-root", "isolated-store"], { registry: definitions, stdout }),
+  ).toBe(0);
+  stdout.value = "";
+  expect(
+    await run(["list", "--pack", "agentic-coding", "--store-root", "isolated-store"], {
+      registry: definitions,
+      stdout,
+    }),
+  ).toBe(0);
+
+  const expectedRoot = { rootPath: resolve(process.cwd(), "isolated-store") };
+  expect(listRequests[0]?.storageRoot).toEqual(expectedRoot);
+  expect(listPackRequests[0]?.storageRoot).toEqual(expectedRoot);
+  expect(listPackRequests[0]?.packName).toBe("agentic-coding");
+});
+
+test("list is included in the production command registry", () => {
+  expect(commandRegistry.map((definition) => definition.name)).toContain("list");
+});

--- a/packages/cli/src/list/list-command.ts
+++ b/packages/cli/src/list/list-command.ts
@@ -1,0 +1,115 @@
+import type { ListService, StorageRoot } from "@lorelum/engine";
+import { PACK_NAME_REGEX } from "@lorelum/format";
+
+import type { JsonSchema, JsonValue } from "../output/protocol.js";
+import { listErrorCodes, throwListVisibleError } from "./errors.js";
+import type { CommandDefinition } from "../registry.js";
+import { invalidInvocationError } from "../runtime/errors.js";
+import { resolveInvocationStorageRoot } from "../store/storage-root.js";
+
+export interface ListCommandServices {
+  readonly list: ListService;
+  readonly storageRoot: StorageRoot;
+}
+
+const stringSchema: JsonSchema = { type: "string" };
+
+const installedPackSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name", "version", "practiceCount"],
+  properties: {
+    name: stringSchema,
+    version: stringSchema,
+    practiceCount: { type: "integer" },
+  },
+};
+
+const packSummarySchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name", "version"],
+  properties: { name: stringSchema, version: stringSchema },
+};
+
+const listedPracticeSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["id", "title", "applies_when"],
+  properties: {
+    id: stringSchema,
+    title: stringSchema,
+    applies_when: stringSchema,
+  },
+};
+
+const resultSchema: JsonSchema = {
+  oneOf: [
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["generation", "effectiveRevision", "packs"],
+      properties: {
+        generation: { type: "integer" },
+        effectiveRevision: { type: "integer" },
+        packs: { type: "array", items: installedPackSchema },
+      },
+    },
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["generation", "effectiveRevision", "pack", "practices"],
+      properties: {
+        generation: { type: "integer" },
+        effectiveRevision: { type: "integer" },
+        pack: packSummarySchema,
+        practices: { type: "array", items: listedPracticeSchema },
+      },
+    },
+  ],
+};
+
+export function createListCommand(
+  services: ListCommandServices,
+): CommandDefinition {
+  return {
+    name: "list",
+    summary: "List installed Packs and their Practice catalogs from the LocalStore.",
+    positionals: [],
+    options: [
+      {
+        longFlag: "--pack",
+        description: "List the Practice catalog for one installed Pack.",
+        value: { name: "name", required: true },
+        optionRequired: false,
+      },
+    ],
+    resultSchema,
+    errorCodes: listErrorCodes,
+    exitCodes: [0, 2],
+    async handler(invocation) {
+      const packName = invocation.options.pack;
+      if (
+        packName !== undefined &&
+        (typeof packName !== "string" || !PACK_NAME_REGEX.test(packName))
+      ) {
+        throw invalidInvocationError();
+      }
+
+      const storageRoot = resolveInvocationStorageRoot(
+        invocation.options.storeRoot,
+        services.storageRoot,
+      );
+
+      try {
+        const result =
+          packName === undefined
+            ? await services.list.list({ storageRoot })
+            : await services.list.listPack({ packName, storageRoot });
+        return { data: result as unknown as JsonValue };
+      } catch (error) {
+        throwListVisibleError(error);
+      }
+    },
+  };
+}

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -34,6 +34,7 @@ test("returns machine-readable root capability discovery", async () => {
         { name: "install" },
         { name: "get" },
         { name: "query" },
+        { name: "list" },
         { name: "format" },
         { name: "i18n.sync" },
         { name: "validate" },

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -214,7 +214,16 @@ test("describes registered commands from a single registry", () => {
         positionals: [
           {
             name: "command",
-            values: ["describe", "install", "get", "query", "format", "i18n.sync", "validate"],
+            values: [
+              "describe",
+              "install",
+              "get",
+              "query",
+              "list",
+              "format",
+              "i18n.sync",
+              "validate",
+            ],
           },
         ],
       },
@@ -224,6 +233,7 @@ test("describes registered commands from a single registry", () => {
       },
       { name: "get", positionals: [{ name: "practice-id", required: true }] },
       { name: "query", positionals: [{ name: "text", required: true }] },
+      { name: "list" },
       { name: "format" },
       { name: "i18n.sync" },
       { name: "validate" },
@@ -275,6 +285,7 @@ test("derives parser options and describe metadata from registered commands", as
           "install",
           "get",
           "query",
+          "list",
           "format",
           "i18n.sync",
           "validate",

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -4,12 +4,18 @@ import {
   type JsonSchema,
   type JsonValue,
 } from "./output/protocol.js";
-import { createLocalStore, createQueryService, defaultStorageRoot } from "@lorelum/engine";
+import {
+  createListService,
+  createLocalStore,
+  createQueryService,
+  defaultStorageRoot,
+} from "@lorelum/engine";
 import { frameworkErrorCodes, invalidInvocationError } from "./runtime/errors.js";
 import { logLevels } from "./runtime/logger.js";
 import { createInstallCommand } from "./install/install-command.js";
 import { createGetCommand } from "./get/get-command.js";
 import { createQueryCommand } from "./query/query-command.js";
+import { createListCommand } from "./list/list-command.js";
 import { createLocalizationCommands } from "./localization/index.js";
 
 export interface CommandOption {
@@ -232,6 +238,10 @@ export const rootCommand = snapshotCommandDefinition({
 const sharedStore = createLocalStore();
 const sharedStorageRoot = defaultStorageRoot();
 const sharedQueryService = createQueryService({ store: sharedStore });
+const sharedListService = createListService({
+  store: sharedStore,
+  storageRoot: sharedStorageRoot,
+});
 
 /** Immutable child-command registry used unless a complete replacement is supplied. */
 export const commandRegistry = snapshotCommandDefinitions([
@@ -239,6 +249,7 @@ export const commandRegistry = snapshotCommandDefinitions([
   createInstallCommand({ store: sharedStore, storageRoot: sharedStorageRoot }),
   createGetCommand({ store: sharedStore, storageRoot: sharedStorageRoot }),
   createQueryCommand({ queryService: sharedQueryService, storageRoot: sharedStorageRoot }),
+  createListCommand({ list: sharedListService, storageRoot: sharedStorageRoot }),
   ...createLocalizationCommands(),
 ]);
 

--- a/packages/cli/src/runtime/errors.ts
+++ b/packages/cli/src/runtime/errors.ts
@@ -12,6 +12,7 @@ export const cliErrorCodes = Object.freeze({
   sourceUnavailable: "source.unavailable",
   storeBusy: "store.busy",
   storeRecoveryRequired: "store.recovery-required",
+  listPackNotFound: "list.pack-not-found",
   localizationInvalid: "localization.invalid",
   localizationPracticeNotFound: "localization.practice-not-found",
   queryUnavailable: "query.unavailable",

--- a/packages/engine/src/index.test.ts
+++ b/packages/engine/src/index.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
-import { PACKAGE_NAME } from "./index";
+import { PACKAGE_NAME, createListService, retrievePackPractices, retrievePacks } from "./index";
 
 describe("@lorelum/engine", () => {
   test("exposes its package name", () => {
     expect(PACKAGE_NAME).toBe("@lorelum/engine");
+  });
+
+  test("exposes the List runtime API through the package boundary", () => {
+    expect(typeof createListService).toBe("function");
+    expect(typeof retrievePacks).toBe("function");
+    expect(typeof retrievePackPractices).toBe("function");
   });
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -9,3 +9,4 @@ export const PACKAGE_NAME = "@lorelum/engine";
 // boundary, never from package-internal directories.
 export * from "./local-store";
 export * from "./query";
+export * from "./list";

--- a/packages/engine/src/list/errors.ts
+++ b/packages/engine/src/list/errors.ts
@@ -1,0 +1,7 @@
+/** Thrown when `list --pack` names a Pack absent from the active manifest. */
+export class UnknownPackError extends Error {
+  constructor(packName: string) {
+    super(`No installed Pack exists with name "${packName}".`);
+    this.name = "UnknownPackError";
+  }
+}

--- a/packages/engine/src/list/index.ts
+++ b/packages/engine/src/list/index.ts
@@ -1,0 +1,15 @@
+export { UnknownPackError } from "./errors.js";
+export { retrievePackPractices, retrievePacks } from "./retrieve.js";
+export { createListService, type ListService, type ListServiceOptions } from "./service.js";
+export type {
+  ListedPack,
+  ListedPractice,
+  ListPackPracticesResult,
+  ListPackRequest,
+  ListPacksResult,
+  ListRequest,
+  RetrievePackPracticesInput,
+  RetrievePackPracticesResult,
+  RetrievePacksInput,
+  RetrievePacksResult,
+} from "./types.js";

--- a/packages/engine/src/list/retrieve.test.ts
+++ b/packages/engine/src/list/retrieve.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+
+import type { EffectivePractice, InstalledPackSummary } from "../local-store/index.js";
+import { retrievePackPractices, retrievePacks } from "./retrieve.js";
+
+function effectivePractice(
+  id: string,
+  packNames: readonly string[],
+  overrides: Partial<EffectivePractice["practice"]> = {},
+): EffectivePractice {
+  const practice: EffectivePractice["practice"] = {
+    id,
+    title: `Practice ${id}`,
+    stage: "test",
+    tech_stack: ["typescript"],
+    applies_when: "testing list retrieval",
+    severity: "warn",
+    body: `Guidance for ${id}.`,
+    anti_patterns: [],
+    ...overrides,
+  };
+  const contentDigest = `${id}-digest`;
+  return {
+    practiceId: id,
+    contentDigest,
+    canonicalContent: id,
+    practice,
+    sources: packNames.map((packName) => ({
+      packName,
+      practiceId: id,
+      contentDigest,
+      sourcePath: `practices/${packName}/${id}.md`,
+      canonicalPractice: { practice, canonicalContent: id, contentDigest },
+    })),
+  };
+}
+
+const packs: readonly InstalledPackSummary[] = [
+  { name: "zeta", version: "0.2.0" },
+  { name: "alpha", version: "0.1.0" },
+  { name: "empty-pack", version: "0.3.0" },
+];
+
+describe("retrievePacks", () => {
+  test("counts Practices by source claim and sorts Packs by name", () => {
+    const packsWithExtras = [
+      { name: "zeta", version: "0.2.0", storageKey: "p-zeta" },
+      { name: "alpha", version: "0.1.0", storageKey: "p-alpha" },
+      { name: "empty-pack", version: "0.3.0", storageKey: "p-empty-pack" },
+    ] as unknown as readonly InstalledPackSummary[];
+
+    const result = retrievePacks({
+      packs: packsWithExtras,
+      effectivePractices: [
+        effectivePractice("react.state", ["alpha"]),
+        effectivePractice("react.api", ["zeta", "alpha", "zeta"]),
+        effectivePractice("react.design", ["zeta"]),
+      ],
+    });
+
+    expect(result.packs).toEqual([
+      { name: "alpha", version: "0.1.0", practiceCount: 2 },
+      { name: "empty-pack", version: "0.3.0", practiceCount: 0 },
+      { name: "zeta", version: "0.2.0", practiceCount: 2 },
+    ]);
+    expect(Object.isFrozen(result.packs)).toBe(true);
+    expect("storageKey" in result.packs[0]!).toBe(false);
+  });
+});
+
+describe("retrievePackPractices", () => {
+  test("returns only Practices claimed by the selected Pack and sorts by id", () => {
+    const result = retrievePackPractices({
+      packName: "alpha",
+      packs,
+      effectivePractices: [
+        effectivePractice("react.z-state", ["alpha"]),
+        effectivePractice("react.a-api", ["alpha", "zeta"]),
+        effectivePractice("react.other", ["zeta"]),
+      ],
+    });
+
+    expect(result).toEqual({
+      pack: { name: "alpha", version: "0.1.0" },
+      practices: [
+        {
+          id: "react.a-api",
+          title: "Practice react.a-api",
+          applies_when: "testing list retrieval",
+        },
+        {
+          id: "react.z-state",
+          title: "Practice react.z-state",
+          applies_when: "testing list retrieval",
+        },
+      ],
+    });
+    if (result === null) throw new Error("expected an installed Pack catalog");
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.pack)).toBe(true);
+    expect(Object.isFrozen(result.practices)).toBe(true);
+    expect(Object.isFrozen(result.practices[0])).toBe(true);
+
+    const sharedInZeta = retrievePackPractices({
+      packName: "zeta",
+      packs,
+      effectivePractices: [
+        effectivePractice("react.z-state", ["alpha"]),
+        effectivePractice("react.a-api", ["alpha", "zeta"]),
+        effectivePractice("react.other", ["zeta"]),
+      ],
+    });
+    expect(sharedInZeta?.practices.map((practice) => practice.id)).toEqual([
+      "react.a-api",
+      "react.other",
+    ]);
+  });
+
+  test("returns a zero-Practice Pack as an empty catalog", () => {
+    expect(
+      retrievePackPractices({
+        packName: "empty-pack",
+        packs,
+        effectivePractices: [effectivePractice("react.api", ["alpha"])],
+      }),
+    ).toEqual({
+      pack: { name: "empty-pack", version: "0.3.0" },
+      practices: [],
+    });
+  });
+
+  test("returns null for an installed-list miss", () => {
+    expect(
+      retrievePackPractices({
+        packName: "missing",
+        packs,
+        effectivePractices: [],
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/engine/src/list/retrieve.ts
+++ b/packages/engine/src/list/retrieve.ts
@@ -1,0 +1,69 @@
+import type { EffectivePractice } from "../local-store/index.js";
+import type {
+  ListedPack,
+  ListedPractice,
+  RetrievePackPracticesInput,
+  RetrievePackPracticesResult,
+  RetrievePacksInput,
+  RetrievePacksResult,
+} from "./types.js";
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function practiceCountsByPack(
+  effectivePractices: readonly EffectivePractice[],
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const effectivePractice of effectivePractices) {
+    const packNames = new Set(effectivePractice.sources.map((source) => source.packName));
+    for (const packName of packNames) {
+      counts.set(packName, (counts.get(packName) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+function projectPractice(effectivePractice: EffectivePractice): ListedPractice {
+  return Object.freeze({
+    id: effectivePractice.practice.id,
+    title: effectivePractice.practice.title,
+    applies_when: effectivePractice.practice.applies_when,
+  });
+}
+
+/** Project the active manifest into the `lore list` Pack catalog. */
+export function retrievePacks(input: RetrievePacksInput): RetrievePacksResult {
+  const counts = practiceCountsByPack(input.effectivePractices);
+  const packs: readonly ListedPack[] = input.packs
+    .map((pack) =>
+      Object.freeze({
+        name: pack.name,
+        version: pack.version,
+        practiceCount: counts.get(pack.name) ?? 0,
+      }),
+    )
+    .sort((left, right) => compareCodeUnits(left.name, right.name));
+  return Object.freeze({ packs: Object.freeze(packs) });
+}
+
+/**
+ * Project one installed Pack's Effective Practice source claims. Returns null
+ * when the Pack is absent; the service boundary converts that to a typed error.
+ */
+export function retrievePackPractices(
+  input: RetrievePackPracticesInput,
+): RetrievePackPracticesResult | null {
+  const pack = input.packs.find((candidate) => candidate.name === input.packName);
+  if (pack === undefined) return null;
+
+  const projectedPack = Object.freeze({ name: pack.name, version: pack.version });
+  const practices = input.effectivePractices
+    .filter((effectivePractice) =>
+      effectivePractice.sources.some((source) => source.packName === pack.name),
+    )
+    .map(projectPractice)
+    .sort((left, right) => compareCodeUnits(left.id, right.id));
+  return Object.freeze({ pack: projectedPack, practices: Object.freeze(practices) });
+}

--- a/packages/engine/src/list/service.test.ts
+++ b/packages/engine/src/list/service.test.ts
@@ -1,0 +1,194 @@
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createLocalStore,
+  decodePackDirectory,
+  StoreBusyError,
+  StoreRecoveryRequiredError,
+  type LocalStore,
+  type OpenResult,
+  type StorageRoot,
+} from "../local-store/index.js";
+import { UnknownPackError } from "./errors.js";
+import { createListService } from "./service.js";
+
+async function removeStoreRoot(rootPath: string): Promise<void> {
+  /* eslint-disable no-await-in-loop -- Windows may release SQLite handles asynchronously. */
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      await rm(rootPath, { force: true, recursive: true });
+      return;
+    } catch (error) {
+      if (attempt === 9) throw error;
+      await Bun.sleep(50);
+    }
+  }
+  /* eslint-enable no-await-in-loop */
+}
+
+async function writeLocalListPack(directory: string): Promise<string> {
+  const packRoot = join(directory, "local-list-pack");
+  const practices = join(packRoot, "practices", "react");
+  await mkdir(practices, { recursive: true });
+  await writeFile(join(packRoot, "pack.yaml"), "name: local-list-fixture\nversion: 0.1.0\n");
+  await writeFile(
+    join(practices, "z-api.md"),
+    [
+      "---",
+      "id: react.z-api",
+      "title: Layer React API access",
+      "stage: api-layer",
+      "tech_stack: [react, typescript]",
+      "applies_when: adding remote requests to a React interface",
+      "severity: warn",
+      "---",
+      "Keep transport, DTO translation, and expected failures behind a feature API boundary.",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    join(practices, "a-state.md"),
+    [
+      "---",
+      "id: react.a-state",
+      "title: Separate resource and UI state",
+      "stage: state",
+      "tech_stack: [react, typescript]",
+      "applies_when: storing remote resource data used by a React interface",
+      "severity: warn",
+      "---",
+      "Model resource data separately from view state and transform DTOs at the boundary.",
+      "",
+    ].join("\n"),
+  );
+  return packRoot;
+}
+
+function fakeStore(open: OpenResult): Pick<LocalStore, "open"> {
+  return {
+    open: async () => open,
+  };
+}
+
+test("ListService reads the Pack catalog and a selected Pack through LocalStore", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-list-service-"));
+  const storageRoot: StorageRoot = { rootPath: join(directory, "store") };
+  try {
+    const packRoot = await writeLocalListPack(directory);
+    const decoded = await decodePackDirectory(packRoot);
+    const store = createLocalStore();
+    await store.install(storageRoot, decoded.candidate, decoded.diagnostics);
+    const service = createListService({ store, storageRoot });
+
+    const packsResult = await service.list();
+    expect(packsResult).toEqual({
+      generation: 1,
+      effectiveRevision: 1,
+      packs: [{ name: "local-list-fixture", version: "0.1.0", practiceCount: 2 }],
+    });
+    expect(Object.isFrozen(packsResult)).toBe(true);
+    expect(Object.isFrozen(packsResult.packs)).toBe(true);
+
+    const practicesResult = await service.listPack({ packName: "local-list-fixture" });
+    expect(practicesResult).toEqual({
+      generation: 1,
+      effectiveRevision: 1,
+      pack: { name: "local-list-fixture", version: "0.1.0" },
+      practices: [
+        {
+          id: "react.a-state",
+          title: "Separate resource and UI state",
+          applies_when: "storing remote resource data used by a React interface",
+        },
+        {
+          id: "react.z-api",
+          title: "Layer React API access",
+          applies_when: "adding remote requests to a React interface",
+        },
+      ],
+    });
+    expect(Object.isFrozen(practicesResult)).toBe(true);
+    expect(Object.isFrozen(practicesResult.pack)).toBe(true);
+    expect(Object.isFrozen(practicesResult.practices)).toBe(true);
+    expect(Object.isFrozen(practicesResult.practices[0])).toBe(true);
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});
+
+test("ListService honors a per-call storageRoot override", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-list-override-"));
+  const defaultRoot: StorageRoot = { rootPath: join(directory, "default-store") };
+  const overrideRoot: StorageRoot = { rootPath: join(directory, "override-store") };
+  try {
+    const packRoot = await writeLocalListPack(directory);
+    const decoded = await decodePackDirectory(packRoot);
+    const store = createLocalStore();
+    await store.install(overrideRoot, decoded.candidate, decoded.diagnostics);
+    const service = createListService({ store, storageRoot: defaultRoot });
+
+    await expect(service.list({ storageRoot: overrideRoot })).resolves.toMatchObject({
+      generation: 1,
+      packs: [{ name: "local-list-fixture", practiceCount: 2 }],
+    });
+    await expect(service.list()).resolves.toMatchObject({
+      generation: 0,
+      packs: [],
+    });
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});
+
+test("ListService succeeds with an empty fresh LocalStore", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lorelum-list-empty-"));
+  const storageRoot: StorageRoot = { rootPath: join(directory, "store") };
+  try {
+    await expect(createListService({ storageRoot }).list()).resolves.toEqual({
+      generation: 0,
+      effectiveRevision: 0,
+      packs: [],
+    });
+  } finally {
+    await removeStoreRoot(directory);
+  }
+});
+
+test("ListService maps missing and blank Pack names to UnknownPackError", async () => {
+  const service = createListService({
+    store: fakeStore({
+      generation: 1,
+      effectiveRevision: 2,
+      packs: [{ name: "platform", version: "1.0.0" }],
+      effectivePractices: [],
+    }),
+  });
+
+  await expect(service.listPack({ packName: "missing" })).rejects.toThrow(UnknownPackError);
+  await expect(service.listPack({ packName: "   " })).rejects.toThrow(UnknownPackError);
+});
+
+test("ListService propagates LocalStore busy and recovery failures", async () => {
+  /* eslint-disable no-await-in-loop -- each error case asserts both sequential call sites. */
+  for (const error of [new StoreBusyError("busy"), new StoreRecoveryRequiredError("recovery")]) {
+    const store: Pick<LocalStore, "open"> = {
+      ...fakeStore({
+        generation: 0,
+        effectiveRevision: 0,
+        packs: [],
+        effectivePractices: [],
+      }),
+      open: async () => {
+        throw error;
+      },
+    };
+    await expect(createListService({ store }).list()).rejects.toBe(error);
+    await expect(createListService({ store }).listPack({ packName: "platform" })).rejects.toBe(
+      error,
+    );
+  }
+  /* eslint-enable no-await-in-loop */
+});

--- a/packages/engine/src/list/service.ts
+++ b/packages/engine/src/list/service.ts
@@ -1,0 +1,63 @@
+import {
+  createLocalStore,
+  defaultStorageRoot,
+  type LocalStore,
+  type StorageRoot,
+} from "../local-store/index.js";
+import { UnknownPackError } from "./errors.js";
+import { retrievePackPractices, retrievePacks } from "./retrieve.js";
+import type {
+  ListPackPracticesResult,
+  ListPackRequest,
+  ListPacksResult,
+  ListRequest,
+} from "./types.js";
+
+export interface ListService {
+  list(request?: ListRequest): Promise<ListPacksResult>;
+  listPack(request: ListPackRequest): Promise<ListPackPracticesResult>;
+}
+
+export interface ListServiceOptions {
+  readonly store?: Pick<LocalStore, "open">;
+  readonly storageRoot?: StorageRoot;
+}
+
+/** Application boundary for the LocalStore-backed `lore list` catalog. */
+export function createListService(options: ListServiceOptions = {}): ListService {
+  const store = options.store ?? createLocalStore();
+  const fallbackStorageRoot = options.storageRoot ?? defaultStorageRoot();
+
+  return Object.freeze({
+    async list(request: ListRequest = {}): Promise<ListPacksResult> {
+      const opened = await store.open(request.storageRoot ?? fallbackStorageRoot);
+      return Object.freeze({
+        ...retrievePacks({
+          packs: opened.packs,
+          effectivePractices: opened.effectivePractices,
+        }),
+        generation: opened.generation,
+        effectiveRevision: opened.effectiveRevision,
+      });
+    },
+
+    async listPack(request: ListPackRequest): Promise<ListPackPracticesResult> {
+      if (typeof request.packName !== "string" || request.packName.trim().length === 0) {
+        throw new UnknownPackError(String(request.packName));
+      }
+
+      const opened = await store.open(request.storageRoot ?? fallbackStorageRoot);
+      const retrieved = retrievePackPractices({
+        packName: request.packName,
+        packs: opened.packs,
+        effectivePractices: opened.effectivePractices,
+      });
+      if (retrieved === null) throw new UnknownPackError(request.packName);
+      return Object.freeze({
+        ...retrieved,
+        generation: opened.generation,
+        effectiveRevision: opened.effectiveRevision,
+      });
+    },
+  });
+}

--- a/packages/engine/src/list/types.ts
+++ b/packages/engine/src/list/types.ts
@@ -1,0 +1,52 @@
+import type { EffectivePractice, InstalledPackSummary, StorageRoot } from "../local-store/index.js";
+
+export type ListedPractice = Readonly<
+  Pick<EffectivePractice["practice"], "id" | "title" | "applies_when">
+>;
+
+export interface ListedPack {
+  readonly name: string;
+  readonly version: string;
+  readonly practiceCount: number;
+}
+
+export interface RetrievePacksInput {
+  readonly packs: readonly InstalledPackSummary[];
+  readonly effectivePractices: readonly EffectivePractice[];
+}
+
+export interface RetrievePackPracticesInput {
+  readonly packName: string;
+  readonly packs: readonly InstalledPackSummary[];
+  readonly effectivePractices: readonly EffectivePractice[];
+}
+
+export interface RetrievePacksResult {
+  readonly packs: readonly ListedPack[];
+}
+
+export interface RetrievePackPracticesResult {
+  readonly pack: InstalledPackSummary;
+  readonly practices: readonly ListedPractice[];
+}
+
+export interface ListRequest {
+  /** Per-call LocalStore root override; omitted uses the service default. */
+  readonly storageRoot?: StorageRoot;
+}
+
+export interface ListPackRequest {
+  readonly packName: string;
+  /** Per-call LocalStore root override; omitted uses the service default. */
+  readonly storageRoot?: StorageRoot;
+}
+
+export interface ListPacksResult extends RetrievePacksResult {
+  readonly generation: number;
+  readonly effectiveRevision: number;
+}
+
+export interface ListPackPracticesResult extends RetrievePackPracticesResult {
+  readonly generation: number;
+  readonly effectiveRevision: number;
+}

--- a/packages/engine/src/local-store/index.ts
+++ b/packages/engine/src/local-store/index.ts
@@ -9,6 +9,7 @@ export {
   defaultStorageRoot,
   type LocalStore,
   type OpenResult,
+  type InstalledPackSummary,
   type StorageRoot,
   type StoreSnapshotIdentity,
   type EffectivePracticeSnapshot,

--- a/packages/engine/src/local-store/lifecycle/local-store.test.ts
+++ b/packages/engine/src/local-store/lifecycle/local-store.test.ts
@@ -92,6 +92,7 @@ test("fresh store open + install + reopen round-trips state", async () => {
     const store = createLocalStore();
     const opened = await store.open(root);
     expect(opened.generation).toBe(0);
+    expect(opened.packs).toEqual([]);
     expect(opened.effectivePractices).toEqual([]);
 
     const installed = await store.install(root, candidate("platform", platform));
@@ -102,11 +103,28 @@ test("fresh store open + install + reopen round-trips state", async () => {
 
     const reopened = await store.open(root);
     expect(reopened.generation).toBe(1);
+    expect(reopened.packs).toEqual([{ name: "platform", version: "1.0.0" }]);
     expect(reopened.effectivePractices.map((p) => p.practiceId)).toEqual([
       "platform.api",
       "platform.auth",
     ]);
     expect(await store.readEffectivePractices(root)).toHaveLength(2);
+  });
+});
+
+test("open exposes minimal installed Pack summaries in manifest order", async () => {
+  await withRoot(async (root) => {
+    const store = createLocalStore();
+    await store.install(root, candidate("platform", platform));
+    await store.install(root, candidate("web", web));
+
+    const opened = await store.open(root);
+    expect(opened.packs).toEqual([
+      { name: "platform", version: "1.0.0" },
+      { name: "web", version: "1.0.0" },
+    ]);
+    expect(Object.isFrozen(opened.packs)).toBe(true);
+    expect(Object.isFrozen(opened.packs[0])).toBe(true);
   });
 });
 

--- a/packages/engine/src/local-store/lifecycle/local-store.ts
+++ b/packages/engine/src/local-store/lifecycle/local-store.ts
@@ -33,9 +33,16 @@ export function defaultStorageRoot(): StorageRoot {
 }
 
 export interface OpenResult {
-  generation: number;
-  effectiveRevision: number;
-  effectivePractices: readonly EffectivePractice[];
+  readonly generation: number;
+  readonly effectiveRevision: number;
+  readonly packs: readonly InstalledPackSummary[];
+  readonly effectivePractices: readonly EffectivePractice[];
+}
+
+/** The public projection of one active manifest Pack entry. */
+export interface InstalledPackSummary {
+  readonly name: string;
+  readonly version: string;
 }
 
 export interface LocalStore {
@@ -99,6 +106,11 @@ export function createLocalStore(
       return {
         generation: result.manifest.generation,
         effectiveRevision: result.manifest.effectiveRevision,
+        packs: Object.freeze(
+          result.manifest.packs.map((pack) =>
+            Object.freeze({ name: pack.packName, version: pack.packVersion }),
+          ),
+        ),
         effectivePractices: result.effectivePractices,
       };
     },


### PR DESCRIPTION
## Summary

新增基于 LocalStore 的 `lore list` 目录发现能力，支持先发现已安装 Pack，再查看指定 Pack 的 Practice 摘要，并将返回的 Practice ID 交给 `lore get`。

本 PR 只包含 list 的 Engine、CLI、LocalStore 扩展、文档和测试，不修改现有 query/get 语义。

## Linked issue

Closes #91

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs only
- [ ] Refactor / chore

## Scope

- 新增 `lore list [--store-root <path>]`，返回 Pack 名称、版本和 `practiceCount`。
- 新增 `lore list --pack <name> [--store-root <path>]`，返回 Practice 的 `id`、`title`、`applies_when` 摘要。
- 基于同一次 LocalStore 快照计算 Pack 目录和 Practice 目录。
- `practiceCount` 按 Effective Practice 的 source claim 统计；多个 Pack 提供同一 Practice 时分别计数。
- 增加 `list.pack-not-found`、参数校验、result schema、command discovery 和错误映射。
- 空 Store 返回成功空列表；已安装但没有 Practice 的 Pack 返回成功空目录。
- 更新 ADR、CLI 文档、开发文档和 `list -> list --pack -> get` integration。

明确不包含 Registry search、语义检索、模糊匹配、分页、过滤、MCP、Skill、Plugin、Hook、Store 新表或派生索引。

## Design context

- ADR 0007: LocalStore lifecycle
- ADR 0011: LocalStore point-read and query boundary
- ADR 0012: persistent keyword index
- ADR 0013: incremental LocalStore projection writes
- 新增 ADR 0014: LocalStore-backed list catalog contract

## How was this tested?

- `bun test packages/engine/src/list packages/cli/src/list packages/cli/src/registry.test.ts packages/cli/src/main.test.ts`: 57 pass / 0 fail
- `bun run --filter @lorelum/engine typecheck`: passed
- `bun run --filter @lorelum/cli typecheck`: passed
- `bun run lint`: passed; only existing site `_splat` warnings remain
- `bun run test:integration`: passed
- `bun run build:cli`: passed
- Full `bun test`: 458 pass; 3 existing Windows environment failures:
  - Git fixture cannot access `\\.\nul`
  - symlink creation returns `EPERM`
  - Windows path assertion expects POSIX formatting

## Checklist

- [x] Linked the issue this closes (`Closes #91`)
- [x] Product behavior and boundaries are defined in Issue #91 and ADR 0014
- [x] Added/updated tests for the changed behavior
- [x] Engine and CLI typecheck passed
- [x] Lint passed
- [x] Integration test and CLI build passed
- [x] Updated relevant documentation
- [x] No secrets, credentials, Store data, binaries, or generated runtime files included

## AI assistance and review

- [x] This PR used AI assistance for implementation and documentation.
- [x] AI review covered the list contract, LocalStore snapshot boundary, error mapping, test coverage, and PR scope. No unresolved material findings remain.

## Notes for reviewers

Please focus on:

1. Whether `LocalStore.open()` exposes only the required Pack name/version summary.
2. Whether `practiceCount` is correctly calculated from source claims without duplicate counting.
3. Whether `list --pack` returns only Practices claimed by the selected Pack.
4. Whether CLI remains an adapter and does not read manifest, SQLite, artifact, or Pack paths directly.
5. Whether the returned Practice ID can be passed directly to the existing `lore get`.
6. Whether the diff remains limited to the list feature and its required tests/documentation.
