### PR TITLE
feat(backend): serve keyword queries through QueryService

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
       "name": "@lorelum/backend",
       "version": "0.0.0",
       "dependencies": {
+        "@lorelum/engine": "workspace:*",
         "@lorelum/shared": "workspace:*",
         "elysia": "1.4.30",
         "zod": "4.4.3",

--- a/docs/cli/backend.md
+++ b/docs/cli/backend.md
@@ -68,4 +68,4 @@ Control requests contain no Store paths or query text; the client authenticates 
 
 ## Implementation scope
 
-This stage provides a resident service and process control. Keyword HTTP query integration is delivered separately. Existing CLI commands still execute through their original Engine path; reducing full CLI startup cost is separate work. No model is loaded. The process supervisor currently targets macOS/Linux; other platforms are not verified.
+This stage provides a resident keyword-query endpoint and process control. Existing CLI commands still execute through their original Engine path; reducing full CLI startup cost is separate work. No model is loaded. The process supervisor currently targets macOS/Linux; other platforms are not verified.

--- a/docs/plans/local-backend-service-design.md
+++ b/docs/plans/local-backend-service-design.md
@@ -1,7 +1,6 @@
 # 本地后端：第一阶段
 
 - 状态：Owner 已授权 B1–B3；实现按 B1、B2、B3 分别提交 PR，后续模型阶段仍需单独启动。
-- 本 PR 交付 B2 进程控制，依赖 B1 服务与共享配置基础；B3 Query 接入由后续 PR 交付。下文描述完整第一阶段合同。
 - Issue：#95（服务基础）、#96（进程管理）、#97（Query 接入）。
 - 相关设计：[Semantic Query v1](./semantic-query-v1-design.md)。
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,14 +7,15 @@
     "./client": "./src/client/index.ts",
     "./protocol": "./src/protocol/index.ts",
     "./server": "./src/app.ts",
-    "./config": "./src/config/index.ts",
+    "./daemon": "./src/runtime/daemon.ts",
     "./control": "./src/runtime/index.ts",
-    "./daemon": "./src/runtime/daemon.ts"
+    "./config": "./src/config/index.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@lorelum/engine": "workspace:*",
     "@lorelum/shared": "workspace:*",
     "elysia": "1.4.30",
     "zod": "4.4.3"

--- a/packages/backend/src/app.test.ts
+++ b/packages/backend/src/app.test.ts
@@ -1,4 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createLocalStore, createQueryService, type QueryService } from "@lorelum/engine";
+
+import { createPackCandidate } from "../../engine/src/local-store/model/candidate";
+
 import { createBackendApp } from "./app";
 import { createBackendService } from "./modules/backend/service";
 
@@ -10,6 +18,27 @@ const identity = Object.freeze({
 });
 const secret = "a secret used only by tests";
 
+function candidate(version: string, text: string) {
+  return createPackCandidate(
+    {
+      pack: { name: "backend-test", version },
+      practices: [
+        {
+          id: "backend.query",
+          title: "Backend query",
+          stage: "api",
+          tech_stack: ["typescript"],
+          applies_when: text,
+          severity: "warn",
+          body: text,
+        },
+      ],
+      decisions: [],
+    },
+    { "backend.query": "practices/backend/query.md" },
+  ).candidate;
+}
+
 function request(path: string, init: RequestInit = {}): Request {
   return new Request(`http://127.0.0.1${path}`, {
     ...init,
@@ -18,6 +47,7 @@ function request(path: string, init: RequestInit = {}): Request {
 }
 
 function app(
+  queryService?: QueryService,
   onStop = () => undefined,
   instanceIdentity: typeof identity = identity,
   isReady: () => boolean = () => true,
@@ -31,6 +61,11 @@ function app(
       onStopFailure,
       isReady,
     }),
+    queryService: queryService ?? {
+      async query() {
+        return { mode: "keyword", results: [] } as const;
+      },
+    },
   });
 }
 
@@ -48,7 +83,7 @@ describe("createBackendApp", () => {
 
   test("whitelists identity fields before putting them on the wire", async () => {
     const withPrivateRuntimeField = Object.assign({}, identity, { runtimeSecret: "must-not-leak" });
-    const response = await app(() => undefined, withPrivateRuntimeField).handle(
+    const response = await app(undefined, () => undefined, withPrivateRuntimeField).handle(
       request(
         "/internal/v1/identity?nonce=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
       ),
@@ -80,9 +115,224 @@ describe("createBackendApp", () => {
     expect((await instance.handle(request("/internal/v1/status"))).status).toBe(401);
   });
 
+  test("delegates a valid query to QueryService without parsing it in the adapter", async () => {
+    const calls: unknown[] = [];
+    const queryService: QueryService = {
+      async query(root, input) {
+        calls.push({ root, input });
+        return { mode: "keyword", results: [] };
+      },
+    };
+    const response = await app(queryService).handle(
+      request("/internal/v1/query", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:26186",
+          authorization: `Bearer ${secret}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          storageRoot: "/tmp/lorelum-test",
+          query: { text: "  keep this input  " },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([
+      {
+        root: { rootPath: "/tmp/lorelum-test" },
+        input: { text: "  keep this input  " },
+      },
+    ]);
+  });
+
+  test("observes LocalStore mutations through the real QueryService", async () => {
+    const rootPath = await mkdtemp(join(tmpdir(), "lorelum-backend-test-"));
+    try {
+      const store = createLocalStore();
+      await store.install({ rootPath }, candidate("1.0.0", "orchid deployment guidance"));
+      const instance = app(createQueryService({ store }));
+      const query = (text: string) =>
+        instance.handle(
+          request("/internal/v1/query", {
+            method: "POST",
+            headers: {
+              host: "127.0.0.1:26186",
+              authorization: `Bearer ${secret}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({ storageRoot: rootPath, query: { text, limit: 1 } }),
+          }),
+        );
+
+      expect(await (await query("orchid")).json()).toMatchObject({
+        results: [{ practiceId: "backend.query" }],
+      });
+      await store.upgrade({ rootPath }, candidate("1.0.1", "violet deployment guidance"));
+      expect(await (await query("orchid")).json()).toMatchObject({ results: [] });
+      expect(await (await query("violet")).json()).toMatchObject({
+        results: [{ practiceId: "backend.query" }],
+      });
+    } finally {
+      await rm(rootPath, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    }
+  });
+
+  test("keeps simultaneous Store roots isolated", async () => {
+    const firstRoot = await mkdtemp(join(tmpdir(), "lorelum-backend-first-"));
+    const secondRoot = await mkdtemp(join(tmpdir(), "lorelum-backend-second-"));
+    try {
+      const store = createLocalStore();
+      await store.install({ rootPath: firstRoot }, candidate("1.0.0", "orchid guidance"));
+      await store.install({ rootPath: secondRoot }, candidate("1.0.0", "violet guidance"));
+      const instance = app(createQueryService({ store }));
+      const query = async (rootPath: string, text: string) => {
+        const response = await instance.handle(
+          request("/internal/v1/query", {
+            method: "POST",
+            headers: {
+              host: "127.0.0.1:26186",
+              authorization: `Bearer ${secret}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({ storageRoot: rootPath, query: { text } }),
+          }),
+        );
+        return response.json();
+      };
+
+      expect(await query(firstRoot, "orchid")).toMatchObject({
+        results: [{ practiceId: "backend.query" }],
+      });
+      expect(await query(firstRoot, "violet")).toMatchObject({ results: [] });
+      expect(await query(secondRoot, "orchid")).toMatchObject({ results: [] });
+      expect(await query(secondRoot, "violet")).toMatchObject({
+        results: [{ practiceId: "backend.query" }],
+      });
+    } finally {
+      await Promise.all([
+        rm(firstRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }),
+        rm(secondRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }),
+      ]);
+    }
+  });
+
+  test("translates typed Engine errors without exposing their details", async () => {
+    const queryService: QueryService = {
+      async query() {
+        throw new Error("/private/path must never be returned");
+      },
+    };
+    const response = await app(queryService).handle(
+      request("/internal/v1/query", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:26186",
+          authorization: `Bearer ${secret}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ storageRoot: "/tmp/lorelum-test", query: { text: "test" } }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: { code: "backend.failed", message: "The backend operation failed." },
+    });
+  });
+
+  test("whitelists QueryService result fields", async () => {
+    const queryService: QueryService = {
+      async query() {
+        return { mode: "keyword", results: [], privateRuntimeDetail: "must-not-leak" } as never;
+      },
+    };
+    const response = await app(queryService).handle(
+      request("/internal/v1/query", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:26186",
+          authorization: `Bearer ${secret}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ storageRoot: "/tmp/lorelum-test", query: { text: "test" } }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      mode: "keyword",
+      results: [],
+    });
+  });
+
+  test("rejects a malformed QueryService result at the success-response boundary", async () => {
+    const queryService: QueryService = {
+      async query() {
+        return { mode: "not-keyword", results: [] } as never;
+      },
+    };
+    const response = await app(queryService).handle(
+      request("/internal/v1/query", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:26186",
+          authorization: `Bearer ${secret}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ storageRoot: "/tmp/lorelum-test", query: { text: "test" } }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: { code: "backend.failed", message: "The backend operation failed." },
+    });
+  });
+
+  test("reports starting and rejects query admission before readiness", async () => {
+    let ready = false;
+    const instance = app(
+      undefined,
+      () => undefined,
+      identity,
+      () => ready,
+    );
+    const status = await instance.handle(
+      request("/internal/v1/status", {
+        headers: { host: "127.0.0.1:26186", authorization: `Bearer ${secret}` },
+      }),
+    );
+    const query = await instance.handle(
+      request("/internal/v1/query", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1:26186",
+          authorization: `Bearer ${secret}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ storageRoot: "/tmp/lorelum-test", query: { text: "test" } }),
+      }),
+    );
+
+    expect(await status.json()).toMatchObject({ state: "starting" });
+    expect(query.status).toBe(503);
+    ready = true;
+    expect(
+      await (
+        await instance.handle(
+          request("/internal/v1/status", {
+            headers: { host: "127.0.0.1:26186", authorization: `Bearer ${secret}` },
+          }),
+        )
+      ).json(),
+    ).toMatchObject({ state: "ready" });
+  });
+
   test("returns stopping before calling lifecycle shutdown", async () => {
     let stopped = false;
-    const response = await app(() => {
+    const response = await app(undefined, () => {
       stopped = true;
     }).handle(
       request("/internal/v1/stop", {
@@ -100,6 +350,7 @@ describe("createBackendApp", () => {
   test("reports a synchronous stop callback failure after scheduling its response", async () => {
     const failures: unknown[] = [];
     const response = await app(
+      undefined,
       () => {
         throw new Error("test lifecycle failure");
       },

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,11 +1,14 @@
+import type { QueryService } from "@lorelum/engine";
 import { Elysia } from "elysia";
 import { backendController } from "./modules/backend/controller";
 import type { BackendService } from "./modules/backend/service";
+import { queryController } from "./modules/query/controller";
 import { localBoundary, reject } from "./plugins/local-auth";
 import { BACKEND_HOST, BACKEND_PORT } from "./protocol/constants";
 
 export interface CreateBackendAppOptions {
   readonly backend: BackendService;
+  readonly queryService: QueryService;
   /** Internal test injection; production always uses the fixed IPv4 endpoint. */
   readonly host?: string;
   readonly port?: number;
@@ -31,5 +34,6 @@ export function createBackendApp(options: CreateBackendAppOptions) {
         ? reject(400, "backend.invalid-request")
         : reject(500, "backend.failed");
     })
-    .use(backendController(backend));
+    .use(backendController(backend))
+    .use(queryController(options.queryService, backend.available));
 }

--- a/packages/backend/src/client/boundary.test.ts
+++ b/packages/backend/src/client/boundary.test.ts
@@ -27,11 +27,14 @@ const elysia = (path: string) => path.includes("node_modules/elysia/");
 
 test("client/control exports exclude server dependencies; server build is the positive control", async () => {
   // No external exclusions: follow the actual complete resolved dependency graph.
-  const client = await bundledInputs([join(import.meta.dir, "index.ts")]);
+  const client = await bundledInputs([
+    join(import.meta.dir, "index.ts"),
+    join(import.meta.dir, "../runtime/index.ts"),
+  ]);
   expect(client.some((path) => path.endsWith("client/client.ts"))).toBe(true);
   expect(client.some(engine)).toBe(false);
   expect(client.some(elysia)).toBe(false);
   const server = await bundledInputs([join(import.meta.dir, "../app.ts")]);
-  expect(server.some(engine)).toBe(false);
+  expect(server.some(engine)).toBe(true);
   expect(server.some(elysia)).toBe(true);
 });

--- a/packages/backend/src/client/client.test.ts
+++ b/packages/backend/src/client/client.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
+import type { QueryService } from "@lorelum/engine";
+
 import { createBackendApp } from "../app";
 import { createBackendService } from "../modules/backend/service";
 import type { InstanceIdentity } from "../protocol/identity";
+import { BackendRemoteError } from "../protocol/errors";
 import { createBackendClient } from "./client";
 
 const identity = Object.freeze({
@@ -18,12 +21,20 @@ afterEach(() => {
   for (const app of apps.splice(0)) app.stop(true);
 });
 
-function runningApp(backendIdentity: InstanceIdentity = identity): {
+function runningApp(
+  queryService?: QueryService,
+  backendIdentity: InstanceIdentity = identity,
+): {
   readonly app: ReturnType<typeof createBackendApp>;
   readonly url: string;
 } {
   const app = createBackendApp({
     backend: createBackendService({ identity: backendIdentity, secret, onStop: () => undefined }),
+    queryService: queryService ?? {
+      async query() {
+        return { mode: "keyword", results: [] } as const;
+      },
+    },
   });
   apps.push(app);
   app.listen({ hostname: "127.0.0.1", port: 0, maxRequestBodySize: 65_536 });
@@ -32,6 +43,32 @@ function runningApp(backendIdentity: InstanceIdentity = identity): {
 }
 
 describe("createBackendClient", () => {
+  test("authenticates the service before making a strict-build query", async () => {
+    const calls: unknown[] = [];
+    const { url } = runningApp({
+      async query(root, request) {
+        calls.push({ root, request });
+        return { mode: "keyword", results: [] };
+      },
+    });
+    const client = createBackendClient({
+      identity,
+      secret,
+      buildIdentity: "test-build",
+      baseUrl: url,
+    });
+
+    await expect(
+      client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "search" }),
+    ).resolves.toEqual({
+      mode: "keyword",
+      results: [],
+    });
+    expect(calls).toEqual([
+      { root: { rootPath: "/tmp/lorelum-client-test" }, request: { text: "search" } },
+    ]);
+  });
+
   test("allows a compatible control client to stop an older build", async () => {
     const { url } = runningApp();
     const client = createBackendClient({
@@ -43,6 +80,54 @@ describe("createBackendClient", () => {
 
     await expect(client.status()).resolves.toMatchObject({ state: "ready" });
     await expect(client.stop()).resolves.toMatchObject({ state: "stopping" });
+  });
+
+  test("does not send a query to a service with a different business build", async () => {
+    const { url } = runningApp();
+    const client = createBackendClient({
+      identity,
+      secret,
+      buildIdentity: "different-build",
+      baseUrl: url,
+    });
+
+    await expect(
+      client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "search" }),
+    ).rejects.toEqual(expect.objectContaining({ code: "backend.incompatible" }));
+  });
+
+  test("allows control operations but rejects queries against an older business protocol", async () => {
+    const { url } = runningApp(undefined, { ...identity, businessVersion: 0 });
+    const client = createBackendClient({
+      identity,
+      secret,
+      buildIdentity: "test-build",
+      baseUrl: url,
+    });
+
+    await expect(client.status()).resolves.toMatchObject({ state: "ready" });
+    await expect(client.stop()).resolves.toMatchObject({ state: "stopping" });
+    await expect(
+      client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "search" }),
+    ).rejects.toEqual(expect.objectContaining({ code: "backend.incompatible" }));
+  });
+
+  test("preserves the established domain error code from a query response", async () => {
+    const { url } = runningApp({
+      async query() {
+        throw new (await import("@lorelum/engine")).InvalidQueryRequestError();
+      },
+    });
+    const client = createBackendClient({
+      identity,
+      secret,
+      buildIdentity: "test-build",
+      baseUrl: url,
+    });
+
+    await expect(
+      client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "search" }),
+    ).rejects.toBeInstanceOf(BackendRemoteError);
   });
 
   test("rejects non-loopback client URLs", () => {

--- a/packages/backend/src/client/client.ts
+++ b/packages/backend/src/client/client.ts
@@ -14,6 +14,7 @@ import {
   backendErrorCodes,
 } from "../protocol/errors";
 import { constantTimeEqual, identityProof, type InstanceIdentity } from "../protocol/identity";
+import { queryRequestSchema, queryResultSchema } from "../modules/query/model";
 import {
   identitySchema,
   statusSchema,
@@ -21,6 +22,7 @@ import {
   type BackendStatus,
 } from "../modules/backend/model";
 import { DEFAULT_BACKEND_SETTINGS } from "../config/model";
+import type { QueryRequest, QueryResult, StorageRoot } from "@lorelum/engine";
 
 export interface CreateBackendClientOptions {
   readonly identity: InstanceIdentity;
@@ -35,6 +37,7 @@ export interface BackendClient {
   identity(): Promise<BackendIdentity>;
   status(): Promise<BackendStatus>;
   stop(): Promise<BackendStatus>;
+  query(root: StorageRoot, request: QueryRequest): Promise<QueryResult>;
 }
 
 function validatedLoopbackUrl(value: string): URL {
@@ -197,6 +200,20 @@ export function createBackendClient(options: CreateBackendClientOptions): Backen
         headers: authenticated.headers,
       });
       return checkedStatus(body, authenticated.identity);
+    },
+    async query(root, request) {
+      const payload = { storageRoot: root.rootPath, query: request };
+      if (!queryRequestSchema.safeParse(payload).success)
+        throw new BackendRemoteError("usage.invalid");
+      const authenticated = await authorized(true);
+      const body = await send("/internal/v1/query", {
+        method: "POST",
+        headers: { ...authenticated.headers, "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const parsed = queryResultSchema.safeParse(body);
+      if (!parsed.success) throw new BackendError("backend.failed");
+      return parsed.data;
     },
   } satisfies BackendClient);
 }

--- a/packages/backend/src/modules/query/controller.ts
+++ b/packages/backend/src/modules/query/controller.ts
@@ -1,0 +1,70 @@
+import {
+  InvalidQueryRequestError,
+  KeywordIndexError,
+  KeywordIndexUnavailableError,
+  StoreBusyError,
+  StoreRecoveryRequiredError,
+  type QueryService,
+  type QueryResult,
+} from "@lorelum/engine";
+import { Elysia, status } from "elysia";
+import { reject, requireJson } from "../../plugins/local-auth";
+import { backendErrorBody, errorSchema } from "../../protocol/errors";
+import { queryRequestSchema, queryResultSchema, type BackendQueryResult } from "./model";
+
+/** QueryService already owns the use case; this controller only adapts transport. */
+export function queryController(service: QueryService, available: () => boolean) {
+  return new Elysia({ prefix: "/internal/v1", normalize: false })
+    .onBeforeHandle(({ request }) => {
+      if (!available()) return reject(503, "backend.busy");
+      return requireJson(request);
+    })
+    .post(
+      "/query",
+      async ({ body }) => {
+        try {
+          const query = {
+            text: body.query.text,
+            ...(body.query.limit === undefined ? {} : { limit: body.query.limit }),
+          };
+          return toResponse(await service.query({ rootPath: body.storageRoot }, query));
+        } catch (error) {
+          if (error instanceof InvalidQueryRequestError)
+            return status(400, domainError("usage.invalid", "The command invocation is invalid."));
+          if (error instanceof KeywordIndexUnavailableError)
+            return status(503, domainError("query.unavailable", "Keyword query is unavailable."));
+          if (error instanceof KeywordIndexError)
+            return status(500, domainError("query.failed", "Keyword query failed."));
+          if (error instanceof StoreBusyError)
+            return status(503, domainError("store.busy", "The local Pack store is busy."));
+          if (error instanceof StoreRecoveryRequiredError)
+            return status(
+              503,
+              domainError("store.recovery-required", "The local Pack store requires recovery."),
+            );
+          return status(500, backendErrorBody("backend.failed"));
+        }
+      },
+      {
+        body: queryRequestSchema,
+        response: { 200: queryResultSchema, 400: errorSchema, 500: errorSchema, 503: errorSchema },
+      },
+    );
+}
+function domainError(code: string, message: string) {
+  return { error: { code, message } };
+}
+function toResponse(result: QueryResult): BackendQueryResult {
+  return {
+    mode: result.mode,
+    results: result.results.map((hit) => ({
+      practiceId: hit.practiceId,
+      title: hit.title,
+      stage: hit.stage,
+      techStack: [...hit.techStack],
+      appliesWhen: hit.appliesWhen,
+      severity: hit.severity,
+      contentDigest: hit.contentDigest,
+    })),
+  };
+}

--- a/packages/backend/src/modules/query/model.ts
+++ b/packages/backend/src/modules/query/model.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/**
+ * Wire contract for the Engine keyword-query facade.  Query text and limit
+ * remain intentionally broad here: QueryService owns their domain validation.
+ */
+export const queryRequestSchema = z.strictObject({
+  storageRoot: z.string().min(1).regex(/^\//),
+  query: z.strictObject({
+    text: z.string(),
+    limit: z.int().optional(),
+  }),
+});
+export type BackendQueryRequest = z.infer<typeof queryRequestSchema>;
+
+export const queryHitSchema = z.strictObject({
+  practiceId: z.string(),
+  title: z.string(),
+  stage: z.string(),
+  techStack: z.array(z.string()),
+  appliesWhen: z.string(),
+  severity: z.enum(["info", "warn", "critical"]),
+  contentDigest: z.string(),
+});
+
+export const queryResultSchema = z.strictObject({
+  mode: z.literal("keyword"),
+  results: z.array(queryHitSchema),
+});
+export type BackendQueryResult = z.infer<typeof queryResultSchema>;

--- a/packages/backend/src/protocol/index.ts
+++ b/packages/backend/src/protocol/index.ts
@@ -2,3 +2,4 @@ export * from "./constants";
 export * from "./errors";
 export * from "./identity";
 export * from "../modules/backend/model";
+export * from "../modules/query/model";

--- a/packages/backend/src/runtime/daemon.ts
+++ b/packages/backend/src/runtime/daemon.ts
@@ -1,4 +1,5 @@
 import { consumeDaemonLaunch, resolveBackendSettings } from "../config";
+import { createLocalStore, createQueryService } from "@lorelum/engine";
 import { BACKEND_HOST, MAX_BODY_BYTES } from "../protocol/constants";
 import { BackendError } from "../protocol/errors";
 import { createBackendApp } from "../app";
@@ -40,6 +41,7 @@ export async function runBackendDaemon(options: { readonly buildIdentity: string
   const app = createBackendApp({
     backend,
     port,
+    queryService: createQueryService({ store: createLocalStore() }),
   });
   const signalHandler = () => {
     void backend.stop();


### PR DESCRIPTION
## Summary

接入内部 keyword Query HTTP 路由与客户端，复用 Engine QueryService；每个请求明确携带 Store root，服务观察外部 Store 更新。既有 `lore query` 保持直接 Engine 路径。

## Linked issue

Closes #97

## Type of change

- [ ] 🐛 Bug fix (non-breaking)
- [x] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change (fix or feature that would cause existing behavior to change)
- [ ] 📚 Docs only
- [ ] 🔧 Refactor / chore

## How was this tested?

B3：HTTP 参数/响应校验、领域错误、多 Store 隔离、外部 mutation 可见及真实构建依赖边界。对齐最新 main 后全量 529 tests passed，typecheck/lint/CLI integration/compile 通过。编译 daemon 在隔离 Store 上成功执行真实 HTTP keyword query，随后验证 stop/restart/SIGTERM 清理。Lint 仅有两条既有站点 warning。

## Checklist

- [x] Linked the issue this closes (`Closes #xxx`)
- [x] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed in the issue / Discussions first
- [x] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

## AI assistance and review

- [x] This PR used AI assistance (describe the scope or tool below)
- [x] If AI-assisted: an AI code review covered the changed behavior and edge cases; material findings are resolved or documented below

使用 Codex 实现并审查。主 agent 审查配置、CLI、文档和各阶段完整 diff；独立 agent 审查 backend 全部 source/test 与生命周期、认证、错误边界。未发现阻塞问题。已检查 staged 文件及完整变更，完成凭证/私有信息模式扫描和生成文件排除检查。新增依赖许可证检查均为 MIT。

## Notes for reviewers

当前 base 为 main。#98、#99 均已 squash merge；本分支已移除两者的旧提交，仅保留 Query 接入的一个提交，直接基于最新 main。重新验证全量 529 项测试、typecheck、lint、CLI integration 和编译通过。Issue 最初列出的全 CLI eager-import 重构和配对性能矩阵已按 Owner 确认的收缩范围延期，设计文档记录了这一调整；本 PR 不声称改善完整 CLI 冷启动性能。未加载 embedding 模型，也未改 retrieval model。

Owner 已在关联 issue 所记录的工作会话中确认第一阶段范围；配置使用共享 YAML、DTO 使用 Zod 的后续调整也经 Owner 授权。
