### PR TITLE
feat(cli): select the linux-x64 install target from the platform

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,8 +24,8 @@ usage() {
   cat <<'EOF'
 Usage: install.sh [--version <version>]
 
-Install the latest stable Lorelum CLI release for macOS arm64. Pass --version
-to install one specific release instead.
+Install the latest stable Lorelum CLI release for macOS arm64 and Linux x64.
+Pass --version to install one specific release instead.
 The script downloads a release archive and SHA256SUMS, verifies both before
 extracting, then atomically creates ~/.local/bin/lore.
 EOF
@@ -53,8 +53,11 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-[ "$(uname -s)" = 'Darwin' ] || fail 'only macOS arm64 is currently supported'
-[ "$(uname -m)" = 'arm64' ] || fail 'only macOS arm64 is currently supported'
+case "$(uname -s):$(uname -m)" in
+  Darwin:arm64) target='darwin-arm64' ;;
+  Linux:x86_64) target='linux-x64' ;;
+  *) fail "unsupported platform: $(uname -s) $(uname -m)" ;;
+esac
 command -v tar >/dev/null 2>&1 || fail 'tar is required to extract the release archive'
 if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
   fail "curl or wget is required; download the release archive manually from $repository/releases"
@@ -108,7 +111,6 @@ else
   release_tag="v$version"
 fi
 
-target='darwin-arm64'
 archive_name="lore-$version-$target.tar.gz"
 package_name="lore-$version-$target"
 archive_url="$release_base/$release_tag/$archive_name"

--- a/scripts/release/install.integration.test.ts
+++ b/scripts/release/install.integration.test.ts
@@ -5,10 +5,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const version = "0.1.0";
-const target = "darwin-arm64";
-const archiveName = `lore-${version}-${target}.tar.gz`;
-const packageName = archiveName.slice(0, -".tar.gz".length);
 const repositoryRoot = join(import.meta.dir, "..", "..");
+
+const platforms = {
+  "darwin-arm64": { unameS: "Darwin", unameM: "arm64" },
+  "linux-x64": { unameS: "Linux", unameM: "x86_64" },
+} as const;
+type InstallerPlatform = keyof typeof platforms;
 
 test("installer verifies, extracts, and atomically links one platform package", async () => {
   const root = await mkdtemp(join(tmpdir(), "lore-install-integration-"));
@@ -25,6 +28,26 @@ test("installer verifies, extracts, and atomically links one platform package", 
       "Apache-2.0 fixture\n",
     );
     expect(result.stdout).toContain(`Installed lore ${version}`);
+  } finally {
+    server.stop(true);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("installer installs the linux-x64 package on Linux x86_64", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lore-install-linux-"));
+  const server = await createReleaseServer(root, { platform: "linux-x64" });
+  try {
+    const result = await runInstaller(root, server.url.origin, ["--version", version], "linux-x64");
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(`Installed lore ${version}`);
+    expect(
+      await readFile(
+        join(root, "share", "versions", version, "native", "linux-x64", "manifest.json"),
+        "utf8",
+      ),
+    ).toBe("{}\n");
   } finally {
     server.stop(true);
     await rm(root, { recursive: true, force: true });
@@ -96,19 +119,25 @@ test("installer leaves an unmanaged command untouched", async () => {
 
 async function createReleaseServer(
   root: string,
-  options: { latestTag?: string; releaseTag?: string } = {},
+  options: { latestTag?: string; releaseTag?: string; platform?: InstallerPlatform } = {},
 ) {
+  const platform = options.platform ?? "darwin-arm64";
+  const archiveName = `lore-${version}-${platform}.tar.gz`;
+  const packageName = archiveName.slice(0, -".tar.gz".length);
   const releaseTag = options.releaseTag ?? `v${version}`;
   const releases = join(root, "releases", releaseTag);
   const packageDirectory = join(root, packageName);
-  await mkdir(join(packageDirectory, "native", target), { recursive: true });
+  await mkdir(join(packageDirectory, "native", platform), { recursive: true });
   await writeFile(join(packageDirectory, "lore"), "#!/bin/sh\nexit 0\n");
   await writeFile(join(packageDirectory, "LICENSE"), "Apache-2.0 fixture\n");
   await writeFile(join(packageDirectory, "THIRD_PARTY_NOTICES.txt"), "notices\n");
-  await writeFile(join(packageDirectory, "native", target, "llama-server"), "#!/bin/sh\nexit 0\n");
-  await writeFile(join(packageDirectory, "native", target, "manifest.json"), "{}\n");
+  await writeFile(
+    join(packageDirectory, "native", platform, "llama-server"),
+    "#!/bin/sh\nexit 0\n",
+  );
+  await writeFile(join(packageDirectory, "native", platform, "manifest.json"), "{}\n");
   await chmod(join(packageDirectory, "lore"), 0o755);
-  await chmod(join(packageDirectory, "native", target, "llama-server"), 0o755);
+  await chmod(join(packageDirectory, "native", platform, "llama-server"), 0o755);
   await mkdir(releases, { recursive: true });
   const archive = join(releases, archiveName);
   const archived = Bun.spawnSync(["tar", "-C", root, "-czf", archive, packageName]);
@@ -140,13 +169,15 @@ async function runInstaller(
   root: string,
   releaseBase: string,
   arguments_: readonly string[] = ["--version", version],
+  platform: InstallerPlatform = "darwin-arm64",
 ) {
   const fakeBin = join(root, "fake-bin");
   await mkdir(fakeBin, { recursive: true });
   const uname = join(fakeBin, "uname");
+  const { unameS, unameM } = platforms[platform];
   await writeFile(
     uname,
-    '#!/bin/sh\ncase "$1" in\n  -s) echo Darwin ;;\n  -m) echo arm64 ;;\nesac\n',
+    `#!/bin/sh\ncase "$1" in\n  -s) echo ${unameS} ;;\n  -m) echo ${unameM} ;;\nesac\n`,
   );
   await chmod(uname, 0o755);
   const child = Bun.spawn(["sh", join(repositoryRoot, "install.sh"), ...arguments_], {


### PR DESCRIPTION
## Summary

`install.sh` 按平台选择安装 target：`Darwin/arm64` → `darwin-arm64`，`Linux/x86_64` → `linux-x64`，其余组合保持显式拒绝。其余校验逻辑（SHA256SUMS、archive 布局、原子链接）原本就按 `$target` 参数化，无需改动。正式 Releases 尚未发布 Linux 包，本 PR 只解锁脚本能力；配合 `LORELUM_INSTALL_RELEASE_BASE_URL` + `--version` 可从本地 HTTP 源离线安装。

## Linked issue

Related to #118（#118 由 #119 关闭，本 PR 是其安装器部分）

## Type of change

- [x] ✨ New feature (non-breaking)

## How was this tested?

- `bun test scripts/release/install.integration.test.ts` 6 项通过：5 个既有 darwin 用例行为不变，新增 linux-x64 用例（fake `uname` 参数化）。
- 全量 `bun test`（655 项）、typecheck、lint、fmt:check 通过。
- 实机验证：`build:release` 产物经本地 HTTP 源 + `install.sh --version 0.0.0` 安装，`lore` 完成 `backend start → model load（384 维）→ backend stop`。

## Checklist

- [x] Linked the issue this closes
- [x] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed in the issue / Discussions first
- [x] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

## Notes for reviewers

- 文档支持范围声明随 #118/#119 的文档改动统一同步，本 PR 不重复改 `docs/cli/backend.md` 以避免冲突。
