### PR TITLE
chore: upgrade Bun to 1.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.8
+          bun-version: 1.4.2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.8
+          bun-version: 1.4.2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "lorelum",
       "devDependencies": {
-        "@types/bun": "1.3.8",
+        "@types/bun": "1.4.2",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
         "typescript": "5.7.2",
@@ -571,7 +571,7 @@
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 
-    "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -669,7 +669,7 @@
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
-    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
 
     "byte-counter": ["byte-counter@0.1.0", "", {}, "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ=="],
 
@@ -726,8 +726,6 @@
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
-    "crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -1464,8 +1462,6 @@
     "@tanstack/router-generator/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
-    "bun-types/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "versions:site": "cd apps/site && npx wrangler versions upload"
   },
   "devDependencies": {
-    "@types/bun": "1.3.8",
+    "@types/bun": "1.4.2",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",
     "typescript": "5.7.2"
@@ -28,5 +28,5 @@
   "overrides": {
     "js-yaml": "4.3.1"
   },
-  "packageManager": "bun@1.3.8"
+  "packageManager": "bun@1.4.2"
 }

--- a/packages/engine/src/local-store/storage/sqlite/practice-reader.test.ts
+++ b/packages/engine/src/local-store/storage/sqlite/practice-reader.test.ts
@@ -3,16 +3,16 @@ import { expect, test } from "bun:test";
 import { LOCAL_STORE_SCHEMA_VERSION, migrateDatabase } from "./migrations";
 import { readPractice } from "./practice-reader";
 
-test("point JOIN uses both existing indexes and one statement even when absent", () => {
+test("point JOIN uses both existing indexes and one query even when absent", () => {
   const database = new Database(":memory:");
   try {
     migrateDatabase(database);
-    const prepared: string[] = [];
-    const originalPrepare = database.prepare.bind(database);
-    database.prepare = ((sql: string) => {
-      prepared.push(sql);
-      return originalPrepare(sql);
-    }) as typeof database.prepare;
+    const queries: string[] = [];
+    const originalQuery = database.query.bind(database);
+    database.query = ((sql: string) => {
+      queries.push(sql);
+      return originalQuery(sql);
+    }) as typeof database.query;
     expect(
       readPractice(
         database,
@@ -24,8 +24,8 @@ test("point JOIN uses both existing indexes and one statement even when absent",
         "example.absent",
       ),
     ).toBeUndefined();
-    expect(prepared).toHaveLength(1);
-    const plan = database.query(`EXPLAIN QUERY PLAN ${prepared[0]}`).all("example.absent");
+    expect(queries).toHaveLength(1);
+    const plan = database.query(`EXPLAIN QUERY PLAN ${queries[0]}`).all("example.absent");
     const details = plan.map((row) => String((row as { detail: unknown }).detail));
     expect(details.some((detail) => /SEARCH e USING INDEX/.test(detail))).toBe(true);
     expect(

--- a/packages/engine/src/local-store/storage/sqlite/snapshot-reader.test.ts
+++ b/packages/engine/src/local-store/storage/sqlite/snapshot-reader.test.ts
@@ -56,25 +56,25 @@ function seedState(database: Database, count: number, packName = "scale-pack"): 
   });
 }
 
-test("materializes Effective Practices and sources from one prepared statement", () => {
+test("materializes Effective Practices and sources with one joined query", () => {
   const database = new Database(":memory:");
   try {
     migrateDatabase(database);
     seedState(database, 25);
 
-    let prepareCalls = 0;
-    const originalPrepare = database.prepare.bind(database);
-    // Count every prepare the reader issues: one for metadata, one for the
-    // single JOINed materialization statement. An N+1 reader would prepare
-    // once per practice, blowing past this bound.
-    database.prepare = ((sql: string) => {
-      prepareCalls += 1;
-      return originalPrepare(sql);
-    }) as typeof database.prepare;
+    let queryCalls = 0;
+    const originalQuery = database.query.bind(database);
+    // Count the public query calls issued by the reader: one for metadata and
+    // one joined materialization query. An N+1 reader would call query once
+    // per practice, blowing past this bound.
+    database.query = ((sql: string) => {
+      queryCalls += 1;
+      return originalQuery(sql);
+    }) as typeof database.query;
 
     const snapshot = readEffectivePracticeSnapshot(database);
     expect(snapshot.effectivePractices).toHaveLength(25);
-    expect(prepareCalls).toBe(2);
+    expect(queryCalls).toBe(2);
   } finally {
     database.close();
   }


### PR DESCRIPTION
## Summary

Upgrade the repository and both existing CI workflows from Bun 1.3.8 to 1.4.2. The SQLite query-count tests now observe `database.query()`, which is the API the readers call, instead of relying on Bun 1.3's internal delegation from `query()` to a replaceable `prepare()` method.

## Linked issue

Closes #106

## Type of change

- [ ] 🐛 Bug fix (non-breaking)
- [ ] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change (fix or feature that would cause existing behavior to change)
- [ ] 📚 Docs only
- [x] 🔧 Refactor / chore

## How was this tested?

- `bun install --frozen-lockfile` with Bun 1.4.2
- `bun run typecheck`
- `bun run lint` — passes with the two existing site `_splat` warnings
- `bun test` — 605 passed
- `bun run build:cli` and compiled `./dist/lore --version`
- Backend integration: embedding reference/HTTP path, daemon lifecycle, resumable model download, and 512/1024/2048-token settings

## Checklist

- [x] Linked the issue this closes (`Closes #106`)
- [x] This preserves the existing product contract; no design discussion is required
- [x] Updated tests for the changed Bun SQLite observation behavior
- [x] Lint, type-check, and tests all pass locally
- [x] Relevant documentation was reviewed; existing Bun 1.3.8 mentions are historical benchmark records and remain unchanged
- [x] No secrets, credentials, or private info in the diff

## AI assistance and review

- [x] This PR used AI assistance for the toolchain update, validation, and review.
- [x] AI code review covered all six changed files. It found the old `database.prepare()` monkey-patches no longer observe `database.query()` on Bun 1.4.2; the tests now observe the public API used by the readers. No remaining material findings.

## Notes for reviewers

The compiled CLI and the resident embedding integration suite were run with Bun 1.4.2. This PR deliberately excludes release packaging, installation scripts, and release workflows.
