### PR TITLE
feat(native): add linux-x64 CPU embedding runtime

### DIFF
--- a/docs/cli/backend.md
+++ b/docs/cli/backend.md
@@ -63,6 +63,6 @@ lore backend stop
 
 ## 构建与支持范围
 
-源码开发先执行 `bun run build:native`；native candidate 位于 `packages/backend/.artifacts/native/embedding/darwin-arm64/`，由源码 backend 直接校验和启动。可安装的编译版必须通过 `bun run build:release` 生成，并保留 archive 内完整的 `native/darwin-arm64/` 目录，不能仅复制 `lore`。`bun run build:cli` 只生成通用 CLI binary，不携带配套 native runtime，不能作为 embedding 的发行构建。native manifest 和许可证说明见 [native 构建说明](../../native/embedding/README.md)。
+源码开发先执行 `bun run build:native`；native candidate 位于 `packages/backend/.artifacts/native/embedding/<target>/`（当前 target：`darwin-arm64`、`linux-x64`），由源码 backend 直接校验和启动。可安装的编译版必须通过 `bun run build:release` 生成，并保留 archive 内完整的 `native/<target>/` 目录，不能仅复制 `lore`（`build:release` 由 catalog 驱动，已可在 Linux 构建主机产出 `linux-x64` archive，但尚未发布，`install.sh` 也尚未放行 Linux）。`bun run build:cli` 只生成通用 CLI binary，不携带配套 native runtime，不能作为 embedding 的发行构建。native manifest 和许可证说明见 [native 构建说明](../../native/embedding/README.md)。
 
-当前 embedding 支持 macOS arm64，已在 M4 验证。Windows native、进程身份/ACL 和端到端验收尚未完成；Linux embedding 不在当前交付范围。普通 `lore query` 仍走原有 Engine 路径，semantic index/query 接入另行实施。
+当前 embedding 支持 macOS arm64（已在 M4 验证并具备 release 打包）。Linux x64 支持源码构建、运行与打包：在 Ubuntu 24.04（glibc 2.39，WSL2）完成过真实构建、backend→native 全链路验收、release staging/打包与编译版 CLI 生命周期（含篡改拒绝），产物为通用 x86-64 基线（无 AVX2/AVX-512 最低要求），仅链接 libc/libstdc++/libm/libgcc_s；尚未在其他发行版验证或正式发布。Windows native、进程身份/ACL 和端到端验收尚未完成。普通 `lore query` 仍走原有 Engine 路径，semantic index/query 接入另行实施。

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -103,9 +103,9 @@ Embedding source checks need one native candidate in the current worktree:
 bun run build:native
 ```
 
-The candidate is copied to `packages/backend/.artifacts/native/embedding/darwin-arm64/`. The completed native runtime is shared only as a developer build cache, currently `~/Library/Caches/Lorelum/native/v1` on macOS. A matching second worktree verifies and copies that runtime instead of running CMake again. The cache does not belong to `~/.lorelum`, is not selected by `config.yaml`, and is never used as the backend runtime path; removing it merely makes the next `build:native` rebuild the candidate.
+The candidate is copied to `packages/backend/.artifacts/native/embedding/<target>/` (`darwin-arm64` on macOS, `linux-x64` on Linux). The completed native runtime is shared only as a developer build cache: `~/Library/Caches/Lorelum/native/v1` on macOS, `$XDG_CACHE_HOME/lorelum/native/v1` (or `~/.cache/lorelum/native/v1`) on Linux. A matching second worktree verifies and copies that runtime instead of running CMake again. The cache does not belong to `~/.lorelum`, is not selected by `config.yaml`, and is never used as the backend runtime path; removing it merely makes the next `build:native` rebuild the candidate.
 
-This remains a macOS arm64 CPU build. The source archive, pinned CMake download, and CMake intermediate files remain in the invoking worktree's ignored `.cache/native-build/` and are only needed on a cache miss. See the [native build guide](../../native/embedding/README.md) for lifecycle checks and the release/source trust boundary.
+This remains a CPU-only build. macOS uses the pinned CMake download and an ARMv8.4 baseline; Linux uses the distribution CMake/toolchain and the generic x86-64 baseline (no AVX2/AVX-512 requirement, OpenMP disabled). The source archive, any pinned CMake download, and CMake intermediate files remain in the invoking worktree's ignored `.cache/native-build/` and are only needed on a cache miss. See the [native build guide](../../native/embedding/README.md) for lifecycle checks and the release/source trust boundary.
 
 ### Store isolation rules
 

--- a/native/embedding/README.md
+++ b/native/embedding/README.md
@@ -6,7 +6,7 @@ The server's standard input is a parent-liveness pipe. Its independent watcher s
 
 The `stalled-main` probe needs the patched llama.cpp source and prepares it in the invoking worktree's `.cache/native-build/` when necessary. It does not rebuild `llama-server` or alter the shared completed-runtime cache.
 
-Build and validate the macOS arm64 artifact:
+Build and validate the host's CPU artifact (macOS arm64, Linux x64):
 
 ```sh
 bun run build:native
@@ -15,11 +15,13 @@ bun scripts/native/test-parent-liveness.ts --mode encoding
 bun scripts/native/test-parent-liveness.ts --mode stalled-main
 ```
 
+Linux builds use the distribution's `cmake` and `c++` (no pinned CMake download); the cache key fingerprints the system CMake, compiler, and glibc versions in place of the macOS SDK. The recipe disables OpenMP so the binary links only the system runtime (`libc`, `libstdc++`, `libm`, `libgcc_s`) and stays portable across distributions with a compatible glibc.
+
 `build:native` keeps downloaded source, CMake, and CMake intermediates in this worktree's ignored `.cache/native-build/`. Its completed runtime is shared through the operating system cache: on macOS, `~/Library/Caches/Lorelum/native/v1`; on Linux, `$XDG_CACHE_HOME/lorelum/native/v1` or `~/.cache/lorelum/native/v1`; on Windows, `%LOCALAPPDATA%\Lorelum\Cache\native\v1`. The first matching build creates a verified cache entry. A later worktree with the same recipe and compiler/SDK fingerprint copies that entry into its own `.artifacts` candidate without downloading or starting CMake. Delete the system cache root to force a rebuild.
 
-The checked-in `packages/backend/src/runtime/native/embedding/darwin-arm64.json` is the reviewed source recipe and the manifest compiled into a release CLI. A source backend accepts a locally built candidate only when its target, recipe fields, model identity, file hashes, executable mode, and dynamic dependencies validate; its `buildIdentity` may differ because the local compiler produced different bytes. A compiled release requires the on-disk manifest to match the manifest compiled into that CLI exactly. A build never silently updates the checked-in trust anchor. When the recipe changes, review the candidate, run the native and backend integration checks, and explicitly update the trusted manifest before compiling a release.
+The checked-in `packages/backend/src/runtime/native/embedding/darwin-arm64.json` and `linux-x64.json` are the reviewed source recipes and the manifests compiled into a release CLI. A source backend accepts a locally built candidate only when its target, recipe fields, model identity, file hashes, executable mode, and dynamic dependencies validate; its `buildIdentity` may differ because the local compiler produced different bytes. A compiled release requires the on-disk manifest to match the manifest compiled into that CLI exactly. A build never silently updates the checked-in trust anchor. When the recipe changes, review the candidate, run the native and backend integration checks, and explicitly update the trusted manifest before compiling a release.
 
-The CPU target is an M1-compatible ARMv8.4/FP16/dot-product baseline, with no i8mm and no compiled GPU backend. It is verified on M4, not yet on every Apple Silicon device. Windows artifacts and private process/file support remain pending.
+The macOS CPU target is an M1-compatible ARMv8.4/FP16/dot-product baseline, with no i8mm and no compiled GPU backend. It is verified on M4, not yet on every Apple Silicon device. The Linux x64 CPU target is the generic x86-64 baseline: `GGML_NATIVE` plus `GGML_SSE42/AVX/AVX2/BMI2/FMA/F16C` and `GGML_OPENMP` are all off, so no AVX2/AVX-512 capability is required; the fast CPU variants remain future work. It was built and verified on Ubuntu 24.04 (glibc 2.39) under WSL2, which does not by itself certify every Linux distribution. Windows artifacts and private process/file support remain pending.
 
 Run the backend acceptance separately after the native build:
 

--- a/native/embedding/build-config.json
+++ b/native/embedding/build-config.json
@@ -12,38 +12,72 @@
     "path": "patches/0001-exit-on-parent-stdin-close.patch",
     "sha256": "f58b3db4c77ae0297679153d893f08dabc1b1759edead5c5b4cd9eef19bab03f"
   },
-  "cmake": {
-    "version": "3.31.6",
-    "darwinUniversalUrl": "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-macos-universal.tar.gz",
-    "darwinUniversalSha256": "330b9514f5112e5ed4fb08b8b05803b776fd9b539a6ae12927d14dcc0ee2ba8d"
-  },
-  "cmakeFlags": [
-    "-DCMAKE_BUILD_TYPE=Release",
-    "-DCMAKE_OSX_ARCHITECTURES=arm64",
-    "-DCMAKE_OSX_DEPLOYMENT_TARGET=13.3",
-    "-DLLAMA_BUILD_NUMBER=@BUILD_NUMBER@",
-    "-DLLAMA_BUILD_COMMIT=@BUILD_COMMIT@",
-    "-DBUILD_SHARED_LIBS=OFF",
-    "-DLLAMA_BUILD_TESTS=OFF",
-    "-DLLAMA_BUILD_EXAMPLES=OFF",
-    "-DLLAMA_BUILD_TOOLS=ON",
-    "-DLLAMA_BUILD_SERVER=ON",
-    "-DLLAMA_BUILD_APP=OFF",
-    "-DLLAMA_BUILD_UI=OFF",
-    "-DLLAMA_USE_PREBUILT_UI=OFF",
-    "-DLLAMA_OPENSSL=OFF",
-    "-DLLAMA_SUBPROCESS=OFF",
-    "-DGGML_METAL=OFF",
-    "-DGGML_CUDA=OFF",
-    "-DGGML_VULKAN=OFF",
-    "-DGGML_OPENCL=OFF",
-    "-DGGML_RPC=OFF",
-    "-DGGML_NATIVE=OFF",
-    "-DGGML_CPU_ARM_ARCH=armv8.4-a+dotprod+fp16"
-  ],
   "model": {
     "fileName": "granite-q4_0.gguf",
     "bytes": 66345216,
     "sha256": "18e8ce8ce834790618e90d26bed465cca87362076f3042eb0d8eee0732596f59"
+  },
+  "targets": {
+    "darwin-arm64": {
+      "cmake": {
+        "version": "3.31.6",
+        "darwinUniversalUrl": "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-macos-universal.tar.gz",
+        "darwinUniversalSha256": "330b9514f5112e5ed4fb08b8b05803b776fd9b539a6ae12927d14dcc0ee2ba8d"
+      },
+      "cmakeFlags": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_OSX_ARCHITECTURES=arm64",
+        "-DCMAKE_OSX_DEPLOYMENT_TARGET=13.3",
+        "-DLLAMA_BUILD_NUMBER=@BUILD_NUMBER@",
+        "-DLLAMA_BUILD_COMMIT=@BUILD_COMMIT@",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DLLAMA_BUILD_TESTS=OFF",
+        "-DLLAMA_BUILD_EXAMPLES=OFF",
+        "-DLLAMA_BUILD_TOOLS=ON",
+        "-DLLAMA_BUILD_SERVER=ON",
+        "-DLLAMA_BUILD_APP=OFF",
+        "-DLLAMA_BUILD_UI=OFF",
+        "-DLLAMA_USE_PREBUILT_UI=OFF",
+        "-DLLAMA_OPENSSL=OFF",
+        "-DLLAMA_SUBPROCESS=OFF",
+        "-DGGML_METAL=OFF",
+        "-DGGML_CUDA=OFF",
+        "-DGGML_VULKAN=OFF",
+        "-DGGML_OPENCL=OFF",
+        "-DGGML_RPC=OFF",
+        "-DGGML_NATIVE=OFF",
+        "-DGGML_CPU_ARM_ARCH=armv8.4-a+dotprod+fp16"
+      ]
+    },
+    "linux-x64": {
+      "cmakeFlags": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DLLAMA_BUILD_NUMBER=@BUILD_NUMBER@",
+        "-DLLAMA_BUILD_COMMIT=@BUILD_COMMIT@",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DLLAMA_BUILD_TESTS=OFF",
+        "-DLLAMA_BUILD_EXAMPLES=OFF",
+        "-DLLAMA_BUILD_TOOLS=ON",
+        "-DLLAMA_BUILD_SERVER=ON",
+        "-DLLAMA_BUILD_APP=OFF",
+        "-DLLAMA_BUILD_UI=OFF",
+        "-DLLAMA_USE_PREBUILT_UI=OFF",
+        "-DLLAMA_OPENSSL=OFF",
+        "-DLLAMA_SUBPROCESS=OFF",
+        "-DGGML_METAL=OFF",
+        "-DGGML_CUDA=OFF",
+        "-DGGML_VULKAN=OFF",
+        "-DGGML_OPENCL=OFF",
+        "-DGGML_RPC=OFF",
+        "-DGGML_NATIVE=OFF",
+        "-DGGML_SSE42=OFF",
+        "-DGGML_AVX=OFF",
+        "-DGGML_AVX2=OFF",
+        "-DGGML_BMI2=OFF",
+        "-DGGML_FMA=OFF",
+        "-DGGML_F16C=OFF",
+        "-DGGML_OPENMP=OFF"
+      ]
+    }
   }
 }

--- a/packages/backend/integration/embedding.integration.ts
+++ b/packages/backend/integration/embedding.integration.ts
@@ -5,7 +5,12 @@ import { createBackendApp } from "../src/app";
 import { createBackendClient } from "../src/client/client";
 import { createBackendService } from "../src/modules/backend/service";
 import { PROTOCOL_VERSION } from "../src/protocol/constants";
-import { assertUnitVector, createNativeFixture, modelPathFromArgs } from "./support/native";
+import {
+  assertUnitVector,
+  createNativeFixture,
+  HARNESS_ENCODE_BUDGET_MS,
+  modelPathFromArgs,
+} from "./support/native";
 import { readRssMiB, waitUntil } from "./support/process";
 import { verifyReferences } from "./support/reference";
 
@@ -40,6 +45,7 @@ try {
     secret,
     buildIdentity: identity.buildIdentity,
     baseUrl: `http://127.0.0.1:${app.server.port}`,
+    timeoutMs: HARNESS_ENCODE_BUDGET_MS,
   });
   assert.equal((await client.statusModel()).state, "unloaded");
   const started = performance.now();

--- a/packages/backend/integration/support/native.ts
+++ b/packages/backend/integration/support/native.ts
@@ -7,6 +7,12 @@ import type { ProcessIdentity } from "../../src/runtime/process-identity";
 import { createEmbeddingProcess } from "../../src/runtime/embedding-process";
 import type { ResolvedEmbeddingConfig } from "../../src/config/embedding";
 
+/**
+ * Baseline CPU targets encode full batches sequentially and can exceed the 5 s product
+ * default for one request; the harness observes throughput instead of gating machine speed.
+ */
+export const HARNESS_ENCODE_BUDGET_MS = 60_000;
+
 export function modelPathFromArgs(): string {
   const path = process.argv[2];
   assert(path, "Provide the fixed Q4_0 model path as the first argument");
@@ -29,7 +35,11 @@ export function createNativeFixture(
     ...(options.maxTokens === undefined ? {} : { maxTokens: options.maxTokens }),
   };
   const service = createEmbeddingService({
-    settings: { ...DEFAULT_BACKEND_SETTINGS, startupTimeoutMs: 15_000 },
+    settings: {
+      ...DEFAULT_BACKEND_SETTINGS,
+      startupTimeoutMs: 15_000,
+      requestTimeoutMs: HARNESS_ENCODE_BUDGET_MS,
+    },
     ...runtimeSettings,
     createRuntime() {
       const native = createEmbeddingProcess({ modelPath, ...runtimeSettings }, async (identity) => {

--- a/packages/backend/src/runtime/embedding-resources.test.ts
+++ b/packages/backend/src/runtime/embedding-resources.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveCompiledEmbeddingResourceRoot, verifyResource } from "./embedding-resources";
@@ -40,6 +40,10 @@ test("resource verification rejects wrong content and detects replacement after 
       verifyResource(path, 7, "0".repeat(64), AbortSignal.timeout(1000)),
     ).rejects.toMatchObject({ code: "embedding.resource-invalid" });
     await writeFile(path, "changed");
+    // Pin a distinct mtime instead of waiting out the kernel's coarse (jiffy) timestamp
+    // granularity on Linux: the verifier must reject any change to the tracked stat fields.
+    const pinned = new Date(Date.now() - 60_000);
+    await utimes(path, pinned, pinned);
     await expect(unchanged()).rejects.toMatchObject({ code: "embedding.resource-invalid" });
     await rm(path);
     const target = join(directory, "target");

--- a/packages/backend/src/runtime/native/embedding/catalog.test.ts
+++ b/packages/backend/src/runtime/native/embedding/catalog.test.ts
@@ -25,3 +25,19 @@ test("embedding artifact catalog owns the development, installed, and trusted-ma
 test("embedding artifact catalog rejects an unsupported platform instead of selecting another target", () => {
   expect(resolveEmbeddingNativeArtifact("win32", "x64")).toBeUndefined();
 });
+
+test("embedding artifact catalog owns the linux-x64 development, installed, and trusted-manifest paths", () => {
+  const artifact = resolveEmbeddingNativeArtifact("linux", "x64");
+  expect(artifact).toBeDefined();
+  if (artifact === undefined) throw new Error("linux-x64 artifact is required");
+
+  expect(artifact.id).toBe("linux-x64");
+  expect(artifact.compileTarget).toBe("bun-linux-x64");
+  expect(developmentEmbeddingArtifactDirectory(artifact)).toBe(
+    resolve(import.meta.dir, "../../../..", ".artifacts", "native", "embedding", artifact.id),
+  );
+  expect(installedEmbeddingArtifactDirectory("/release", artifact)).toBe(
+    join("/release", "native", artifact.id),
+  );
+  expect(trustedEmbeddingManifestPath(artifact)).toBe(join(import.meta.dir, "linux-x64.json"));
+});

--- a/packages/backend/src/runtime/native/embedding/catalog.ts
+++ b/packages/backend/src/runtime/native/embedding/catalog.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from "node:path";
 import { parseNativeArtifactManifest } from "./manifest";
 import darwinArm64Manifest from "./darwin-arm64.json";
+import linuxX64Manifest from "./linux-x64.json";
 
 const backendPackageRoot = resolve(import.meta.dir, "../../../..");
 const developmentEmbeddingArtifactRoot = join(
@@ -17,6 +18,13 @@ const embeddingNativeArtifacts = [
     arch: "arm64",
     compileTarget: "bun-darwin-arm64",
     manifest: parseNativeArtifactManifest(darwinArm64Manifest),
+  },
+  {
+    id: "linux-x64",
+    platform: "linux",
+    arch: "x64",
+    compileTarget: "bun-linux-x64",
+    manifest: parseNativeArtifactManifest(linuxX64Manifest),
   },
 ] as const satisfies readonly {
   readonly id: string;

--- a/packages/backend/src/runtime/native/embedding/linux-x64.json
+++ b/packages/backend/src/runtime/native/embedding/linux-x64.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": 1,
+  "buildIdentity": "59f1c47caa11cd67a7c6da8a79460192e16e5bc7d19bbd31aec2322ee5b91873",
+  "recipeIdentity": "e747196a0e9eda4e84c706e46ced6986f5efcd63d47087284c84d2f8c149c8f0",
+  "platform": "linux",
+  "arch": "x64",
+  "executable": "llama-server",
+  "source": {
+    "tag": "b10901",
+    "commit": "28ff0958291ce3465fabd7bd679d4b0edd742bd9",
+    "archiveSha256": "b4220cefe053c18fb2d5c27a859c0aaab3106a5644bcbbbb2bdd67699dfe4b79"
+  },
+  "patchSha256": "f58b3db4c77ae0297679153d893f08dabc1b1759edead5c5b4cd9eef19bab03f",
+  "toolchain": {
+    "cmake": "cmake version 3.28.3",
+    "compiler": "c++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0"
+  },
+  "cmakeFlags": [
+    "-DCMAKE_BUILD_TYPE=Release",
+    "-DLLAMA_BUILD_NUMBER=10901",
+    "-DLLAMA_BUILD_COMMIT=28ff0958-lorelum.f58b3db4",
+    "-DBUILD_SHARED_LIBS=OFF",
+    "-DLLAMA_BUILD_TESTS=OFF",
+    "-DLLAMA_BUILD_EXAMPLES=OFF",
+    "-DLLAMA_BUILD_TOOLS=ON",
+    "-DLLAMA_BUILD_SERVER=ON",
+    "-DLLAMA_BUILD_APP=OFF",
+    "-DLLAMA_BUILD_UI=OFF",
+    "-DLLAMA_USE_PREBUILT_UI=OFF",
+    "-DLLAMA_OPENSSL=OFF",
+    "-DLLAMA_SUBPROCESS=OFF",
+    "-DGGML_METAL=OFF",
+    "-DGGML_CUDA=OFF",
+    "-DGGML_VULKAN=OFF",
+    "-DGGML_OPENCL=OFF",
+    "-DGGML_RPC=OFF",
+    "-DGGML_NATIVE=OFF",
+    "-DGGML_SSE42=OFF",
+    "-DGGML_AVX=OFF",
+    "-DGGML_AVX2=OFF",
+    "-DGGML_BMI2=OFF",
+    "-DGGML_FMA=OFF",
+    "-DGGML_F16C=OFF",
+    "-DGGML_OPENMP=OFF"
+  ],
+  "model": {
+    "fileName": "granite-q4_0.gguf",
+    "bytes": 66345216,
+    "sha256": "18e8ce8ce834790618e90d26bed465cca87362076f3042eb0d8eee0732596f59"
+  },
+  "files": [
+    {
+      "path": "llama-server",
+      "bytes": 14505992,
+      "sha256": "a756a95816dbdef48a475d0d82b80efc4c571260e1a11a9db7580e01050c6f24"
+    },
+    {
+      "path": "LICENSE.llama.cpp",
+      "bytes": 1078,
+      "sha256": "94f29bbed6a22c35b992c5c6ebf0e7c92f13b836b90f36f461c9cf2f0f1d010d"
+    },
+    {
+      "path": "LICENSE.cpp-httplib",
+      "bytes": 1075,
+      "sha256": "4b45cbe16d7b71b89ae6127e26e0d90a029198ca5e958ad8e3d0b8bbed364d8b"
+    },
+    {
+      "path": "LICENSE.nlohmann-json",
+      "bytes": 1075,
+      "sha256": "c0d068392ea65358b798b8c165103560f06e9e3b38c4ab4e2d8810a7b931af86"
+    },
+    {
+      "path": "LICENSE.rotate-bits",
+      "bytes": 1088,
+      "sha256": "ca0b44aec101afb6b46f4c39b23369fa06a64fb9c0add37c2689d702156fee55"
+    },
+    {
+      "path": "LICENSE.sha256",
+      "bytes": 41,
+      "sha256": "b81d0022ca6367918c67b57e9647d3513ee58809fd4b0ef0b3492f1356bced25"
+    },
+    {
+      "path": "LICENSE.xxhash",
+      "bytes": 1389,
+      "sha256": "6ffedbc0f7878612d2b23589f1ff2ab15633e1df7963a5d9fc750ec5500c7e7a"
+    },
+    {
+      "path": "THIRD_PARTY_NOTICES.txt",
+      "bytes": 634,
+      "sha256": "6582d4fb7712326c65f62d3a7c7f9291a7b8649df4e0bbc2c3f97ae2782d9668"
+    }
+  ],
+  "licenses": [
+    "LICENSE.llama.cpp",
+    "LICENSE.cpp-httplib",
+    "LICENSE.nlohmann-json",
+    "LICENSE.rotate-bits",
+    "LICENSE.sha256",
+    "LICENSE.xxhash",
+    "THIRD_PARTY_NOTICES.txt"
+  ],
+  "dynamicDependencies": ["libstdc++.so.6", "libm.so.6", "libgcc_s.so.1", "libc.so.6"]
+}

--- a/packages/backend/src/runtime/native/embedding/manifest.test.ts
+++ b/packages/backend/src/runtime/native/embedding/manifest.test.ts
@@ -98,3 +98,35 @@ test("native artifact verification checks declared bytes, digests, mode and depe
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test("linux artifacts validate against the linux system soname allowlist only", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lore-release-native-linux-"));
+  const contents = "native";
+  try {
+    const manifest: NativeArtifactManifest = {
+      ...fixture(contents),
+      platform: "linux",
+      arch: "x64",
+      dynamicDependencies: ["libc.so.6", "libstdc++.so.6"],
+    };
+    await writeFile(join(directory, "llama-server"), contents);
+    await chmod(join(directory, "llama-server"), 0o755);
+    await writeFile(join(directory, "manifest.json"), JSON.stringify(manifest));
+    await expect(verifyNativeArtifact(directory)).resolves.toEqual(manifest);
+
+    await writeFile(
+      join(directory, "manifest.json"),
+      JSON.stringify({ ...manifest, dynamicDependencies: ["/usr/lib/libSystem.B.dylib"] }),
+    );
+    // A darwin system path is not part of the linux allowlist.
+    await expect(verifyNativeArtifact(directory)).rejects.toThrow("unsupported dynamic dependency");
+    // Neither is an unexpected native library.
+    await writeFile(
+      join(directory, "manifest.json"),
+      JSON.stringify({ ...manifest, dynamicDependencies: ["libcrypto.so.3"] }),
+    );
+    await expect(verifyNativeArtifact(directory)).rejects.toThrow("unsupported dynamic dependency");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/backend/src/runtime/native/embedding/manifest.ts
+++ b/packages/backend/src/runtime/native/embedding/manifest.ts
@@ -7,20 +7,28 @@ const MAX_MANIFEST_BYTES = 16_384;
 const SHA256 = /^[a-f0-9]{64}$/;
 const FILE_NAME = /^[A-Za-z0-9_.-]+$/;
 
-export const DARWIN_ARM64_SYSTEM_DEPENDENCIES = Object.freeze(
-  new Set([
+export type NativeArtifactPlatform = "darwin" | "linux";
+export type NativeArtifactArch = "arm64" | "x64";
+
+/** Static llama-server builds may only link the operating system's own libraries. */
+export const NATIVE_SYSTEM_DEPENDENCIES: Readonly<
+  Record<"darwin-arm64" | "linux-x64", ReadonlySet<string>>
+> = {
+  "darwin-arm64": new Set([
     "/usr/lib/libSystem.B.dylib",
     "/System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate",
     "/usr/lib/libc++.1.dylib",
   ]),
-);
+  // Sonames from ldd on the Ubuntu 24.04 (glibc 2.39) build baseline.
+  "linux-x64": new Set(["libc.so.6", "libstdc++.so.6", "libm.so.6", "libgcc_s.so.1"]),
+};
 
 export interface NativeArtifactManifest {
   readonly schemaVersion: 1;
   readonly buildIdentity: string;
   readonly recipeIdentity: string;
-  readonly platform: "darwin";
-  readonly arch: "arm64";
+  readonly platform: NativeArtifactPlatform;
+  readonly arch: NativeArtifactArch;
   readonly executable: string;
   readonly source: {
     readonly tag: string;
@@ -59,7 +67,7 @@ export async function readNativeArtifactManifest(
   return parseNativeArtifactManifest(value);
 }
 
-/** Verify every declared native file and the macOS system-library allowlist. */
+/** Verify every declared native file and the target's system-library allowlist. */
 export async function verifyNativeArtifact(directory: string): Promise<NativeArtifactManifest> {
   const manifest = await readNativeArtifactManifest(directory);
   const expectedNames = new Set(["manifest.json", ...manifest.files.map((file) => file.path)]);
@@ -85,10 +93,14 @@ export async function verifyNativeArtifact(directory: string): Promise<NativeArt
   const executableInfo = await lstat(join(directory, manifest.executable));
   if (!executable || (executableInfo.mode & 0o111) === 0)
     throw new Error("native executable is missing execute permissions");
+  const target = `${manifest.platform}-${manifest.arch}`;
+  const allowed =
+    target === "darwin-arm64" || target === "linux-x64"
+      ? NATIVE_SYSTEM_DEPENDENCIES[target]
+      : undefined;
   if (
-    manifest.dynamicDependencies.some(
-      (dependency) => !DARWIN_ARM64_SYSTEM_DEPENDENCIES.has(dependency),
-    )
+    allowed === undefined ||
+    manifest.dynamicDependencies.some((dependency) => !allowed.has(dependency))
   )
     throw new Error("native artifact links an unsupported dynamic dependency");
   return manifest;
@@ -150,7 +162,14 @@ export function parseNativeArtifactManifest(value: unknown): NativeArtifactManif
     ],
     "manifest",
   );
-  if (manifest.schemaVersion !== 1 || manifest.platform !== "darwin" || manifest.arch !== "arm64")
+  const platform = text(manifest.platform, "manifest.platform");
+  const arch = text(manifest.arch, "manifest.arch");
+  if (
+    manifest.schemaVersion !== 1 ||
+    (platform !== "darwin" && platform !== "linux") ||
+    (arch !== "arm64" && arch !== "x64") ||
+    !Object.hasOwn(NATIVE_SYSTEM_DEPENDENCIES, `${platform}-${arch}`)
+  )
     throw new Error("native manifest target is unsupported");
   const files = array(manifest.files, "manifest.files").map((entry, index) => {
     const file = object(entry, `manifest.files[${index}]`);
@@ -180,8 +199,8 @@ export function parseNativeArtifactManifest(value: unknown): NativeArtifactManif
     schemaVersion: 1,
     buildIdentity: digest(manifest.buildIdentity, "manifest.buildIdentity"),
     recipeIdentity: digest(manifest.recipeIdentity, "manifest.recipeIdentity"),
-    platform: "darwin",
-    arch: "arm64",
+    platform,
+    arch,
     executable,
     source: {
       tag: text(source.tag, "manifest.source.tag"),

--- a/scripts/native/build-config.test.ts
+++ b/scripts/native/build-config.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import { resolve } from "node:path";
+import buildConfig from "../../native/embedding/build-config.json";
+import darwinTrusted from "../../packages/backend/src/runtime/native/embedding/darwin-arm64.json";
+import linuxTrusted from "../../packages/backend/src/runtime/native/embedding/linux-x64.json";
+import { stableSha256 } from "./cache-paths";
+import { assertNativePatchDigest } from "./source-tree";
+
+const repositoryRoot = resolve(import.meta.dir, "../..");
+
+function expandedCmakeFlags(target: "darwin-arm64" | "linux-x64"): readonly string[] {
+  return buildConfig.targets[target].cmakeFlags.map((flag) =>
+    flag
+      .replace("@BUILD_NUMBER@", buildConfig.source.tag.slice(1))
+      .replace(
+        "@BUILD_COMMIT@",
+        `${buildConfig.source.commit.slice(0, 8)}-lorelum.${buildConfig.patch.sha256.slice(0, 8)}`,
+      ),
+  );
+}
+
+/** The trusted manifests and the reviewed recipe must describe the same build inputs. */
+function recipeIdentity(target: "darwin-arm64" | "linux-x64"): string {
+  return stableSha256({
+    schemaVersion: buildConfig.schemaVersion,
+    source: buildConfig.source,
+    patchSha256: buildConfig.patch.sha256,
+    cmakeFlags: expandedCmakeFlags(target),
+    model: buildConfig.model,
+  });
+}
+
+test("each target's recipe identity still reproduces its trusted manifest", () => {
+  expect(recipeIdentity("darwin-arm64")).toBe(darwinTrusted.recipeIdentity);
+  expect(recipeIdentity("linux-x64")).toBe(linuxTrusted.recipeIdentity);
+});
+
+test("trusted manifests record exactly the expanded recipe flags", () => {
+  expect(darwinTrusted.cmakeFlags).toEqual(expandedCmakeFlags("darwin-arm64"));
+  expect(linuxTrusted.cmakeFlags).toEqual(expandedCmakeFlags("linux-x64"));
+});
+
+test("linux-x64 recipe keeps the generic x86-64 baseline", () => {
+  const flags = buildConfig.targets["linux-x64"].cmakeFlags;
+  for (const cap of [
+    "GGML_NATIVE",
+    "GGML_SSE42",
+    "GGML_AVX",
+    "GGML_AVX2",
+    "GGML_BMI2",
+    "GGML_FMA",
+    "GGML_F16C",
+  ])
+    expect(flags).toContain(`-D${cap}=OFF`);
+  // The darwin-only architecture and deployment flags must not leak into Linux builds.
+  for (const flag of flags) expect(flag).not.toMatch(/^-DCMAKE_OSX_|^-DGGML_CPU_ARM_ARCH/);
+});
+
+test("reviewed patch file matches its pinned digest", () => {
+  expect(() => assertNativePatchDigest(repositoryRoot)).not.toThrow();
+});

--- a/scripts/native/build-embedding.ts
+++ b/scripts/native/build-embedding.ts
@@ -9,11 +9,12 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import config from "../../native/embedding/build-config.json";
 import {
   developmentEmbeddingArtifactDirectory,
   resolveEmbeddingNativeArtifact,
+  type EmbeddingNativeArtifact,
 } from "../../packages/backend/src/runtime/native/embedding/catalog";
 import {
   assertSourceNativeArtifactMatch,
@@ -32,15 +33,18 @@ import {
 const repositoryRoot = resolve(import.meta.dir, "../..");
 const worktreeBuildRoot = nativeBuildWorktreeDirectory(repositoryRoot);
 const sourceRoot = patchedLlamaSourceDirectory(repositoryRoot);
-const buildRoot = join(worktreeBuildRoot, "build-darwin-arm64");
 const toolRoot = join(worktreeBuildRoot, "tools");
-const cmakeArchive = join(toolRoot, `cmake-${config.cmake.version}-macos-universal.tar.gz`);
-const cmakeExecutable = join(
-  toolRoot,
-  `cmake-${config.cmake.version}-macos-universal`,
-  "CMake.app/Contents/bin/cmake",
-);
-const cmakeFlags = config.cmakeFlags.map((flag) =>
+
+const artifact = resolveEmbeddingNativeArtifact(process.platform, process.arch);
+if (artifact === undefined) {
+  throw new Error(
+    `this validated build recipe currently supports darwin-arm64 and linux-x64, got ${process.platform}-${process.arch}`,
+  );
+}
+const buildRoot = join(worktreeBuildRoot, `build-${artifact.id}`);
+
+const recipe = targetRecipe(artifact);
+const cmakeFlags = recipe.cmakeFlags.map((flag) =>
   flag
     .replace("@BUILD_NUMBER@", config.source.tag.slice(1))
     .replace(
@@ -66,6 +70,106 @@ const licenses = [
   ["vendor/hash/xxhash/LICENSE", "LICENSE.xxhash", "xxHash (vendored by llama.cpp)"],
 ] as const;
 
+/** Per-target inputs: flags always, a pinned CMake download only where the recipe pins one. */
+function targetRecipe(target: EmbeddingNativeArtifact): {
+  readonly cmakeFlags: readonly string[];
+  readonly cmake?: {
+    readonly version: string;
+    readonly darwinUniversalUrl: string;
+    readonly darwinUniversalSha256: string;
+  };
+} {
+  if (target.platform === "darwin" && target.id === "darwin-arm64")
+    return config.targets["darwin-arm64"];
+  if (target.platform === "linux" && target.id === "linux-x64") return config.targets["linux-x64"];
+  throw new Error(`unsupported build target ${target.id}`);
+}
+
+/** Toolchain resolution differs per target; the recipe and manifest shape stay shared. */
+interface TargetToolchain {
+  readonly cmakeExecutable: string;
+  readonly cmakeVersion: string;
+  /** Cache-key input; the pinned archive digest on darwin, empty when using the system CMake. */
+  readonly cmakeArchiveSha256: string;
+  readonly compiler: string;
+  /** Cache-key input standing in for the OS runtime ABI: macOS SDK or Linux glibc version. */
+  readonly platformFingerprint: string;
+  prepare(): Promise<void>;
+  dynamicDependencies(executable: string): string[];
+}
+
+function darwinToolchain(): TargetToolchain {
+  const pinned = recipe.cmake;
+  if (pinned === undefined) throw new Error("darwin-arm64 recipe must pin its CMake download");
+  const cmakeArchive = join(toolRoot, `cmake-${pinned.version}-macos-universal.tar.gz`);
+  const cmakeExecutable = join(
+    toolRoot,
+    `cmake-${pinned.version}-macos-universal`,
+    "CMake.app/Contents/bin/cmake",
+  );
+  return {
+    cmakeExecutable,
+    cmakeVersion: pinned.version,
+    cmakeArchiveSha256: pinned.darwinUniversalSha256,
+    compiler: run(["xcrun", "clang++", "--version"]).split("\n")[0] ?? "unknown",
+    platformFingerprint: run(["xcrun", "--show-sdk-version"]),
+    async prepare() {
+      mkdirSync(worktreeBuildRoot, { recursive: true });
+      mkdirSync(toolRoot, { recursive: true });
+      await ensurePinnedDownload({
+        url: pinned.darwinUniversalUrl,
+        destination: cmakeArchive,
+        sha256: pinned.darwinUniversalSha256,
+      });
+      if (!existsSync(cmakeExecutable)) run(["tar", "-xzf", cmakeArchive, "-C", toolRoot]);
+    },
+    dynamicDependencies(executable) {
+      return run(["otool", "-L", executable])
+        .split("\n")
+        .slice(1)
+        .map((line) => line.trim().split(" ")[0])
+        .filter((value): value is string => Boolean(value));
+    },
+  };
+}
+
+function linuxToolchain(): TargetToolchain {
+  return {
+    cmakeExecutable: "cmake",
+    cmakeVersion: run(["cmake", "--version"]).split("\n")[0] ?? "unknown",
+    cmakeArchiveSha256: "",
+    compiler: run(["c++", "--version"]).split("\n")[0] ?? "unknown",
+    // glibc decides which systems the dynamically linked llama-server can start on.
+    platformFingerprint: run(["ldd", "--version"]).split("\n")[0] ?? "unknown",
+    async prepare() {
+      // Linux builds use the distribution CMake; the version above already gated its presence.
+    },
+    dynamicDependencies(executable) {
+      const output = run(["ldd", executable]);
+      if (output.length === 0) throw new Error("ldd produced no dependency output");
+      const sonames = output
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && !line.startsWith("/"))
+        .map((line) => line.split(/\s+/)[0] ?? "")
+        .map((name) => basename(name))
+        .filter(
+          (name) =>
+            /^lib.+\.so(\.[0-9]+)*$/.test(name) &&
+            name !== "linux-vdso.so.1" &&
+            name !== "linux-gate.so.1",
+        );
+      // The recipe always links the C++ runtime dynamically; an empty set means the
+      // ldd output format changed, not that the binary has no dependencies.
+      if (sonames.length === 0 && !output.includes("not a dynamic executable"))
+        throw new Error(`could not parse ldd output for ${executable}`);
+      return sonames;
+    },
+  };
+}
+
+const toolchain = artifact.platform === "darwin" ? darwinToolchain() : linuxToolchain();
+
 function sha256File(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
@@ -86,24 +190,13 @@ function copyArtifact(source: string, destination: string): void {
   chmodSync(destination, statSync(source).mode);
 }
 
-async function prepareBuildInputs(): Promise<void> {
-  mkdirSync(worktreeBuildRoot, { recursive: true });
-  mkdirSync(toolRoot, { recursive: true });
-  await ensurePinnedDownload({
-    url: config.cmake.darwinUniversalUrl,
-    destination: cmakeArchive,
-    sha256: config.cmake.darwinUniversalSha256,
-  });
-  if (!existsSync(cmakeExecutable)) run(["tar", "-xzf", cmakeArchive, "-C", toolRoot]);
-}
-
-function buildNativeArtifact(outputRoot: string, compiler: string): NativeArtifactManifest {
+function buildNativeArtifact(outputRoot: string): NativeArtifactManifest {
   rmSync(buildRoot, { recursive: true, force: true });
   run(
     [
       "/usr/bin/env",
       `GIT_CEILING_DIRECTORIES=${repositoryRoot}`,
-      cmakeExecutable,
+      toolchain.cmakeExecutable,
       "-S",
       sourceRoot,
       "-B",
@@ -112,7 +205,15 @@ function buildNativeArtifact(outputRoot: string, compiler: string): NativeArtifa
     ],
     sourceRoot,
   );
-  run([cmakeExecutable, "--build", buildRoot, "--target", "llama-server", "--parallel", "4"]);
+  run([
+    toolchain.cmakeExecutable,
+    "--build",
+    buildRoot,
+    "--target",
+    "llama-server",
+    "--parallel",
+    "4",
+  ]);
 
   const builtExecutable = join(buildRoot, "bin/llama-server");
   if (!existsSync(builtExecutable)) throw new Error(`build completed without ${builtExecutable}`);
@@ -155,8 +256,8 @@ function buildNativeArtifact(outputRoot: string, compiler: string): NativeArtifa
     schemaVersion: 1,
     buildIdentity: stableSha256({ recipeIdentity, files }),
     recipeIdentity,
-    platform: "darwin",
-    arch: "arm64",
+    platform: artifact.platform,
+    arch: artifact.arch,
     executable: "llama-server",
     source: {
       tag: config.source.tag,
@@ -165,29 +266,19 @@ function buildNativeArtifact(outputRoot: string, compiler: string): NativeArtifa
     },
     patchSha256: config.patch.sha256,
     toolchain: {
-      cmake: run([cmakeExecutable, "--version"]).split("\n")[0] ?? "unknown",
-      compiler,
+      cmake: run([toolchain.cmakeExecutable, "--version"]).split("\n")[0] ?? "unknown",
+      compiler: toolchain.compiler,
     },
     cmakeFlags,
     model: config.model,
     files,
     licenses: licenseFiles,
-    dynamicDependencies: run(["otool", "-L", join(outputRoot, "llama-server")])
-      .split("\n")
-      .slice(1)
-      .map((line) => line.trim().split(" ")[0])
-      .filter((value): value is string => Boolean(value)),
+    dynamicDependencies: toolchain.dynamicDependencies(join(outputRoot, "llama-server")),
   };
   writeFileSync(join(outputRoot, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
   return manifest;
 }
 
-const artifact = resolveEmbeddingNativeArtifact(process.platform, process.arch);
-if (artifact === undefined) {
-  throw new Error(
-    `this validated build recipe currently supports darwin-arm64, got ${process.platform}-${process.arch}`,
-  );
-}
 assertNativePatchDigest(repositoryRoot);
 
 const recipeIdentity = stableSha256({
@@ -197,15 +288,13 @@ const recipeIdentity = stableSha256({
   cmakeFlags,
   model: config.model,
 });
-const compiler = run(["xcrun", "clang++", "--version"]).split("\n")[0] ?? "unknown";
-const sdkVersion = run(["xcrun", "--show-sdk-version"]);
 const cacheKey = nativeBuildCacheKey({
   target: artifact.id,
   recipeIdentity,
-  cmakeVersion: config.cmake.version,
-  cmakeArchiveSha256: config.cmake.darwinUniversalSha256,
-  compiler,
-  sdkVersion,
+  cmakeVersion: toolchain.cmakeVersion,
+  cmakeArchiveSha256: toolchain.cmakeArchiveSha256,
+  compiler: toolchain.compiler,
+  sdkVersion: toolchain.platformFingerprint,
 });
 const manifest = await materializeNativeBuildCache({
   cacheRoot: nativeBuildCacheRoot(),
@@ -214,9 +303,9 @@ const manifest = await materializeNativeBuildCache({
   candidateDirectory: developmentEmbeddingArtifactDirectory(artifact),
   validate: (candidate) => assertSourceNativeArtifactMatch(artifact.manifest, candidate),
   async build(outputDirectory) {
-    await prepareBuildInputs();
+    await toolchain.prepare();
     await materializePatchedLlamaSource(repositoryRoot);
-    buildNativeArtifact(outputDirectory, compiler);
+    buildNativeArtifact(outputDirectory);
   },
   report: (message) => console.log(message),
 });

--- a/scripts/native/test-parent-liveness.ts
+++ b/scripts/native/test-parent-liveness.ts
@@ -16,7 +16,7 @@ const repositoryRoot = resolve(import.meta.dir, "../..");
 const artifact = resolveEmbeddingNativeArtifact(process.platform, process.arch);
 if (artifact === undefined)
   throw new Error(
-    `native lifecycle tests currently support darwin-arm64, got ${process.platform}-${process.arch}`,
+    `native lifecycle tests currently support darwin-arm64 and linux-x64, got ${process.platform}-${process.arch}`,
   );
 const executable = join(developmentEmbeddingArtifactDirectory(artifact), "llama-server");
 const model = join(repositoryRoot, ".cache/embedding-validation", buildConfig.model.fileName);
@@ -45,10 +45,11 @@ async function ensureHarness(): Promise<void> {
   const sourceRoot = await materializePatchedLlamaSource(repositoryRoot);
   const patchedMain = join(sourceRoot, "tools/server/main.cpp");
   mkdirSync(join(repositoryRoot, ".cache/native-liveness"), { recursive: true });
+  // The liveness harness links against the same patched server entrypoint it probes.
+  const compiler = artifact.platform === "darwin" ? ["xcrun", "clang++"] : ["c++"];
   const result = Bun.spawnSync(
     [
-      "xcrun",
-      "clang++",
+      ...compiler,
       "-std=c++17",
       "-pthread",
       patchedMain,


### PR DESCRIPTION
## Summary

按 native artifact boundary 设计预留的 target catalog 扩展点，新增 `linux-x64` CPU artifact。Linux 上 `bun run build:native` 从显式报错变为完整产出，源码与编译 CLI 均可加载模型并执行 embedding；不改公共 CLI/MCP 契约、检索模型、产品默认值与 release workflow。

- `build-config.json` 重构为共享 `source/patch/model` + `targets`：darwin-arm64 的 19 条 flags 逐字节保留（`recipeIdentity` 不变，守卫测试锁定）；linux-x64 显式关闭 `GGML_NATIVE`、六个 ISA 开关与 `GGML_OPENMP`——通用 x86-64 基线（ggml 默认会在 Linux 启用 AVX2/FMA/F16C，OpenMP 会引入 libgomp 依赖），产物仅链接 libc/libstdc++/libm/libgcc_s。
- catalog 新增 `linux-x64` 项；manifest 平台类型放宽为 `darwin|linux` / `arm64|x64`，系统依赖 allowlist 按 target 选择（Linux 冻结为 ldd soname 集合）；新增受信 manifest `linux-x64.json`，由真实构建产物显式冻结。
- `build-embedding.ts` 工具链按 target 解析：macOS 保留 pinned CMake/`xcrun`/`otool`；Linux 用系统 cmake/c++，缓存键以 glibc 版本替代 SDK 指纹，darwin 缓存键不变。
- 验收 harness：integration 编码预算收敛为 `HARNESS_ENCODE_BUDGET_MS`（60s，基线 CPU 顺序编码整批会超产品默认 5s，产品默认值不动）；`embedding-resources` 测试用 `utimes` 钉住 mtime，消除 Linux jiffy 级时间戳粒度导致的随机失败。

## Linked issue

Closes #118

## Type of change

- [x] ✨ New feature (non-breaking)

## How was this tested?

- `bun test` 654 项通过；`bun run typecheck`、`bun run lint`、`bun run fmt:check` 通过。
- 真实构建（Ubuntu 24.04 / glibc 2.39 / WSL2）：全新构建 + 二次缓存命中；`ldd` 依赖恰为 allowlist 集合；objdump 0 条 AVX/FMA 指令。
- 源码 CLI（隔离 HOME）：`backend start → model load（真实下载 granite-q4_0.gguf）→ embedding（384 维、L2 单位范数、encodingId 一致）→ unload → stop`；parent-liveness 三场景（startup/encoding/stalled-main）通过。
- integration（真实模型）：`http-embedding`、`daemon-lifecycle`、`token-settings`（512/1024/2048）通过。
- 编译版：`build:release` 产出 `lore-0.0.0-linux-x64.tar.gz`；archive 解压 + 符号链接的编译 CLI 完成同等生命周期；篡改 native 一字节后 `model load` 以 `embedding.resource-invalid` 拒绝。

## Checklist

- [x] Linked the issue this closes (`Closes #118`)
- [x] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed in the issue / Discussions first
- [x] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

## Notes for reviewers

- 重点看 `build-embedding.ts` 的 toolchain 分支与 `manifest.ts` 的 allowlist 选择；darwin `recipeIdentity` 零漂移由 `build-config.test.ts` 守卫，无需 macOS 环境即可复核。
- 残余风险：glibc 兼容面仅 Ubuntu 24.04（2.39）验证；高速 x86 变体与 Windows 不在本 PR；`install.sh` 仍只放行 macOS arm64，发布流程未触碰。
