### PR TITLE
feat(backend): add local service and shared YAML configuration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,15 @@
         "wrangler": "^4.74.0",
       },
     },
+    "packages/backend": {
+      "name": "@lorelum/backend",
+      "version": "0.0.0",
+      "dependencies": {
+        "@lorelum/shared": "workspace:*",
+        "elysia": "1.4.30",
+        "zod": "4.4.3",
+      },
+    },
     "packages/cli": {
       "name": "@lorelum/cli",
       "version": "0.0.0",
@@ -96,6 +105,12 @@
     "packages/shared": {
       "name": "@lorelum/shared",
       "version": "0.0.0",
+      "dependencies": {
+        "js-yaml": "4.3.1",
+      },
+      "devDependencies": {
+        "@types/js-yaml": "4.0.9",
+      },
     },
   },
   "overrides": {
@@ -139,6 +154,8 @@
     "@base-ui/react": ["@base-ui/react@1.7.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.3.2", "@floating-ui/react-dom": "^2.1.9", "@floating-ui/utils": "^0.2.12", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug=="],
 
     "@base-ui/utils": ["@base-ui/utils@0.3.2", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.12", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
@@ -296,6 +313,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@lorelum/backend": ["@lorelum/backend@workspace:packages/backend"],
+
     "@lorelum/cli": ["@lorelum/cli@workspace:packages/cli"],
 
     "@lorelum/engine": ["@lorelum/engine@workspace:packages/engine"],
@@ -452,6 +471,8 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.24", "", {}, "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw=="],
@@ -527,6 +548,10 @@
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 
@@ -668,7 +693,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
@@ -703,6 +728,8 @@
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.409", "", {}, "sha512-ChI4N44d0B4A6C8prnNjMOaGgE59fUyEVYcRYm2XEXIjMbbvF5i9UL1cblDbpGqiU0uS8FE8UcKxqZqTXdmzbQ=="],
+
+    "elysia": ["elysia@1.4.30", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-S2qqV0CbM4faB1hQQ5IYoeYnAUinjHlzRduxaBc4OoNqh0GjOc8k6tt3hv5ozWcG6Svr6hugw6JL4zNke4jwfA=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -752,6 +779,8 @@
 
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
+    "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
+
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
@@ -762,6 +791,8 @@
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
@@ -771,6 +802,8 @@
     "fetchdts": ["fetchdts@0.1.7", "", {}, "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA=="],
 
     "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
+    "file-type": ["file-type@22.0.2", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-0H8TsCUGBLx+V5adH3EY52hTAcyLKbV1D4gq5cIOJ6DnQAHeV9Z2Hhuc5CoBX4YmvB2oL+JIC84z0qO7JsCoNw=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -964,6 +997,8 @@
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
+    "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
+
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
@@ -1075,6 +1110,8 @@
     "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "oxfmt": ["oxfmt@0.59.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.59.0", "@oxfmt/binding-android-arm64": "0.59.0", "@oxfmt/binding-darwin-arm64": "0.59.0", "@oxfmt/binding-darwin-x64": "0.59.0", "@oxfmt/binding-freebsd-x64": "0.59.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.59.0", "@oxfmt/binding-linux-arm-musleabihf": "0.59.0", "@oxfmt/binding-linux-arm64-gnu": "0.59.0", "@oxfmt/binding-linux-arm64-musl": "0.59.0", "@oxfmt/binding-linux-ppc64-gnu": "0.59.0", "@oxfmt/binding-linux-riscv64-gnu": "0.59.0", "@oxfmt/binding-linux-riscv64-musl": "0.59.0", "@oxfmt/binding-linux-s390x-gnu": "0.59.0", "@oxfmt/binding-linux-x64-gnu": "0.59.0", "@oxfmt/binding-linux-x64-musl": "0.59.0", "@oxfmt/binding-openharmony-arm64": "0.59.0", "@oxfmt/binding-win32-arm64-msvc": "0.59.0", "@oxfmt/binding-win32-ia32-msvc": "0.59.0", "@oxfmt/binding-win32-x64-msvc": "0.59.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w=="],
 
@@ -1216,6 +1253,8 @@
 
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
@@ -1238,6 +1277,8 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
@@ -1249,6 +1290,8 @@
     "typescript": ["typescript@5.7.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg=="],
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
@@ -1374,6 +1417,8 @@
 
     "bun-types/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "fumadocs-ui/motion": ["motion@13.1.0", "", { "dependencies": { "framer-motion": "^13.1.0", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-qtvscq59uCPdWnNW4SdSkrxR+BS/QYsa923bx7ocA+4p+ZGNbbVQwkSnG4aukB81QWjtl3AxX36plxNyZLmHCA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -1383,8 +1428,6 @@
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
-
-    "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -21,6 +21,7 @@ This is the index for day-to-day development topics that do not belong in the pr
 ## Proposed plans
 
 - [Query phased implementation roadmap (Chinese)](../plans/query-roadmap.md) - keyword retrieval, configuration, embedding profiles, and derived indexes. The keyword query foundation is implemented; later phases remain proposed.
+- [Local resident backend design (Chinese)](../plans/local-backend-service-design.md) - approved first-stage service lifecycle, shared configuration, and Store isolation; model residency remains deferred.
 
 ## Local CLI and multiple worktrees
 

--- a/docs/plans/local-backend-service-design.md
+++ b/docs/plans/local-backend-service-design.md
@@ -1,0 +1,96 @@
+# 本地后端：第一阶段
+
+- 状态：Owner 已授权 B1–B3；实现按 B1、B2、B3 分别提交 PR，后续模型阶段仍需单独启动。
+- 本 PR 交付 B1 服务与共享配置基础；B2 进程控制和 B3 Query 接入由依赖 PR 交付。下文描述完整第一阶段合同。
+- Issue：#95（服务基础）、#96（进程管理）、#97（Query 接入）。
+- 相关设计：[Semantic Query v1](./semantic-query-v1-design.md)。
+
+## 当前范围
+
+使用 **Elysia + Bun + TypeScript** 建立常驻服务，固定监听 `127.0.0.1:26186`。提供 `lore backend start/status/stop`，并允许本地客户端通过 HTTP 调用现有 keyword QueryService。不同 Store 共用服务，每个请求明确传入自己的绝对 Store root。
+
+本轮保留现有 CLI 命令结构。HTTP client 和进程控制入口本身保持轻量；**完整 CLI 的启动优化另行测量和实施，本轮不承诺降低 fresh CLI 延迟。**
+
+不加载 embedding 模型，不改变 `lore query` 的默认行为，不迁移 Store 写入，不添加 MCP、模型下载、后台 index 构建或登录自启。原定 B4–B6 留待后续阶段。
+
+## 代码如何组织
+
+参考 [Elysia Best Practice](https://elysiajs.com/essential/best-practice.md)，按功能组织 controller、service 和 model：
+
+```text
+packages/backend/src/
+  app.ts                         # 组装模块及统一错误边界
+  app.test.ts                    # HTTP 合同与真实 Store 集成验证
+  modules/
+    backend/
+      controller.ts              # identity、status、stop 路由
+      service.ts                 # 就绪、停止状态和幂等关闭
+      model.ts                   # 请求/响应 DTO schema 与推导类型
+    query/
+      controller.ts              # 调用已有 Engine QueryService
+      model.ts                   # 查询请求/响应 DTO schema
+  plugins/local-auth.ts          # loopback、Host、Origin、认证边界
+  config/                        # 配置 schema、文件/env 读取、内部启动参数
+  runtime/                       # OS 进程、启动互斥、私有文件、日志
+  client/                        # HTTP 客户端及依赖隔离测试
+  protocol/                      # 跨模块错误、协议常量、身份签名
+```
+
+- Controller 使用 Elysia 实例和内联 handler，让框架推导 Context；只传普通参数给 service，不将整个 Context 传入业务层。
+- Backend service 拥有服务内状态；runtime supervisor 拥有外部进程启动/停止及资源回收。HTTP controller 不发现 PID、不直接执行文件或 SQL 操作。
+- Query 复用 Engine 中的 QueryService，不新增纯转发 service。snapshot、排序、候选回读和 digest 校验继续由 Engine 所有。
+- Model 是 DTO schema，同时推导 TypeScript 类型。共享 schema 使用 Zod，通过 Standard Schema 接入 Elysia 校验；client 复用相同定义，不加载 Elysia 服务端。不另写 DTO class 或重复类型。
+- `app.ts` 不堆业务逻辑。`index.ts` 遵循仓库规范，只做 re-export；官方示例中的路由入口在本仓库命名为 `controller.ts`。
+
+包导出分别为 `./client`、`./protocol`、`./control`、`./server`、`./daemon`。前两类客户端入口和 `./control` 不导入 server/Engine 运行时代码；完整 CLI 仍保留现有 Engine 依赖。
+
+## 可见行为
+
+| 命令                  | 行为                                                                     |
+| --------------------- | ------------------------------------------------------------------------ |
+| `lore backend start`  | 幂等启动一个兼容实例，等待初始化完成并通过身份验证。                     |
+| `lore backend status` | 返回 starting/ready/stopping/stopped；不启动服务、不创建缺失的运行目录。 |
+| `lore backend stop`   | 请求经过验证的实例停止，确认它退出后才报告成功；未运行时幂等成功。       |
+
+命令继续使用现有 CLI 单行 JSON envelope 和退出码：成功为 0，失败为 2。第一阶段的模型状态固定为 `unloaded`。全局 `--store-root` 不影响控制命令；它们不读取 LocalStore。
+
+内部协议只供第一方客户端使用：
+
+| 路由 | 合同 |
+| --- | --- |
+| `GET /internal/v1/identity?nonce=...` | 返回实例、build、控制/业务协议版本和 nonce 签名；不接受或返回凭证。 |
+| `GET /internal/v1/status` | 认证后读取服务状态。 |
+| `POST /internal/v1/stop` | 认证后进入 stopping，响应发送后开始关闭；重复请求不重复执行关闭回调。 |
+| `POST /internal/v1/query` | 认证后接收 `{ storageRoot, query: { text, limit? } }`，返回现有 keyword 结果摘要。 |
+
+请求和成功响应都经 schema 校验，错误不返回内部 stack、私有路径或凭证。非法请求返回输入错误；服务产出非法响应属于服务端失败，不归咎调用方。Query 的领域错误沿用 `usage.invalid`、`query.*` 和 `store.*`。
+
+## 进程、身份和数据边界
+
+运行文件位于用户私有的 `~/.lorelum/run/backend/`，目录权限 0700，实例凭证文件 0600。它与 Store config/index 分离，不受 `--store-root` 重定向；拒绝不安全权限和符号链接。
+
+并发启动使用独立 `control.sqlite` 的 `BEGIN IMMEDIATE` writer lock。它不保存业务数据，进程崩溃会释放锁。父 CLI 先记录子进程身份，再通过 stdin 授予启动许可；子进程完成监听与初始化后才报告 ready。服务只继承必需的环境变量，不保留 CLI 环境里的无关密钥。
+
+身份握手通过私有密钥验证随机 nonce 的 HMAC；确认服务身份后才发送 bearer 和业务数据。拒绝浏览器 Origin、非预期 Host 和超过限制的请求；客户端禁用代理、重定向并限制响应大小/等待时间。该边界不承诺隔离能读取同一用户私有文件的程序。
+
+控制协议和业务协议分开：兼容控制协议的新 CLI 可以显式停止旧 build；Query 必须匹配业务版本和 build。端口被其他进程占用时明确失败，不另选外部端口，不按端口或进程名杀进程。
+
+停止时不再接受新查询，限时等待在途请求，再释放监听。控制端核对 PID 与进程启动时间，不将 PID 本身视为所有权。异常退出的 descriptor 只有确认旧实例失效后才清理。日志有大小上限，只写生命周期事件。
+
+Store 的 canonical 内容、完整 snapshot 和跨进程 writer lock 仍由 Engine 所有。本阶段不缓存现有 SQLite/FTS handle；外部进程更新 Store 后，下一次查询继续执行现有 snapshot/revision 校验。
+
+## 验收与后续
+
+| Task | 本轮完成标准 |
+| --- | --- |
+| B1 服务基础 | Elysia 模块职责明确；身份、认证、DTO、错误、请求与响应边界可测试。 |
+| B2 进程管理 | 并发启动单实例；CLI 退出后服务存活；正常停止、旧 build 控制与崩溃恢复通过真实子进程验证。 |
+| B3 Query 接入 | HTTP 与 Engine 结果一致；多 Store 隔离、外部 mutation 可见；client/control 包导出不加载服务端。 |
+
+保留真实 SQLite 和进程测试；单元测试不访问模型/registry，不使用用户 Store 或运行目录。依赖隔离测试检查完整构建图，不将被检查模块设为 external，并用服务端构建作正向对照。
+
+实现 PR 需要通过相关测试、lint、typecheck 和完整 diff 审查。必要的安全与恢复用例不能为了减少行数删除。CLI 全局懒加载和完整性能矩阵已移出本轮；在获得配对测量后另行提出小范围改动，不能把服务存活当作性能收益。
+
+配置由 config 层统一读取和校验，优先级为默认值 < 可选的 `~/.lorelum/config.yaml` 中的 `backend` 段 < 明确命名的环境变量 < 内部显式注入。当前仅开放启动、请求、退出超时（毫秒，1–120000），监听地址仍固定。每次控制命令读取配置，daemon 使用启动时保存的快照，重启后更新。内部启动握手参数和生成的实例凭证不属于用户配置；业务层只接收已解析的配置，不读取文件或环境变量。
+
+共享 YAML 文件由 `packages/shared/src/config/` 读取，保留各模块的配置段；后端 config 层校验 `backend` 段并合并环境变量。其他模块及后端未来使用的其他配置均复用共享读取入口，各自负责领域校验，无需依赖后端包。

--- a/docs/plans/semantic-query-v1-design.md
+++ b/docs/plans/semantic-query-v1-design.md
@@ -5,6 +5,7 @@
 - 范围：为已安装的 Practice 增加本地优先的 semantic query；不实现 Hybrid 或后续检索优化。
 - 关联 Issue：[Semantic Query v1 设计 #92](https://github.com/lorelum/lorelum/issues/92)、[后续模型评测 #85](https://github.com/lorelum/lorelum/issues/85)。
 - 前置文档：[Query 功能路线](./query-implementation-design.md)、[持久关键词 index ADR](../adr/0012-persistent-keyword-index.md)、[Query CLI 合同](../cli/query.md)。
+- 后续设计：[本地常驻后端](./local-backend-service-design.md) 承接已批准的服务基础、进程管理与 keyword HTTP 接入；模型驻留仍留待后续阶段。
 
 ## 结论
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@lorelum/backend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./client": "./src/client/index.ts",
+    "./protocol": "./src/protocol/index.ts",
+    "./server": "./src/app.ts",
+    "./config": "./src/config/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@lorelum/shared": "workspace:*",
+    "elysia": "1.4.30",
+    "zod": "4.4.3"
+  }
+}

--- a/packages/backend/src/app.test.ts
+++ b/packages/backend/src/app.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { createBackendApp } from "./app";
+import { createBackendService } from "./modules/backend/service";
+
+const identity = Object.freeze({
+  instanceId: "test-instance",
+  buildIdentity: "test-build",
+  controlVersion: 1,
+  businessVersion: 1,
+});
+const secret = "a secret used only by tests";
+
+function request(path: string, init: RequestInit = {}): Request {
+  return new Request(`http://127.0.0.1${path}`, {
+    ...init,
+    headers: { host: "127.0.0.1:26186", ...init.headers },
+  });
+}
+
+function app(
+  onStop = () => undefined,
+  instanceIdentity: typeof identity = identity,
+  isReady: () => boolean = () => true,
+  onStopFailure: (error: unknown) => void = () => undefined,
+) {
+  return createBackendApp({
+    backend: createBackendService({
+      identity: instanceIdentity,
+      secret,
+      onStop,
+      onStopFailure,
+      isReady,
+    }),
+  });
+}
+
+describe("createBackendApp", () => {
+  test("returns a nonce-bound identity without accepting credentials", async () => {
+    const response = await app().handle(
+      request(
+        "/internal/v1/identity?nonce=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ ...identity, proof: expect.any(String) });
+  });
+
+  test("whitelists identity fields before putting them on the wire", async () => {
+    const withPrivateRuntimeField = Object.assign({}, identity, { runtimeSecret: "must-not-leak" });
+    const response = await app(() => undefined, withPrivateRuntimeField).handle(
+      request(
+        "/internal/v1/identity?nonce=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      ),
+    );
+
+    expect(await response.json()).toEqual({ ...identity, proof: expect.any(String) });
+  });
+
+  test("rejects browser origins, an unexpected host, and missing credentials", async () => {
+    const instance = app();
+    expect(
+      (
+        await instance.handle(
+          request("/internal/v1/status", {
+            headers: { host: "127.0.0.1", origin: "https://example.test" },
+          }),
+        )
+      ).status,
+    ).toBe(403);
+    expect(
+      (
+        await instance.handle(
+          new Request("http://example.test/internal/v1/status", {
+            headers: { host: "example.test:26186" },
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    expect((await instance.handle(request("/internal/v1/status"))).status).toBe(401);
+  });
+
+  test("returns stopping before calling lifecycle shutdown", async () => {
+    let stopped = false;
+    const response = await app(() => {
+      stopped = true;
+    }).handle(
+      request("/internal/v1/stop", {
+        method: "POST",
+        headers: { host: "127.0.0.1:26186", authorization: `Bearer ${secret}` },
+      }),
+    );
+
+    expect(await response.json()).toMatchObject({ state: "stopping", model: "unloaded" });
+    expect(stopped).toBe(false);
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    expect(stopped).toBe(true);
+  });
+
+  test("reports a synchronous stop callback failure after scheduling its response", async () => {
+    const failures: unknown[] = [];
+    const response = await app(
+      () => {
+        throw new Error("test lifecycle failure");
+      },
+      identity,
+      () => true,
+      (error) => failures.push(error),
+    ).handle(
+      request("/internal/v1/stop", {
+        method: "POST",
+        headers: { host: "127.0.0.1:26186", authorization: `Bearer ${secret}` },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    expect(failures).toEqual([expect.objectContaining({ message: "test lifecycle failure" })]);
+  });
+});

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,0 +1,35 @@
+import { Elysia } from "elysia";
+import { backendController } from "./modules/backend/controller";
+import type { BackendService } from "./modules/backend/service";
+import { localBoundary, reject } from "./plugins/local-auth";
+import { BACKEND_HOST, BACKEND_PORT } from "./protocol/constants";
+
+export interface CreateBackendAppOptions {
+  readonly backend: BackendService;
+  /** Internal test injection; production always uses the fixed IPv4 endpoint. */
+  readonly host?: string;
+  readonly port?: number;
+}
+
+/** Composition only: feature controllers own routes, services own state. */
+export function createBackendApp(options: CreateBackendAppOptions) {
+  const port = options.port ?? BACKEND_PORT;
+  if (
+    (options.host ?? BACKEND_HOST) !== BACKEND_HOST ||
+    !Number.isInteger(port) ||
+    port < 0 ||
+    port > 65_535
+  ) {
+    throw new TypeError("Invalid local backend configuration");
+  }
+  const { backend } = options;
+  return new Elysia({ normalize: false })
+    .use(localBoundary(port, backend.authenticate))
+    .onError(({ code, error }) => {
+      const responseFailure = "type" in error && error.type === "response";
+      return (code === "VALIDATION" && !responseFailure) || code === "PARSE" || code === "NOT_FOUND"
+        ? reject(400, "backend.invalid-request")
+        : reject(500, "backend.failed");
+    })
+    .use(backendController(backend));
+}

--- a/packages/backend/src/client/boundary.test.ts
+++ b/packages/backend/src/client/boundary.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+
+async function bundledInputs(entrypoints: string[]): Promise<string[]> {
+  // Isolate Bun's resolver cache between the small client and workspace server builds.
+  const script = `const result = await Bun.build({ entrypoints: ${JSON.stringify(entrypoints)}, target: "bun", metafile: true });
+    if (!result.success) throw new Error("Boundary build failed");
+    console.log(JSON.stringify(Object.keys(result.metafile.inputs)));`;
+  const process = Bun.spawn([Bun.which("bun")!, "-e", script], { stdout: "pipe", stderr: "pipe" });
+  const [output, errors, exit] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  expect(exit).toBe(0);
+  expect(errors).toBe("");
+  const inputs: unknown = JSON.parse(output);
+  if (
+    !Array.isArray(inputs) ||
+    !inputs.every((value): value is string => typeof value === "string")
+  )
+    throw new Error("Invalid build metadata");
+  return inputs;
+}
+const engine = (path: string) => path.includes("packages/engine/src/");
+const elysia = (path: string) => path.includes("node_modules/elysia/");
+
+test("client exports exclude server dependencies; server build is the positive control", async () => {
+  // No external exclusions: follow the actual complete resolved dependency graph.
+  const client = await bundledInputs([join(import.meta.dir, "index.ts")]);
+  expect(client.some((path) => path.endsWith("client/client.ts"))).toBe(true);
+  expect(client.some(engine)).toBe(false);
+  expect(client.some(elysia)).toBe(false);
+  const server = await bundledInputs([join(import.meta.dir, "../app.ts")]);
+  expect(server.some(engine)).toBe(false);
+  expect(server.some(elysia)).toBe(true);
+});

--- a/packages/backend/src/client/client.test.ts
+++ b/packages/backend/src/client/client.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createBackendApp } from "../app";
+import { createBackendService } from "../modules/backend/service";
+import type { InstanceIdentity } from "../protocol/identity";
+import { createBackendClient } from "./client";
+
+const identity = Object.freeze({
+  instanceId: "test-instance",
+  buildIdentity: "test-build",
+  controlVersion: 1,
+  businessVersion: 1,
+});
+const secret = "a secret used only by tests";
+const apps: Array<ReturnType<typeof createBackendApp>> = [];
+
+afterEach(() => {
+  for (const app of apps.splice(0)) app.stop(true);
+});
+
+function runningApp(backendIdentity: InstanceIdentity = identity): {
+  readonly app: ReturnType<typeof createBackendApp>;
+  readonly url: string;
+} {
+  const app = createBackendApp({
+    backend: createBackendService({ identity: backendIdentity, secret, onStop: () => undefined }),
+  });
+  apps.push(app);
+  app.listen({ hostname: "127.0.0.1", port: 0, maxRequestBodySize: 65_536 });
+  if (app.server === null) throw new Error("test server did not start");
+  return { app, url: `http://127.0.0.1:${app.server.port}` };
+}
+
+describe("createBackendClient", () => {
+  test("allows a compatible control client to stop an older build", async () => {
+    const { url } = runningApp();
+    const client = createBackendClient({
+      identity,
+      secret,
+      buildIdentity: "newer-build",
+      baseUrl: url,
+    });
+
+    await expect(client.status()).resolves.toMatchObject({ state: "ready" });
+    await expect(client.stop()).resolves.toMatchObject({ state: "stopping" });
+  });
+
+  test("rejects non-loopback client URLs", () => {
+    expect(() =>
+      createBackendClient({
+        identity,
+        secret,
+        buildIdentity: "test-build",
+        baseUrl: "http://example.test",
+      }),
+    ).toThrow(TypeError);
+    expect(() =>
+      createBackendClient({
+        identity,
+        secret,
+        buildIdentity: "test-build",
+        baseUrl: "http://localhost:26186/query",
+      }),
+    ).toThrow(TypeError);
+  });
+});

--- a/packages/backend/src/client/client.ts
+++ b/packages/backend/src/client/client.ts
@@ -1,0 +1,202 @@
+import { randomBytes } from "node:crypto";
+
+import {
+  BACKEND_URL,
+  BUSINESS_VERSION,
+  CONTROL_VERSION,
+  MAX_RESPONSE_BYTES,
+} from "../protocol/constants";
+import {
+  errorSchema,
+  BackendRemoteError,
+  backendRemoteErrorCodes,
+  BackendError,
+  backendErrorCodes,
+} from "../protocol/errors";
+import { constantTimeEqual, identityProof, type InstanceIdentity } from "../protocol/identity";
+import {
+  identitySchema,
+  statusSchema,
+  type BackendIdentity,
+  type BackendStatus,
+} from "../modules/backend/model";
+import { DEFAULT_BACKEND_SETTINGS } from "../config/model";
+
+export interface CreateBackendClientOptions {
+  readonly identity: InstanceIdentity;
+  readonly secret: string;
+  /** Test-only alternate loopback HTTP address. */
+  readonly baseUrl?: string;
+  readonly buildIdentity: string;
+  readonly timeoutMs?: number;
+}
+
+export interface BackendClient {
+  identity(): Promise<BackendIdentity>;
+  status(): Promise<BackendStatus>;
+  stop(): Promise<BackendStatus>;
+}
+
+function validatedLoopbackUrl(value: string): URL {
+  const url = new URL(value);
+  if (url.protocol !== "http:" || url.username !== "" || url.password !== "") {
+    throw new TypeError("Backend URL must be an unauthenticated HTTP loopback URL");
+  }
+  if (url.hostname !== "127.0.0.1") {
+    throw new TypeError("Backend URL must use a loopback host");
+  }
+  if (url.pathname !== "/" || url.search !== "" || url.hash !== "") {
+    throw new TypeError("Backend URL must not include a path, query, or fragment");
+  }
+  return url;
+}
+
+function isTimeout(error: unknown): boolean {
+  return (
+    typeof error === "object" && error !== null && "name" in error && error.name === "TimeoutError"
+  );
+}
+
+async function readBoundedJson(response: Response, signal: AbortSignal): Promise<unknown> {
+  const reader = response.body?.getReader();
+  if (reader === undefined) throw new BackendError("backend.failed");
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      // A response body is ordered; each chunk must be consumed before the next.
+      // eslint-disable-next-line no-await-in-loop
+      const next = await reader.read();
+      if (next.done) break;
+      size += next.value.byteLength;
+      if (size > MAX_RESPONSE_BYTES) {
+        // eslint-disable-next-line no-await-in-loop
+        await reader.cancel();
+        throw new BackendError("backend.failed");
+      }
+      chunks.push(next.value);
+    }
+  } catch (error) {
+    if (error instanceof BackendError) throw error;
+    if (signal.aborted || isTimeout(error)) {
+      throw new BackendError("backend.deadline-exceeded", { cause: error });
+    }
+    throw new BackendError("backend.failed", { cause: error });
+  } finally {
+    reader.releaseLock();
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(Buffer.concat(chunks)));
+  } catch {
+    throw new BackendError("backend.failed");
+  }
+}
+
+function remoteError(body: unknown): Error | undefined {
+  const parsed = errorSchema.safeParse(body);
+  if (!parsed.success) return undefined;
+  if ((backendErrorCodes as readonly string[]).includes(parsed.data.error.code)) {
+    return new BackendError(parsed.data.error.code as (typeof backendErrorCodes)[number]);
+  }
+  if ((backendRemoteErrorCodes as readonly string[]).includes(parsed.data.error.code)) {
+    return new BackendRemoteError(
+      parsed.data.error.code as (typeof backendRemoteErrorCodes)[number],
+    );
+  }
+  return new BackendError("backend.failed");
+}
+
+/** A fetch-only client boundary; it has no runtime dependency on Engine or Elysia. */
+export function createBackendClient(options: CreateBackendClientOptions): BackendClient {
+  if (options.secret.length === 0) throw new TypeError("Backend secret must not be empty");
+  if (options.buildIdentity.length === 0) throw new TypeError("Build identity must not be empty");
+  const timeoutMs = options.timeoutMs ?? DEFAULT_BACKEND_SETTINGS.requestTimeoutMs;
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1)
+    throw new TypeError("Timeout must be a positive integer");
+  const baseUrl = validatedLoopbackUrl(options.baseUrl ?? BACKEND_URL);
+
+  const send = async (path: string, init: RequestInit = {}): Promise<unknown> => {
+    const url = new URL(path, baseUrl);
+    const signal = AbortSignal.timeout(timeoutMs);
+    const response = await fetch(url, {
+      ...init,
+      redirect: "error",
+      proxy: "",
+      signal,
+      headers: { host: baseUrl.host, ...init.headers },
+    }).catch((error: unknown) => {
+      if (isTimeout(error)) {
+        throw new BackendError("backend.deadline-exceeded", { cause: error });
+      }
+      throw new BackendError("backend.unavailable", { cause: error });
+    });
+    const body = await readBoundedJson(response, signal);
+    if (!response.ok) throw remoteError(body) ?? new BackendError("backend.failed");
+    return body;
+  };
+
+  const identify = async (): Promise<BackendIdentity> => {
+    const nonce = randomBytes(32).toString("hex");
+    const body = await send(`/internal/v1/identity?nonce=${nonce}`);
+    const parsed = identitySchema.safeParse(body);
+    if (!parsed.success) throw new BackendError("backend.port-conflict");
+    const { proof, ...identity } = parsed.data;
+    if (!constantTimeEqual(proof, identityProof(options.secret, nonce, identity))) {
+      throw new BackendError("backend.port-conflict");
+    }
+    if (
+      identity.instanceId !== options.identity.instanceId ||
+      identity.buildIdentity !== options.identity.buildIdentity ||
+      identity.controlVersion !== CONTROL_VERSION
+    ) {
+      throw new BackendError("backend.incompatible");
+    }
+    return parsed.data;
+  };
+
+  const authorized = async (
+    strictBusinessBuild: boolean,
+  ): Promise<{
+    readonly headers: Record<string, string>;
+    readonly identity: BackendIdentity;
+  }> => {
+    const identity = await identify();
+    if (
+      strictBusinessBuild &&
+      (identity.buildIdentity !== options.buildIdentity ||
+        identity.businessVersion !== BUSINESS_VERSION)
+    ) {
+      throw new BackendError("backend.incompatible");
+    }
+    return { headers: { authorization: `Bearer ${options.secret}` }, identity };
+  };
+
+  const checkedStatus = (body: unknown, authenticated: BackendIdentity): BackendStatus => {
+    const parsed = statusSchema.safeParse(body);
+    if (
+      !parsed.success ||
+      parsed.data.instanceId !== authenticated.instanceId ||
+      parsed.data.buildIdentity !== authenticated.buildIdentity
+    ) {
+      throw new BackendError("backend.failed");
+    }
+    return parsed.data;
+  };
+
+  return Object.freeze({
+    identity: identify,
+    async status() {
+      const authenticated = await authorized(false);
+      const body = await send("/internal/v1/status", { headers: authenticated.headers });
+      return checkedStatus(body, authenticated.identity);
+    },
+    async stop() {
+      const authenticated = await authorized(false);
+      const body = await send("/internal/v1/stop", {
+        method: "POST",
+        headers: authenticated.headers,
+      });
+      return checkedStatus(body, authenticated.identity);
+    },
+  } satisfies BackendClient);
+}

--- a/packages/backend/src/client/index.ts
+++ b/packages/backend/src/client/index.ts
@@ -1,0 +1,1 @@
+export { createBackendClient, type BackendClient, type CreateBackendClientOptions } from "./client";

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -1,0 +1,13 @@
+export {
+  loadBackendConfig,
+  resolveBackendSettings,
+  defaultRuntimeDirectory,
+  type LoadBackendConfigOptions,
+} from "./load";
+export {
+  DEFAULT_BACKEND_SETTINGS,
+  backendSettingsSchema,
+  type BackendConfig,
+  type BackendSettings,
+  type Environment,
+} from "./model";

--- a/packages/backend/src/config/load.test.ts
+++ b/packages/backend/src/config/load.test.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadBackendConfig, resolveBackendSettings } from "./load";
+import { DEFAULT_BACKEND_SETTINGS } from "./model";
+
+async function fixture(run: (homeDirectory: string, filePath: string) => Promise<void>) {
+  const home = await mkdtemp(join(tmpdir(), "lorelum-config-"));
+  try {
+    await run(home, join(home, "config.yaml"));
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+}
+
+test("absent config uses defaults without creating files", () =>
+  fixture(async (homeDirectory) => {
+    const config = await loadBackendConfig({ homeDirectory, environment: {} });
+    expect(config.settings).toEqual(DEFAULT_BACKEND_SETTINGS);
+    expect(config.runtimeDirectory).toBe(join(homeDirectory, ".lorelum/run/backend"));
+    expect(await readdir(homeDirectory)).toEqual([]);
+    expect(Object.isFrozen(config)).toBe(true);
+    expect(Object.isFrozen(config.settings)).toBe(true);
+  }));
+
+test("file, environment and explicit values override defaults in order", () =>
+  fixture(async (homeDirectory, filePath) => {
+    await writeFile(filePath, "backend:\n  startupTimeoutMs: 2000\n  requestTimeoutMs: 3000\n");
+    const options = {
+      homeDirectory,
+      filePath,
+      environment: { LORELUM_BACKEND_REQUEST_TIMEOUT_MS: "4000" },
+    };
+    const config = await loadBackendConfig({ ...options, overrides: { shutdownTimeoutMs: 6000 } });
+    expect(config.settings).toEqual({
+      startupTimeoutMs: 2000,
+      requestTimeoutMs: 4000,
+      shutdownTimeoutMs: 6000,
+    });
+    await writeFile(filePath, "backend:\n  startupTimeoutMs: 9000\n");
+    expect(config.settings.startupTimeoutMs).toBe(2000);
+    expect((await loadBackendConfig(options)).settings.startupTimeoutMs).toBe(9000);
+  }));
+
+test("invalid sources are rejected even when later sources override them", () => {
+  expect(() =>
+    resolveBackendSettings({ requestTimeoutMs: -1 }, { requestTimeoutMs: 1000 }),
+  ).toThrow("The local backend configuration is invalid.");
+});
+
+for (const content of [
+  "null",
+  "{",
+  '{"backend":{"port":26186}}',
+  '{"backend":{"requestTimeoutMs":0}}',
+  '{"backend":{"requestTimeoutMs":1.5}}',
+  '{"backend":{"shutdownTimeoutMs":120001}}',
+  " ".repeat(16385),
+]) {
+  test(
+    "invalid config file is rejected without exposing its contents: " + content.slice(0, 30),
+    () =>
+      fixture(async (homeDirectory, filePath) => {
+        await writeFile(filePath, content);
+        await expect(
+          loadBackendConfig({
+            homeDirectory,
+            filePath,
+            environment: {},
+            overrides: { requestTimeoutMs: 1000 },
+          }),
+        ).rejects.toMatchObject({ code: "backend.config-invalid" });
+      }),
+  );
+}
+for (const value of ["", "-1", "1.5", "Infinity", "120001", " 1000"]) {
+  test("invalid environment timeout: " + value, () =>
+    fixture(async (homeDirectory) => {
+      await expect(
+        loadBackendConfig({
+          homeDirectory,
+          environment: { LORELUM_BACKEND_REQUEST_TIMEOUT_MS: value },
+        }),
+      ).rejects.toMatchObject({ code: "backend.config-invalid" });
+    }),
+  );
+}
+
+test("explicit undefined cannot erase a required resolved setting", () => {
+  expect(() => resolveBackendSettings({ requestTimeoutMs: undefined })).toThrow();
+});
+
+test("backend reads only its section from shared config", () =>
+  fixture(async (homeDirectory, filePath) => {
+    await writeFile(filePath, "backend:\n  requestTimeoutMs: 2000\nquery:\n  profile: local\n");
+    expect(
+      (await loadBackendConfig({ homeDirectory, filePath, environment: {} })).settings
+        .requestTimeoutMs,
+    ).toBe(2000);
+    await writeFile(filePath, "query:\n  profile: local\n");
+    expect(
+      (await loadBackendConfig({ homeDirectory, filePath, environment: {} })).settings,
+    ).toEqual(DEFAULT_BACKEND_SETTINGS);
+    await writeFile(filePath, "backend: null\n");
+    await expect(
+      loadBackendConfig({ homeDirectory, filePath, environment: {} }),
+    ).rejects.toMatchObject({ code: "backend.config-invalid" });
+  }));

--- a/packages/backend/src/config/load.ts
+++ b/packages/backend/src/config/load.ts
@@ -1,0 +1,71 @@
+import { loadConfig, ConfigError } from "@lorelum/shared/config";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { BackendError } from "../protocol/errors";
+import {
+  backendSettingsSchema,
+  DEFAULT_BACKEND_SETTINGS,
+  type BackendConfig,
+  type BackendSettings,
+  type Environment,
+} from "./model";
+
+const settingsSource = backendSettingsSchema.partial();
+const environmentKeys = {
+  startupTimeoutMs: "LORELUM_BACKEND_STARTUP_TIMEOUT_MS",
+  requestTimeoutMs: "LORELUM_BACKEND_REQUEST_TIMEOUT_MS",
+  shutdownTimeoutMs: "LORELUM_BACKEND_SHUTDOWN_TIMEOUT_MS",
+} as const;
+
+export function defaultRuntimeDirectory(homeDirectory = homedir()): string {
+  return join(homeDirectory, ".lorelum", "run", "backend");
+}
+
+/** Pure resolver for already-read sources; each source must be valid on its own. */
+export function resolveBackendSettings(...sources: readonly unknown[]): BackendSettings {
+  const values = sources.map((source) => {
+    const result = settingsSource.safeParse(source === undefined ? {} : source);
+    if (!result.success) throw new BackendError("backend.config-invalid");
+    return result.data;
+  });
+  const resolved = backendSettingsSchema.safeParse(
+    Object.assign({}, DEFAULT_BACKEND_SETTINGS, ...values),
+  );
+  if (!resolved.success) throw new BackendError("backend.config-invalid");
+  return Object.freeze(resolved.data);
+}
+
+export interface LoadBackendConfigOptions {
+  readonly homeDirectory?: string;
+  readonly filePath?: string;
+  readonly environment?: Environment;
+  /** Dependency injection, not an additional public CLI surface. */
+  readonly overrides?: Partial<BackendSettings>;
+}
+
+/** Defaults < shared YAML file < named environment values < explicit injection. No writes. */
+export async function loadBackendConfig(
+  options: LoadBackendConfigOptions = {},
+): Promise<BackendConfig> {
+  const homeDirectory = options.homeDirectory ?? homedir();
+  const environment = options.environment ?? process.env;
+  const fromEnvironment: Record<string, number> = {};
+  for (const [key, variable] of Object.entries(environmentKeys)) {
+    const value = environment[variable];
+    if (value === undefined) continue;
+    if (!/^[1-9][0-9]*$/.test(value)) throw new BackendError("backend.config-invalid");
+    fromEnvironment[key] = Number(value);
+  }
+  let document: Readonly<Record<string, unknown>>;
+  try {
+    document = await loadConfig(options);
+  } catch (error) {
+    if (error instanceof ConfigError) throw new BackendError("backend.config-invalid");
+    throw error;
+  }
+  const fromFile = document.backend;
+  return Object.freeze({
+    runtimeDirectory: defaultRuntimeDirectory(homeDirectory),
+    settings: resolveBackendSettings(fromFile, fromEnvironment, options.overrides),
+  });
+}

--- a/packages/backend/src/config/model.ts
+++ b/packages/backend/src/config/model.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+const timeout = z.number().int().min(1).max(120_000);
+export const backendSettingsSchema = z.strictObject({
+  startupTimeoutMs: timeout,
+  requestTimeoutMs: timeout,
+  shutdownTimeoutMs: timeout,
+});
+export type BackendSettings = Readonly<z.infer<typeof backendSettingsSchema>>;
+export const DEFAULT_BACKEND_SETTINGS: BackendSettings = Object.freeze({
+  startupTimeoutMs: 10_000,
+  requestTimeoutMs: 5_000,
+  shutdownTimeoutMs: 5_000,
+});
+export interface BackendConfig {
+  readonly runtimeDirectory: string;
+  readonly settings: BackendSettings;
+}
+export type Environment = Readonly<Record<string, string | undefined>>;

--- a/packages/backend/src/modules/backend/controller.ts
+++ b/packages/backend/src/modules/backend/controller.ts
@@ -1,0 +1,30 @@
+import { Elysia } from "elysia";
+import { identityQuerySchema, identitySchema, statusSchema } from "./model";
+import type { BackendService } from "./service";
+
+export function backendController(service: BackendService) {
+  const controls = new Elysia({ normalize: false })
+    .get("/status", () => service.status(), { response: { 200: statusSchema } })
+    .post(
+      "/stop",
+      () => {
+        const result = service.beginStop();
+        // Schedule shutdown after the HTTP response; the service makes it idempotent.
+        setTimeout(() => {
+          void service.stop();
+        }, 0);
+        return result;
+      },
+      { response: { 200: statusSchema } },
+    );
+
+  return new Elysia({ prefix: "/internal/v1", normalize: false })
+    .get(
+      "/identity",
+      ({ query }) => {
+        return service.identify(query.nonce);
+      },
+      { query: identityQuerySchema, response: { 200: identitySchema } },
+    )
+    .use(controls);
+}

--- a/packages/backend/src/modules/backend/model.ts
+++ b/packages/backend/src/modules/backend/model.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const identitySchema = z.strictObject({
+  instanceId: z.string().min(1).max(128),
+  buildIdentity: z.string().min(1).max(128),
+  controlVersion: z.int(),
+  businessVersion: z.int(),
+  proof: z.string().regex(/^[a-f0-9]{64}$/),
+});
+export type BackendIdentity = z.infer<typeof identitySchema>;
+export const backendStatusStates = ["starting", "ready", "stopping", "stopped"] as const;
+export const statusSchema = z.strictObject({
+  state: z.enum(backendStatusStates),
+  model: z.literal("unloaded"),
+  instanceId: z.string().optional(),
+  buildIdentity: z.string().optional(),
+});
+export type BackendStatus = z.infer<typeof statusSchema>;
+
+export const identityQuerySchema = z.strictObject({
+  nonce: z.string().regex(/^[a-f0-9]{64}$/),
+});

--- a/packages/backend/src/modules/backend/service.test.ts
+++ b/packages/backend/src/modules/backend/service.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { createBackendService } from "./service";
+
+test("concurrent stop calls share one shutdown and close admission without HTTP", async () => {
+  let ready = false;
+  let calls = 0;
+  let complete: () => void = () => undefined;
+  const pending = new Promise<void>((resolve) => {
+    complete = resolve;
+  });
+  const service = createBackendService({
+    identity: { instanceId: "test", buildIdentity: "test", controlVersion: 1, businessVersion: 1 },
+    secret: "test-only",
+    isReady: () => ready,
+    onStop: () => {
+      calls++;
+      return pending;
+    },
+  });
+  expect(service.status().state).toBe("starting");
+  ready = true;
+  expect(service.available()).toBe(true);
+  const first = service.stop();
+  const second = service.stop();
+  expect(first).toBe(second);
+  expect(service.available()).toBe(false);
+  expect(service.status().state).toBe("stopping");
+  await Promise.resolve();
+  expect(calls).toBe(1);
+  complete();
+  await first;
+});

--- a/packages/backend/src/modules/backend/service.ts
+++ b/packages/backend/src/modules/backend/service.ts
@@ -1,0 +1,51 @@
+import { constantTimeEqual, identityProof, type InstanceIdentity } from "../../protocol/identity";
+import type { BackendStatus } from "./model";
+
+export interface BackendServiceOptions {
+  readonly identity: InstanceIdentity;
+  readonly secret: string;
+  readonly isReady?: () => boolean;
+  readonly onStop: () => void | Promise<void>;
+  readonly onStopFailure?: (error: unknown) => void;
+}
+
+/** Owns this daemon's admission and stop state; no HTTP Context or process discovery. */
+export function createBackendService(options: BackendServiceOptions) {
+  if (!options.secret) throw new TypeError("Backend secret must not be empty");
+  // Select public fields explicitly: structural types may carry private runtime fields.
+  const { instanceId, buildIdentity, controlVersion, businessVersion } = options.identity;
+  const identity = Object.freeze({ instanceId, buildIdentity, controlVersion, businessVersion });
+  let stopping = false;
+  let shutdown: Promise<void> | undefined;
+  const available = () => !stopping && (options.isReady?.() ?? true);
+  const status = (): BackendStatus => ({
+    state: stopping ? "stopping" : available() ? "ready" : "starting",
+    model: "unloaded",
+    instanceId,
+    buildIdentity,
+  });
+  return {
+    authenticate: (credential: string) => constantTimeEqual(credential, options.secret),
+    available,
+    status,
+    identify: (nonce: string) => ({
+      ...identity,
+      proof: identityProof(options.secret, nonce, identity),
+    }),
+    beginStop() {
+      stopping = true;
+      return status();
+    },
+    stop(): Promise<void> {
+      stopping = true;
+      shutdown ??= Promise.resolve()
+        .then(options.onStop)
+        .catch((error) => {
+          if (options.onStopFailure) options.onStopFailure(error);
+          else console.error("Local backend lifecycle stop callback failed");
+        });
+      return shutdown;
+    },
+  };
+}
+export type BackendService = ReturnType<typeof createBackendService>;

--- a/packages/backend/src/plugins/local-auth.ts
+++ b/packages/backend/src/plugins/local-auth.ts
@@ -1,0 +1,49 @@
+import { Elysia } from "elysia";
+import { backendErrorBody, type BackendErrorCode } from "../protocol/errors";
+import { BACKEND_HOST, MAX_BODY_BYTES } from "../protocol/constants";
+
+export function reject(status: number, code: BackendErrorCode): Response {
+  return Response.json(backendErrorBody(code), { status });
+}
+
+/** Shared transport boundary, scoped to the application that installs this plugin. */
+export function localBoundary(port: number, authenticate: (credential: string) => boolean) {
+  let authority = `${BACKEND_HOST}:${port}`;
+  return new Elysia({ name: "lorelum.local-boundary" })
+    .onStart(({ server }) => {
+      if (server?.port !== undefined) authority = `${BACKEND_HOST}:${server.port}`;
+    })
+    .onRequest(({ request }) => {
+      if (request.headers.has("origin")) return reject(403, "backend.unauthorized");
+      if (request.headers.get("host") !== authority) return reject(400, "backend.invalid-request");
+      const publicIdentity =
+        request.method === "GET" && new URL(request.url).pathname === "/internal/v1/identity";
+      if (publicIdentity) {
+        if (request.headers.has("authorization") || request.headers.has("cookie"))
+          return reject(401, "backend.unauthorized");
+      } else return requireAuthorization(request, authenticate);
+    })
+    .as("scoped");
+}
+
+/** Installed only on protected controllers, before parsing any request body. */
+export function requireAuthorization(
+  request: Request,
+  authenticate: (credential: string) => boolean,
+): Response | undefined {
+  const header = request.headers.get("authorization") ?? "";
+  if (!header.startsWith("Bearer ") || !authenticate(header.slice(7))) {
+    return reject(401, "backend.unauthorized");
+  }
+}
+
+export function requireJson(request: Request): Response | undefined {
+  const type = request.headers.get("content-type") ?? "";
+  const length = request.headers.get("content-length");
+  if (
+    !/^application\/json(?:\s*;|\s*$)/i.test(type) ||
+    (length !== null && (!/^[0-9]+$/.test(length) || Number(length) > MAX_BODY_BYTES))
+  ) {
+    return reject(400, "backend.invalid-request");
+  }
+}

--- a/packages/backend/src/protocol/constants.ts
+++ b/packages/backend/src/protocol/constants.ts
@@ -1,0 +1,7 @@
+export const BACKEND_HOST = "127.0.0.1";
+export const BACKEND_PORT = 26186;
+export const BACKEND_URL = `http://${BACKEND_HOST}:${BACKEND_PORT}`;
+export const CONTROL_VERSION = 1;
+export const BUSINESS_VERSION = 1;
+export const MAX_BODY_BYTES = 65_536;
+export const MAX_RESPONSE_BYTES = 262_144;

--- a/packages/backend/src/protocol/errors.ts
+++ b/packages/backend/src/protocol/errors.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+export const backendErrorCodes = [
+  "backend.unavailable",
+  "backend.port-conflict",
+  "backend.incompatible",
+  "backend.unauthorized",
+  "backend.invalid-request",
+  "backend.busy",
+  "backend.deadline-exceeded",
+  "backend.state-invalid",
+  "backend.config-invalid",
+  "backend.failed",
+] as const;
+export type BackendErrorCode = (typeof backendErrorCodes)[number];
+
+const messages: Record<BackendErrorCode, string> = {
+  "backend.unavailable": "The local backend is not running.",
+  "backend.port-conflict": "The local backend address is occupied by an unverified service.",
+  "backend.incompatible": "The backend version differs; explicitly stop and restart it.",
+  "backend.unauthorized": "The local backend could not authenticate this request.",
+  "backend.invalid-request": "The backend request is invalid.",
+  "backend.busy": "The local backend is busy or stopping.",
+  "backend.deadline-exceeded": "The backend operation did not finish before its deadline.",
+  "backend.state-invalid": "The backend runtime state cannot be safely used or recovered.",
+  "backend.config-invalid": "The local backend configuration is invalid.",
+  "backend.failed": "The backend operation failed.",
+};
+export class BackendError extends Error {
+  constructor(
+    readonly code: BackendErrorCode,
+    options?: ErrorOptions,
+  ) {
+    super(messages[code], options);
+    this.name = "BackendError";
+  }
+}
+
+/** Domain failures intentionally keep the established CLI error identities. */
+export const backendRemoteErrorCodes = [
+  "usage.invalid",
+  "query.unavailable",
+  "query.failed",
+  "store.busy",
+  "store.recovery-required",
+] as const;
+export type BackendRemoteErrorCode = (typeof backendRemoteErrorCodes)[number];
+
+export class BackendRemoteError extends Error {
+  constructor(readonly code: BackendRemoteErrorCode) {
+    super("The local backend could not complete this request.");
+    this.name = "BackendRemoteError";
+  }
+}
+
+export const errorSchema = z.strictObject({
+  error: z.strictObject({ code: z.string(), message: z.string() }),
+});
+export type ErrorBody = z.infer<typeof errorSchema>;
+export function backendErrorBody(code: BackendErrorCode): ErrorBody {
+  return { error: { code, message: messages[code] } };
+}

--- a/packages/backend/src/protocol/identity.ts
+++ b/packages/backend/src/protocol/identity.ts
@@ -1,0 +1,22 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { BackendIdentity } from "../modules/backend/model";
+
+export type InstanceIdentity = Omit<BackendIdentity, "proof">;
+export function identityProof(secret: string, nonce: string, identity: InstanceIdentity): string {
+  return createHmac("sha256", secret)
+    .update(
+      JSON.stringify([
+        nonce,
+        identity.instanceId,
+        identity.buildIdentity,
+        identity.controlVersion,
+        identity.businessVersion,
+      ]),
+    )
+    .digest("hex");
+}
+export function constantTimeEqual(left: string, right: string): boolean {
+  const a = Buffer.from(left),
+    b = Buffer.from(right);
+  return a.length === b.length && timingSafeEqual(a, b);
+}

--- a/packages/backend/src/protocol/index.ts
+++ b/packages/backend/src/protocol/index.ts
@@ -1,0 +1,4 @@
+export * from "./constants";
+export * from "./errors";
+export * from "./identity";
+export * from "../modules/backend/model";

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,9 +6,16 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./config": "./src/config/index.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "js-yaml": "4.3.1"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "4.0.9"
   }
 }

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -1,0 +1,1 @@
+export { loadConfig, ConfigError, type LoadConfigOptions } from "./load";

--- a/packages/shared/src/config/load.test.ts
+++ b/packages/shared/src/config/load.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ConfigError, loadConfig } from "./load";
+
+async function fixture(run: (homeDirectory: string, filePath: string) => Promise<void>) {
+  const home = await mkdtemp(join(tmpdir(), "lorelum-shared-config-"));
+  try {
+    await run(home, join(home, ".lorelum", "config.yaml"));
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+}
+test("shared default path supports comments and independent sections", () =>
+  fixture(async (homeDirectory, filePath) => {
+    expect(await loadConfig({ homeDirectory })).toEqual({});
+    expect(await readdir(homeDirectory)).toEqual([]);
+    await mkdir(join(homeDirectory, ".lorelum"));
+    await writeFile(
+      filePath,
+      "# shared config\nbackend:\n  requestTimeoutMs: 2000\nquery:\n  profile: local\n",
+    );
+    expect(await loadConfig({ homeDirectory })).toEqual({
+      backend: { requestTimeoutMs: 2000 },
+      query: { profile: "local" },
+    });
+  }));
+for (const content of ["", "# comment only\n"]) {
+  test("empty YAML uses an empty document", () =>
+    fixture(async (homeDirectory, filePath) => {
+      await mkdir(join(homeDirectory, ".lorelum"));
+      await writeFile(filePath, content);
+      expect(await loadConfig({ filePath })).toEqual({});
+    }));
+}
+for (const content of [
+  "null",
+  "[]",
+  "text",
+  "backend: 1\nbackend: 2",
+  "private: [secret",
+  "---\na: 1\n---\nb: 2",
+  " ".repeat(16385),
+]) {
+  test("invalid document produces a sanitized error: " + content.slice(0, 20), () =>
+    fixture(async (homeDirectory, filePath) => {
+      await mkdir(join(homeDirectory, ".lorelum"));
+      await writeFile(filePath, content);
+      await expect(loadConfig({ filePath })).rejects.toEqual(new ConfigError());
+    }),
+  );
+}

--- a/packages/shared/src/config/load.ts
+++ b/packages/shared/src/config/load.ts
@@ -1,0 +1,49 @@
+import { open, type FileHandle } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { load, JSON_SCHEMA } from "js-yaml";
+
+export class ConfigError extends Error {
+  constructor() {
+    super("The Lorelum configuration file is invalid or unreadable.");
+    this.name = "ConfigError";
+  }
+}
+
+export interface LoadConfigOptions {
+  readonly homeDirectory?: string;
+  readonly filePath?: string;
+}
+
+/** Reads the shared document; consumers validate the sections they own. No writes. */
+export async function loadConfig(
+  options: LoadConfigOptions = {},
+): Promise<Readonly<Record<string, unknown>>> {
+  const path =
+    options.filePath ?? join(options.homeDirectory ?? homedir(), ".lorelum", "config.yaml");
+  let file: FileHandle;
+  try {
+    file = await open(path, "r");
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT")
+      return Object.freeze({});
+    throw new ConfigError();
+  }
+  try {
+    const info = await file.stat();
+    if (!info.isFile() || info.size > 16_384) throw new ConfigError();
+    const source = await file.readFile("utf8");
+    if (source.split(/\r?\n/).every((line) => /^\s*(#.*)?$/.test(line))) return Object.freeze({});
+    const document: unknown = load(source, { schema: JSON_SCHEMA });
+    // An empty/comment-only YAML file is an empty config; explicit null is invalid.
+    if (document === undefined) return Object.freeze({});
+    if (document === null || typeof document !== "object" || Array.isArray(document))
+      throw new ConfigError();
+    return Object.freeze(document as Record<string, unknown>);
+  } catch {
+    // YAML parser errors can contain configuration values. Do not expose them.
+    throw new ConfigError();
+  } finally {
+    await file.close();
+  }
+}


### PR DESCRIPTION
## Summary

建立 Elysia 本地 HTTP 服务基础与轻量控制客户端，统一使用 Zod DTO。新增可复用的 shared/config YAML 读取入口：`~/.lorelum/config.yaml` 按模块分段，backend 校验自己的配置并合并环境变量。

## Linked issue

Closes #95

## Type of change

- [ ] 🐛 Bug fix (non-breaking)
- [x] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change (fix or feature that would cause existing behavior to change)
- [ ] 📚 Docs only
- [ ] 🔧 Refactor / chore

## How was this tested?

B1：身份、Host/Origin/认证、结构化错误、幂等停止 service、配置优先级和非法配置校验。拆分时全量 476 tests passed，typecheck/lint/CLI integration 通过；对齐最新 main 后，完整三阶段组合全量 529 tests passed，typecheck、CLI integration 与编译通过。Lint 仅有站点既有的两条 _splat warning。

## Checklist

- [x] Linked the issue this closes (`Closes #xxx`)
- [x] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed in the issue / Discussions first
- [x] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

## AI assistance and review

- [x] This PR used AI assistance (describe the scope or tool below)
- [x] If AI-assisted: an AI code review covered the changed behavior and edge cases; material findings are resolved or documented below

使用 Codex 实现并审查。主 agent 审查配置、CLI、文档和各阶段完整 diff；独立 agent 审查 backend 全部 source/test 与生命周期、认证、错误边界。未发现阻塞问题。已检查 staged 文件及完整变更，完成凭证/私有信息模式扫描和生成文件排除检查。新增依赖许可证检查均为 MIT。

## Notes for reviewers

依赖链的第一项，base 为 main。后续进程管理和 Query 接入分别由 #99 和 #100 交付；设计文档标明完整第一阶段合同及当前 B1 交付范围。固定生产端口为 26186；内部测试注入端口 80 的 Host 规范化存在低优先级限制，当前固定端口不受影响。

Owner 已在关联 issue 所记录的工作会话中确认第一阶段范围；配置使用共享 YAML、DTO 使用 Zod 的后续调整也经 Owner 授权。
