### PR TITLE
feat(query): add backend-hosted semantic query

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Two modes share the same commands:
 - **Local mode (default):** `lore install` a public pack, query offline. Zero ops. Like npm.
 - **Endpoint mode:** point the CLI at a team/SaaS/self-hosted endpoint for real-time, multi-user knowledge.
 
-The current local foundation provides exact `lore get` and offline keyword `lore query`; semantic and hybrid retrieval remain on the roadmap.
+The current local foundation provides exact `lore get`, local semantic `lore query`, and an explicit offline keyword fallback with `lore query --mode keyword`. Hybrid retrieval remains on the roadmap.
 
 ## Roadmap
 

--- a/docs/api/query.md
+++ b/docs/api/query.md
@@ -1,6 +1,6 @@
-# Keyword Query API
+# Query API
 
-`POST /internal/v1/query` 使用 backend 的本地认证边界，不启动模型，也不访问 embedding 下载器。它查询选定 LocalStore 的 keyword index；semantic query/index 仍是后续阶段。
+`POST /internal/v1/query` uses the Backend's local authentication boundary. It neither starts the model nor accesses the model downloader. Omitting `mode` selects semantic retrieval; callers that need the offline keyword path must send `mode: "keyword"` explicitly.
 
 请求 body：
 
@@ -9,18 +9,21 @@
   "storageRoot": "/absolute/path/to/isolated-store",
   "query": {
     "text": "responsibility boundary",
-    "limit": 5
+    "limit": 5,
+    "mode": "semantic"
   }
 }
 ```
 
-`storageRoot` 必须是绝对路径。`text` 由 QueryService 做领域校验，不能为空，最多 4,096 个 Unicode code points；`limit` 可省略，默认 5，范围为 1–50。请求体必须是严格 JSON 对象，不接受额外字段。
+`storageRoot` must be an absolute path. `text` must not be blank and is limited to 4,096 Unicode code points; `limit` defaults to 5 and ranges from 1 through 50. `mode` is `semantic` or `keyword`; it is optional and defaults to `semantic`. The request body is a strict JSON object and rejects extra fields.
 
 成功 `200`：
 
 ```json
 {
-  "mode": "keyword",
+  "mode": "semantic",
+  "profileId": "...",
+  "coverage": "complete",
   "results": [
     {
       "practiceId": "example.api.guidance",
@@ -35,17 +38,24 @@
 }
 ```
 
-响应只包含可公开的 Practice 摘要字段，不返回完整 body、SQLite handle 或内部 score。常见错误为 `usage.invalid`、`query.unavailable`、`query.failed`、`store.busy` 和 `store.recovery-required`。
+Semantic results include `coverage: "complete"` when the active index exactly matches the Store snapshot. They include `coverage: "partial"` only when retained Store history allows the Engine to exclude every changed Practice before searching stale vectors. A history gap fails instead of returning an unsafe result. Keyword results retain their existing shape: `{ "mode": "keyword", "results": [...] }`.
+
+Responses expose only public Practice summary fields, never a body, vector, SQLite handle, or internal score.
 
 ## 错误映射
 
-| HTTP | code                      | 含义                            |
-| ---- | ------------------------- | ------------------------------- |
-| 400  | `backend.invalid-request` | JSON/字段/请求体不符合合同      |
-| 400  | `usage.invalid`           | 查询文本或 limit 不符合领域约束 |
-| 503  | `query.unavailable`       | keyword index 不可用            |
-| 500  | `query.failed`            | keyword index 查询失败          |
-| 503  | `store.busy`              | 无法取得可用 Store snapshot     |
-| 503  | `store.recovery-required` | Store 需要恢复                  |
+| HTTP | code | Meaning |
+| ---- | ---- | ------- |
+| 400 | `backend.invalid-request` | JSON, fields, or request body violates the wire contract. |
+| 400 | `usage.invalid` | Query text or limit violates the Engine query contract. |
+| 503 | `embedding.*` | The local model is not loaded, busy, timed out, or failed. |
+| 503 | `semantic.index-not-ready` | No safe semantic index is available; build it explicitly. |
+| 503 | `semantic.index-incompatible` | The index does not match the Store or fixed Profile. |
+| 500 | `semantic.index-failed` | SQLite/index data or candidate verification failed. |
+| 503 | `semantic.embedding-failed` | The query embedding violated the fixed Profile contract. |
+| 503 | `query.unavailable` | The explicit keyword index is unavailable. |
+| 500 | `query.failed` | The explicit keyword index failed. |
+| 503 | `store.busy` | A stable Store snapshot could not be obtained. |
+| 503 | `store.recovery-required` | The Store requires recovery. |
 
 认证、Origin、Host 及通用内部错误见 [API 入口](README.md)。

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -9,7 +9,7 @@ Lorelum CLI 的机器接口是单行 JSON envelope。成功输出包含 `command
 - [Backend 控制](backend.md)：启动、状态、停止本地 backend。
 - [Model 生命周期](model.md)：准备、加载、状态、卸载 embedding 模型。
 - [Semantic index](index.md)：查看、构建或替换某个 Store 的 semantic index。
-- [Query](query.md)：使用 LocalStore 的 keyword query。
+- [Query](query.md)：默认使用本地 semantic query；`--mode keyword` 保留离线 keyword query。
 - [Get](get.md)：读取一个已安装 Practice。
 - [List](list.md)：列出 Pack 或 Practice 目录。
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,6 +1,6 @@
 # Semantic index 命令
 
-`lore index status/build/rebuild` 管理指定 LocalStore 的 semantic index。它们通过本地 Backend 使用已经加载的 embedding 模型；这一步只准备按语义检索所需的派生数据，**不会改变当前 `lore query` 的 keyword 行为**。
+`lore index status/build/rebuild` 管理指定 LocalStore 的 semantic index。它们通过本地 Backend 使用已经加载的 embedding 模型；`lore query` 默认会使用这个 index，`--mode keyword` 则保留独立的离线路径。
 
 在当前 worktree 验收这组命令时，先按[开发指南的 normal workflow](../development/README.md#normal-development-workflow)选择源码或编译路径；不要用全局 `lore` 或其他 worktree 的 binary 验证当前改动。
 
@@ -74,4 +74,4 @@ canonical Practice 仍在 LocalStore；index 不是正文事实来源。首次�
 | `store.busy`、`store.recovery-required` | Store 正在变更或需要恢复；等待变更完成，或先修复 Store 后再重试。 |
 | `embedding.failed`、`backend.failed` | 模型或构建失败；查看 `lore model status`，修复后显式 build，必要时 rebuild。 |
 
-当前阶段不提供 semantic query、Hybrid、多个 Profile 或自动重建。这些功能会在 semantic index 的真实流程完成验收后另行推进。
+v1 不提供 Hybrid、多个 Profile 或自动重建。semantic query 仍要求用户显式启动 Backend、加载模型并构建 index。

--- a/docs/cli/query.md
+++ b/docs/cli/query.md
@@ -1,48 +1,52 @@
 # Query installed Practices
 
-`lore query <text>` searches the installed Practices in the selected LocalStore and returns a small summary for each match. The current command is offline keyword search; it does not call an Embedding provider and does not claim semantic understanding. The Engine contract and implementation boundary are defined in [ADR 0011](../adr/0011-local-store-point-read-and-query-boundary.md) and implemented under [Issue #60](https://github.com/lorelum/lorelum/issues/60).
+`lore query <text>` searches the installed Practices in the selected LocalStore and returns a small summary for each match. It defaults to local semantic retrieval; `--mode keyword` retains the offline FTS5 path.
 
 ```sh
+# Semantic is the default. Start the Backend, load the model, and build this Store's index first.
 lore query "React 登录页接入现有认证接口"
 lore query "database migration rollback" --top-k 10
+
+# Explicit zero-configuration, offline keyword retrieval.
+lore query "database migration rollback" --mode keyword
+
 lore --store-root /path/to/isolated-store query "request validation"
 lore describe query
 ```
 
-The positional text is trimmed before validation. It must contain at least one non-whitespace character and may contain at most 4,096 Unicode code points after trimming. `--top-k` is optional, defaults to `5`, and accepts a decimal positive integer from `1` through `50`. A value such as `5.0`, `-1`, or `51` is invalid. The global `--store-root` option follows the same resolution rules as `get`.
+The positional text is trimmed before validation. It must contain at least one non-whitespace character and may contain at most 4,096 Unicode code points after trimming. `--top-k` is optional, defaults to `5`, and accepts a decimal positive integer from `1` through `50`. `--mode` accepts `semantic` (the default) or `keyword`. The global `--store-root` option follows the same resolution rules as `get`.
 
-## Result
+## Semantic mode
 
-The command writes one JSON protocol envelope to stdout. A successful result has `command: "query"`, `ok: true`, and this data shape:
+Semantic mode uses the fixed local Profile and the selected Store's previously built semantic index. It does not start the Backend, download or load the model, or build an index. Prepare those resources explicitly:
+
+```sh
+lore backend start
+lore model load
+lore --store-root /path/to/store index build
+lore --store-root /path/to/store query "how should I verify this release?"
+```
+
+The successful result includes the Profile identity and how completely the active index covers the Store snapshot:
 
 ```json
 {
-  "mode": "keyword",
-  "results": [
-    {
-      "practiceId": "react.api.layered-design",
-      "title": "分层 API 设计",
-      "stage": "api-layer",
-      "techStack": ["react", "typescript"],
-      "appliesWhen": "在 React SPA 中构建 API 层",
-      "severity": "warn",
-      "contentDigest": "..."
-    }
-  ]
+  "mode": "semantic",
+  "profileId": "...",
+  "coverage": "complete",
+  "results": []
 }
 ```
 
-`results` may be empty and contains at most `top-k` entries. Results are Practices, not individual source files. The response intentionally omits the full body and internal BM25 score; use `lore get <practice-id>` to retrieve the complete canonical Practice. Ordering is deterministic for the same Store snapshot and query implementation: higher internal relevance first, then Practice ID for ties. A query does not pin a revision for a later `get` invocation.
+`coverage: "complete"` means the index and Store snapshot are identical. `coverage: "partial"` means the Store changed after the index was built, but Lorelum could use a continuous change history to exclude every affected Practice and safely return results from the remaining vectors. If that safety proof is unavailable, the command fails and asks for an explicit `index build`; it never silently switches to keyword retrieval.
 
-## Store and index behavior
+## Keyword mode
 
-The first query builds a derived SQLite FTS5 index under the selected Store root at `indexes/keyword/v<index-version>/active.sqlite`; it is separate from `store.sqlite`, whose canonical Practice rows remain the source of truth. Later queries reuse an index whose root binding and effective revision match the Store. An implementation-version directory isolates indexes when the FTS schema, projection, tokenizer, or ranking behavior changes. Queries search FTS5, then materialize and digest-check only the matched canonical Practice rows before assembling summaries.
+`--mode keyword` runs directly in Engine, does not need a Backend or model, and does not access the network. It maintains its own derived FTS5 index at `indexes/keyword/v<index-version>/active.sqlite`. The index is separate from `store.sqlite`; canonical Practice rows remain the source of returned summaries. A missing, corrupt, incompatible, or history-gap keyword index is rebuilt from a consistent Store snapshot.
 
-Install, upgrade, uninstall, and reindex do not wait for index work. LocalStore records an internal effective-revision delta with each changed corpus. A later query applies a contiguous delta to the FTS table in one SQLite transaction; it deletes affected IDs, inserts the final changed rows, and advances the index checkpoint. A missing, corrupt, incompatible, or history-gap index is rebuilt from one complete consistent snapshot. The index is never treated as a source for summaries or as a fallback for an inconsistent Store.
+## Shared result behavior
 
-The indexed fields are Practice ID, title, applies-when text, tech-stack values, stage, anti-pattern text, and body. The current internal weights are `id: 8`, `title: 5`, `appliesWhen: 3`, `techStack: 2`, `stage: 1`, `antiPatterns: 1`, and `body: 1`. These are implementation parameters, not CLI options. Query text and indexed text use the same tokenizer, including normalization for technical identifiers and CJK text; raw user text is encoded as FTS literal terms rather than passed through as FTS operators.
-
-The query path does not run the full artifact audit performed by `open()`, and it does not converge pending operation journals. It uses the same lock-free manifest/SQLite snapshot protocol as the existing full-read path. A Store that is busy or inconsistent therefore fails instead of returning a mixed or stale corpus. The query does not access the Registry or network. A query checks index metadata and its returned candidate digests; it is not a whole-index audit.
+Both modes return one JSON protocol envelope on stdout. `results` may be empty and contains at most `top-k` entries. Results are Practice summaries, not source files. They omit the full body and internal scores; use `lore get <practice-id>` to retrieve the complete canonical Practice. Results are deterministic for the same Store snapshot and query implementation. A query does not pin a revision for a later `get` invocation.
 
 ## Errors and exit codes
 
@@ -50,11 +54,12 @@ Success exits `0`. Failures use `ok: false` with `error: { code, message }` and 
 
 | Code | Meaning |
 | --- | --- |
-| `usage.invalid` | Missing text, invalid text length, malformed `--top-k`, duplicate option, or another command-line syntax error. |
-| `query.unavailable` | Bun SQLite FTS5 is unavailable in the current runtime. |
-| `query.failed` | The keyword index could not be built or searched. |
-| `store.busy` | A stable LocalStore corpus could not be obtained because it kept changing or a mutation is in progress. |
-| `store.recovery-required` | The selected LocalStore is inconsistent or cannot be read normally. |
+| `usage.invalid` | Missing or invalid text, `--top-k`, or `--mode`. Validation happens before a semantic query connects to the Backend. |
+| `backend.*` | The local Backend is absent, incompatible, busy, or exceeded its request deadline. Start or inspect it with `lore backend ...`. |
+| `embedding.*` | The local model is not loaded, is busy, timed out, or failed. Check `lore model status` and explicitly load it when needed. |
+| `semantic.index-not-ready` | No usable index exists, or Store history cannot safely bridge its age. Run `lore index build`. |
+| `semantic.index-incompatible` | The index does not match the fixed Profile or selected Store. Run `lore index rebuild`. |
+| `semantic.index-failed` / `semantic.embedding-failed` | The stored index or query embedding violates its contract. Rebuild the index; inspect model status for embedding failures. |
+| `query.unavailable` / `query.failed` | The explicit keyword index could not be searched. |
+| `store.busy` / `store.recovery-required` | The selected Store kept changing, is mutating, or needs recovery. |
 | `runtime.unexpected` | An undeclared internal failure prevented completion. |
-
-The Engine API reports `InvalidQueryRequestError`, `KeywordIndexUnavailableError`, and `KeywordIndexError` for the corresponding domain failures. CLI translation keeps those implementation types out of the protocol. Semantic, hybrid, structured-filter, and result-count options are not part of this command.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -25,7 +25,7 @@ This is the index for day-to-day development topics that do not belong in the pr
 
 ## Design records and remaining plans
 
-- [Query phased implementation roadmap (Chinese)](../plans/query-roadmap.md) - keyword retrieval, configuration, embedding profiles, and derived indexes. The keyword query foundation is implemented; later phases remain proposed.
+- [Query phased implementation roadmap (Chinese)](../plans/query-roadmap.md) - historical phased planning for keyword retrieval, configuration, embedding profiles, and derived indexes. Use the CLI documents for the shipped semantic query contract.
 - [Local resident backend design (Chinese)](../plans/local-backend-service-design.md) - the historical first-stage lifecycle and Store-isolation design. For current commands and model behavior, use the CLI documents above.
 
 ## Local CLI and multiple worktrees
@@ -196,8 +196,10 @@ const result = await queryService.query(
 );
 ```
 
-`text` is trimmed, must not be empty, and is limited to 4,096 Unicode code points. `limit` defaults to `5` and must be an integer from `1` to `50`. The result has `mode: "keyword"` and `results` containing `practiceId`, `title`, `stage`, `techStack`, `appliesWhen`, `severity`, and `contentDigest`; it does not include full bodies or internal scores. Invalid requests throw `InvalidQueryRequestError`. FTS5 runtime failures throw `KeywordIndexUnavailableError` or `KeywordIndexError`; callers at protocol boundaries translate these types to their own error codes.
+`text` is trimmed, must not be empty, and is limited to 4,096 Unicode code points. `limit` defaults to `5` and must be an integer from `1` to `50`. The result has `mode: "keyword"` and `results` containing `practiceId`, `title`, `stage`, `techStack`, `appliesWhen`, `severity`, and `contentDigest`; it does not include full bodies or internal scores. Invalid requests throw `InvalidQueryRequestError`. FTS5 runtime failures throw `KeywordIndexUnavailableError` or `KeywordIndexError`; callers at protocol boundaries translate these types to their own error codes. This is the Engine-only keyword use case used by CLI `--mode keyword`.
 
-QueryService keeps its public request/result contract local, but reuses a derived FTS5 SQLite index under the selected Store root across CLI processes. It binds that index to a verified effective revision, updates it from LocalStore's retained revision deltas, and rebuilds only when the index or its history cannot be trusted. Canonical Store rows remain the source of returned summaries; QueryService does not expose SQLite handles. Semantic retrieval and MCP lifecycle caching remain later design work.
+QueryService keeps its public request/result contract local, but reuses a derived FTS5 SQLite index under the selected Store root across CLI processes. It binds that index to a verified effective revision, updates it from LocalStore's retained revision deltas, and rebuilds only when the index or its history cannot be trusted. Canonical Store rows remain the source of returned summaries; QueryService does not expose SQLite handles.
+
+Semantic query is a separate Engine use case composed inside the local Backend with the fixed Profile and the already loaded model. It reads one active semantic-index connection per request, verifies the selected Store snapshot, and returns `complete` or safely reduced `partial` coverage. CLI must route semantic requests through that Backend; Engine must not import the Backend client. See [Query](../cli/query.md) for lifecycle and CLI behavior.
 
 全局配置基础包是 `packages/config`，CLI、Engine 和 backend 可直接依赖它；它不依赖服务进程。各包自己的 config 模块负责 section schema 与业务默认值。共享文件初始化由应用组装层触发，不能放进某个消费方的读取函数。详见[配置包边界](../configuration/README.md#包边界与直接读取)。

--- a/docs/plans/semantic-query-v1-design.md
+++ b/docs/plans/semantic-query-v1-design.md
@@ -1,6 +1,6 @@
 # Semantic Query v1 设计
 
-- 状态：分阶段设计；semantic index 阶段已在 #116 实现，semantic query 仍待后续设计与实现
+- 状态：Semantic Query v1 已在当前工作树实现；semantic index 来自 #116，semantic query 已通过真实本地流程验收，待按仓库流程提交
 - 日期：2026-09-10；最后更新：2026-09-12
 - 范围：为已安装的 Practice 增加本地优先的 semantic query；不实现 Hybrid 或后续检索优化。
 - 关联 Issue：[Semantic Query v1 设计 #92](https://github.com/lorelum/lorelum/issues/92)、[后续模型评测 #85](https://github.com/lorelum/lorelum/issues/85)。
@@ -10,20 +10,20 @@
 
 ## 结论
 
-Semantic Query 是 Lorelum 的目标默认检索方式：Semantic Query v1 交付后，未指定 `--mode` 的 `lore query` 使用本地 semantic Profile。当前默认 keyword query 只是已交付的过渡能力，不是最终产品方向。keyword query 保留为显式 `--mode keyword` 的零配置、离线模式。
+Semantic Query 是 Lorelum 的默认检索方式：未指定 `--mode` 的 `lore query` 使用本地 semantic Profile。keyword query 保留为显式 `--mode keyword` 的零配置、离线模式。
 
 Semantic Query v1 使用固定 default Profile：[`ibm-granite/granite-embedding-97m-multilingual-r2`](https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2)。它于 2026 年发布，采用 Apache-2.0 许可，规模为 97M、输出 384 维，面向多语言检索，也覆盖中英和代码。它符合“本地、够用、不要太大”的约束。
 
-Semantic Query v1 的目标链路是：固定本地 default Profile、显式构建 index、执行 semantic query、再用 `lore get` 读取完整 Practice。当前已完成显式 index status/build/rebuild 及增量构建；semantic query、默认路由和 query 结果合同仍待下一阶段。首次模型下载、index 初建和强制 rebuild 仍由显式命令触发；多 Profile、远程 provider 和模型选择不属于 v1。
+Semantic Query v1 使用固定本地 default Profile，用户显式构建 index 后执行 semantic query，再用 `lore get` 读取完整 Practice。显式 index status/build/rebuild、增量构建和本文定义的 query 路由均已实现。首次模型下载、index 初建和强制 rebuild 仍由显式命令触发；多 Profile、远程 provider 和模型选择不属于 v1。
 
-## 现状
+## Observed：现状
 
 以下内容已由代码和已接受 ADR 确认：
 
-- `QueryService` 当前只有 keyword query；请求只有 `text` 和 `limit`，结果 `mode` 固定为 `keyword`。见 [query-service.ts](../../packages/engine/src/query/query-service.ts)、[types.ts](../../packages/engine/src/query/types.ts)。
-- CLI 只暴露 `lore query <text> [--top-k]`，默认离线运行。见 [query-command.ts](../../packages/cli/src/query/query-command.ts) 和 [Query CLI 文档](../cli/query.md)。
+- Engine 保留 keyword `QueryService` 的 `text`/`limit` 合同，并新增独立 `SemanticQueryService`；两者复用输入校验和 canonical 摘要组装。见 [query-service.ts](../../packages/engine/src/query/query-service.ts)、[semantic/query-service.ts](../../packages/engine/src/query/semantic/query-service.ts) 和 [types.ts](../../packages/engine/src/query/types.ts)。
+- CLI 暴露 `lore query <text> [--mode semantic|keyword] [--top-k]`；缺省 semantic，显式 keyword 离线直连 Engine。见 [query-command.ts](../../packages/cli/src/query/query-command.ts) 和 [Query CLI 文档](../cli/query.md)。
 - keyword index 是 LocalStore 之外的派生 SQLite 数据；它绑定经过验证的 Store snapshot，并使用 `effectiveRevision` 和 revision delta 保持同步。canonical Practice 和 `contentDigest` 仍然是结果的事实来源。见 [ADR 0012](../adr/0012-persistent-keyword-index.md)。
-- 共享 config、固定本地模型、Backend 生命周期、embedding service、`lore index status/build/rebuild` 与增量 build/发布一致性已在当前工作树中落地；semantic query CLI、默认路由和 query 结果合同仍未实现。
+- 共享 config、固定本地模型、Backend 生命周期、embedding service、`lore index status/build/rebuild`、增量 build/发布一致性、semantic query CLI、默认路由和 query 结果合同均已在当前工作树中落地。
 
 因此，Semantic Query 不能把向量或缓存正文写入 LocalStore 的内容事务，也不能把 index 当作 Practice 内容或来源的事实来源。
 
@@ -32,7 +32,7 @@ Semantic Query v1 的目标链路是：固定本地 default Profile、显式构�
 ### Required
 
 - Semantic Query v1 改变 `lore query` 的默认检索方式为 semantic；keyword query 的现有行为、离线属性、JSON 摘要和 keyword index 保留在显式 `--mode keyword` 下。
-- 没有 `--mode` 或指定 `--mode semantic` 时执行语义检索；没有配置或没有可用 index 时明确报错，不能退回 keyword query 假装成功。
+- 没有 `--mode` 或指定 `--mode semantic` 时执行语义检索；配置无效或没有可用 index 时明确报错，不能退回 keyword query 假装成功。共享 config 可以使用当前默认值，不存在手写 config 文件本身不必然是错误。
 - 默认 semantic query 使用固定的本地 default Profile。没有有效本地配置、没有 active index、index/Profile 不兼容，或无法证明旧向量与当前 Store 的安全关系时明确报错；index 正在追赶一个较新的 Store 时可返回明确标记为 partial 的 semantic 结果。远程 provider 不属于 v1。
 - 每个 semantic index 必须同时绑定 Store snapshot 与 EmbeddingProfile。不同模型、模型 revision、输入投影、向量维度或归一化方式不得混用数据。
 - 用户必须先显式执行 `lore index build`。这条命令才允许编码完整 Practice 集；普通 query 不得隐式发送内容、花费远程额度或长时间占用本地资源。
@@ -60,13 +60,13 @@ v1 固定使用 Granite 97M：384 维、32K context、Apache-2.0。其模型卡�
 
 模型运行配置归共享 `~/.lorelum/config.yaml` 的 embedding 段，资源身份由固定 manifest 确定，不再采用早期 `<store-root>/config.json` 中保存模型 revision 的提案。index 与 Store 的绑定仍归 Engine；`--store-root` 仍由现有 resolver 决定，模型配置不能重定向 Store。
 
-Lorelum 本地后端服务固定监听 `http://127.0.0.1:26186`。`26186` 表示 `26-186`：2026 年的第 186 天，即 Lorelum 仓库创建日期 2026-07-05。它只绑定 loopback，不能监听 `0.0.0.0`、`::` 或其他网络接口。Semantic Query v1 通过后端 client 使用第二阶段定义的认证 embedding 入口；端口本身不专属于 embedding，未来本地能力可以复用此后端服务。`baseUrl` 不进入 config，也不允许用户改成常用端口或远程地址。
+Lorelum 本地后端服务固定监听 `http://127.0.0.1:26186`。它只绑定 loopback，不能监听 `0.0.0.0`、`::` 或其他网络接口。Semantic Query v1 通过后端 client 调用认证 query 入口，由 Backend 在进程内注入 embedding 能力。`baseUrl` 不进入 config，也不允许用户改成常用端口或远程地址。
 
 运行配置、固定 GGUF 资源与 llama.cpp build 身份由[第二阶段计划](./local-backend-stage-2-design.md)统一定义；本篇不另设 modelRevision、provider 或 endpoint 配置。
 
 v1 的 default Profile 不是用户可选 alias，但仍需要内部 `profileId` 作为向量空间和 index 身份。它由固定模型 `ibm-granite/granite-embedding-97m-multilingual-r2`、固定源 revision、Q4_0 GGUF 摘要、经过验收的编码实现版本、document/query 输入投影、384 维、归一化、距离度量及其版本确定性生成。固定 endpoint 不进入 `profileId`；实测维度必须为 384，否则 build 失败。index metadata 记录 `profileId` 和实测维度，禁止通过实测值改变既有身份。
 
-`transport` 在 v1 固定为 `local`；远程 provider 不在范围内。config、`show` 和错误输出不得保存或展开密钥。没有有效 local config 时，普通 semantic query 返回 `semantic.config-invalid`。固定端口没有 Lorelum 后端服务、端口被其他进程占用或该服务的 embedding 路由不符合协议时，返回 `semantic.provider-failed`；不得扫描或随机改用其他端口。
+`transport` 在 v1 固定为 `local`；远程 provider 不在范围内。config、`show` 和错误输出不得保存或展开密钥。配置、服务、模型故障保留现有 `config.*`、`backend.*`、`embedding.*` 错误，映射见文末本阶段合同；不得扫描或随机改用其他端口。
 
 本阶段不再沿用 `set-model-revision` / `unset-model-revision` 的旧配置提案。未来 semantic CLI 的状态输出复用已验收模型身份；写入配置、启动模型和构建 index 的职责分离，具体命令在 semantic 接入阶段对齐，不作为模型常驻阶段的附加任务。
 
@@ -95,7 +95,7 @@ v1 只有固定 default Profile 对应的一个 active index。固定合同变�
 
 ### Semantic query
 
-Semantic query 阶段拟采用以下请求合同：
+Semantic query 使用以下请求合同：
 
 ```ts
 type QueryMode = "semantic" | "keyword";
@@ -108,35 +108,36 @@ interface QueryRequest {
 }
 ```
 
-v1 没有 `--profile`。Semantic Query v1 合入前，现有 CLI 仍只有 keyword query，本段不改变已发布行为。
+v1 没有 `--profile`。
 
 ```sh
 lore query "如何避免组件直接请求接口"
 lore query "database migration rollback" --mode keyword
 ```
 
-未指定 `--mode` 或指定 `--mode semantic` 时，使用固定 local default Profile。没有有效 local config 时返回 `semantic.config-invalid`。`--mode keyword` 才跳过 semantic config，并继续返回 `mode: "keyword"`。
+未指定 `--mode` 或指定 `--mode semantic` 时，使用固定 local default Profile。配置故障保留现有 config/backend 错误。`--mode keyword` 跳过模型配置与 Backend，并继续返回 `mode: "keyword"`。
 
 Semantic query 的成功 JSON 保持现有 `results` 摘要形状，并返回：
 
 ```json
 {
   "mode": "semantic",
-  "profileId": "sha256:...",
+  "profileId": "<existing 64-character hex profile ID>",
+  "coverage": "complete",
   "results": []
 }
 ```
 
 不公开 cosine score。结果仍然通过 Store snapshot 批量读取 canonical Practice，并逐一核对 `practiceId` 与 `contentDigest`；semantic index 只返回候选身份、内部 rank 和相似度。
 
-建议新增以下错误码，具体命名在 CLI 设计 Issue 中冻结：
+早期错误分类在当前实现阶段收敛如下，详细映射见文末：
 
 | 情况                               | 可见错误                                       |
 | ---------------------------------- | ---------------------------------------------- |
-| config 缺失、损坏或版本不支持      | `config.invalid`                               |
-| semantic index 不存在或过期        | `semantic.index-not-ready`                     |
+| config 损坏或版本不支持            | 复用现有 `config.*` / `backend.config-invalid` |
+| semantic index 不存在或无法安全复用 | `semantic.index-not-ready`                    |
 | index 与 Profile/Store 不兼容      | `semantic.index-incompatible`                  |
-| 本地 provider 不可用、返回非法向量 | `semantic.provider-failed`                     |
+| 模型不可用、返回非法向量           | 现有 `embedding.*` / `semantic.embedding-failed` |
 | Store 无法获得稳定 snapshot        | 复用 `store.busy` 或 `store.recovery-required` |
 
 所有失败保持现有单行 JSON envelope 和退出码约定。semantic query 不静默回退 keyword query。
@@ -148,11 +149,11 @@ Semantic query 的成功 JSON 保持现有 `results` 摘要形状，并返回：
 | 模块 | 责任 |
 | --- | --- |
 | LocalStore | 验证并提供 canonical Practice、来源、digest 和 Store snapshot；不执行 embedding。 |
-| config | 解析、验证和原子写入 Store-scoped config；隐藏凭证值。 |
-| 本地后端服务 | 独占 loopback `26186`，并提供 Semantic Query v1 所需的 `/v1` embedding 路由；其他本地路由不在本阶段定义。 |
+| config | 解析、验证和原子写入用户级共享 config；隐藏凭证值。 |
+| 本地后端服务 | 独占 loopback `26186`，通过已有 `/internal/v1/query` 托管 Engine 查询用例，并复用已加载模型。 |
 | embedding provider | 按 Profile 编码 document/query，验证向量数量、维度、有限值和归一化合同。 |
 | semantic index | 保存向量、Practice binding、profileId、snapshot identity 和构建状态；负责 staging、发布和清理自身文件。 |
-| QueryService | 固定请求所见 snapshot，选择 keyword 或 semantic retriever，回读并验证候选后组装摘要。 |
+| Engine query 用例 | keyword 与 semantic 分别固定请求所见 snapshot，回读并验证候选后组装摘要；入口按 mode 选择用例。 |
 | CLI | 解析 mode/index 命令，并把 typed error 转成既有 JSON 协议。 |
 
 ### 最小 index 数据
@@ -186,27 +187,15 @@ active index 损坏、metadata 缺失或 staging 发布失败时，不修改 Loc
 ```ts
 interface EmbeddingProfile {
   readonly profileId: string;
-  readonly providerNamespace: string;
-  readonly model: string;
-  readonly modelRevision: string | undefined;
+  readonly encodingId: string;
   readonly dimensions: number;
-  readonly documentInstruction: string | undefined;
-  readonly queryInstruction: string | undefined;
   readonly documentProjectionVersion: number;
-  readonly queryProjectionVersion: number;
-  readonly tokenizerRevision: string;
-  readonly maxInputTokens: number;
   readonly normalization: "l2";
-  readonly distanceMetric: "cosine";
-  readonly runtimeVariant: string | undefined;
 }
 
-interface EmbeddingProvider {
-  embedDocuments(
-    profile: EmbeddingProfile,
-    inputs: readonly string[],
-  ): Promise<readonly Float32Array[]>;
-  embedQuery(profile: EmbeddingProfile, input: string): Promise<Float32Array>;
+interface EmbeddingPort {
+  readonly maxBatchSize: number;
+  embed(inputs: readonly string[]): Promise<EmbeddingBatch>;
 }
 
 interface SemanticCandidate {
@@ -218,13 +207,13 @@ interface SemanticCandidate {
 }
 ```
 
-`EmbeddingProvider` 不接触 LocalStore、CLI 或 SQLite。`SemanticIndex` 不重新解析 Pack、也不返回正文。QueryService 保留完整请求编排和 snapshot 校验责任，从而使未来添加 Hybrid 不必绕过当前一致性边界。
+`EmbeddingPort` 不接触 LocalStore、CLI 或 SQLite；Backend 分别注入 document/query 适配。Profile 与 batch 类型复用当前 Engine 实现，不增加 token 字段。`SemanticIndex` 不重新解析 Pack、也不返回正文。QueryService 保留完整请求编排和 snapshot 校验责任。
 
 ## 分阶段实施
 
-当前阶段（#116）已经完成 Backend 托管的 semantic index：Engine 提供固定 `profileId` 的 status/build/rebuild、增量同步、staging 发布、过期检测和恢复；Backend 托管 operation 和已加载模型；CLI 只调用 Backend client。此阶段不改变 `lore query` 的当前 keyword 默认行为。
+上一阶段（#116）完成了 Backend 托管的 semantic index：Engine 提供固定 `profileId` 的 status/build/rebuild、增量同步、staging 发布、过期检测和恢复；Backend 托管 operation 和已加载模型。
 
-下一阶段才设计和实现 Backend 托管的 semantic query：Backend 在进程内托管 Engine semantic QueryService，CLI 将 semantic 路径路由到 Backend，`--mode keyword` 继续直连 Engine。只有该阶段完成并通过真实进程验收，才能称 Semantic Query v1 已交付。
+最后一个 query 阶段已实现：Backend 在进程内托管 Engine `SemanticQueryService`，CLI 将默认 semantic 路径路由到 Backend，`--mode keyword` 继续直连 Engine。真实本地流程已验证 `index build → semantic query → get`，因此本实现构成 Semantic Query v1 的完整能力闭环。
 
 Hybrid 或更进一步的性能优化，以 v1 的实际使用和测量数据为依据另行设计。
 
@@ -238,7 +227,3 @@ Hybrid 或更进一步的性能优化，以 v1 的实际使用和测量数据为
 - 空 Store 可以完成 build/status/query：index 不调用 provider，semantic query 返回空结果；第一份 Practice 写入后必须重新 build 并验证实际维度。
 - 同一 Profile 下，重复执行 semantic query 的结果顺序和摘要确定；删除或更新的 Practice 不会从 stale index 返回。新增或更新 Practice 的向量尚未发布时，query 只能返回其余未受影响 Practice 的 partial 结果。
 - 固定模型 revision、384 维、投影或归一化改变后，旧 index 不可用也不可复用。
-
-## 设计对齐门槛
-
-semantic query 阶段开始前，仍需在对应 Issue 或 Discussion 中确认 query 的 Backend operation/轮询合同、错误码、index 清理行为，以及 Granite 97M 的真实运行验证结果。多 Profile、远程 provider 和模型评测由后续 Issue 单独对齐。

--- a/packages/backend/integration/embedding.integration.ts
+++ b/packages/backend/integration/embedding.integration.ts
@@ -31,9 +31,14 @@ const app = createBackendApp({
   }),
   embedding: fixture.service,
   port: 0,
-  queryService: {
+  keywordQueryService: {
     async query() {
       return { mode: "keyword", results: [] };
+    },
+  },
+  semanticQueryService: {
+    async query() {
+      return { mode: "semantic", profileId: "a".repeat(64), coverage: "complete", results: [] };
     },
   },
 });

--- a/packages/backend/src/app.test.ts
+++ b/packages/backend/src/app.test.ts
@@ -3,7 +3,12 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createLocalStore, createQueryService, type QueryService } from "@lorelum/engine";
+import {
+  createLocalStore,
+  createQueryService,
+  type QueryService,
+  type SemanticQueryService,
+} from "@lorelum/engine";
 
 import { createPackCandidate } from "../../engine/src/local-store/model/candidate";
 
@@ -46,12 +51,30 @@ function request(path: string, init: RequestInit = {}): Request {
 }
 
 function app(
-  queryService?: QueryService,
+  keywordQueryService?: QueryService,
   onStop = () => undefined,
   instanceIdentity: typeof identity = identity,
   isReady: () => boolean = () => true,
   onStopFailure: (error: unknown) => void = () => undefined,
+  semanticQueryService?: SemanticQueryService,
 ) {
+  const keyword = keywordQueryService ?? {
+    async query() {
+      return { mode: "keyword", results: [] } as const;
+    },
+  };
+  const semantic =
+    semanticQueryService ??
+    ({
+      async query() {
+        return {
+          mode: "semantic",
+          profileId: "a".repeat(64),
+          coverage: "complete",
+          results: [],
+        } as const;
+      },
+    } satisfies SemanticQueryService);
   return createBackendApp({
     backend: createBackendService({
       identity: instanceIdentity,
@@ -60,11 +83,8 @@ function app(
       onStopFailure,
       isReady,
     }),
-    queryService: queryService ?? {
-      async query() {
-        return { mode: "keyword", results: [] } as const;
-      },
-    },
+    keywordQueryService: keyword,
+    semanticQueryService: semantic,
   });
 }
 
@@ -132,7 +152,7 @@ describe("createBackendApp", () => {
         },
         body: JSON.stringify({
           storageRoot: "/tmp/lorelum-test",
-          query: { text: "  keep this input  " },
+          query: { text: "  keep this input  ", mode: "keyword" },
         }),
       }),
     );
@@ -161,7 +181,10 @@ describe("createBackendApp", () => {
               authorization: `Bearer ${secret}`,
               "content-type": "application/json",
             },
-            body: JSON.stringify({ storageRoot: rootPath, query: { text, limit: 1 } }),
+            body: JSON.stringify({
+              storageRoot: rootPath,
+              query: { text, limit: 1, mode: "keyword" },
+            }),
           }),
         );
 
@@ -195,7 +218,7 @@ describe("createBackendApp", () => {
               authorization: `Bearer ${secret}`,
               "content-type": "application/json",
             },
-            body: JSON.stringify({ storageRoot: rootPath, query: { text } }),
+            body: JSON.stringify({ storageRoot: rootPath, query: { text, mode: "keyword" } }),
           }),
         );
         return response.json();
@@ -231,7 +254,10 @@ describe("createBackendApp", () => {
           authorization: `Bearer ${secret}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify({ storageRoot: "/tmp/lorelum-test", query: { text: "test" } }),
+        body: JSON.stringify({
+          storageRoot: "/tmp/lorelum-test",
+          query: { text: "test", mode: "keyword" },
+        }),
       }),
     );
 
@@ -255,7 +281,10 @@ describe("createBackendApp", () => {
           authorization: `Bearer ${secret}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify({ storageRoot: "/tmp/lorelum-test", query: { text: "test" } }),
+        body: JSON.stringify({
+          storageRoot: "/tmp/lorelum-test",
+          query: { text: "test", mode: "keyword" },
+        }),
       }),
     );
 
@@ -280,7 +309,10 @@ describe("createBackendApp", () => {
           authorization: `Bearer ${secret}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify({ storageRoot: "/tmp/lorelum-test", query: { text: "test" } }),
+        body: JSON.stringify({
+          storageRoot: "/tmp/lorelum-test",
+          query: { text: "test", mode: "keyword" },
+        }),
       }),
     );
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,6 +1,6 @@
 import { embeddingController } from "./modules/embedding/controller";
 import type { EmbeddingService } from "./modules/embedding/service";
-import type { QueryService } from "@lorelum/engine";
+import type { QueryService, SemanticQueryService } from "@lorelum/engine";
 import { Elysia } from "elysia";
 import { backendController } from "./modules/backend/controller";
 import type { BackendService } from "./modules/backend/service";
@@ -14,7 +14,8 @@ export interface CreateBackendAppOptions {
   readonly backend: BackendService;
   readonly embedding?: EmbeddingService;
   readonly indexOperations?: IndexOperationService;
-  readonly queryService: QueryService;
+  readonly keywordQueryService: QueryService;
+  readonly semanticQueryService: SemanticQueryService;
   /** Internal test injection; production always uses the fixed IPv4 endpoint. */
   readonly host?: string;
   readonly port?: number;
@@ -49,5 +50,13 @@ export function createBackendApp(options: CreateBackendAppOptions) {
         ? indexController(options.indexOperations, backend.available)
         : new Elysia(),
     )
-    .use(queryController(options.queryService, backend.available));
+    .use(
+      queryController(
+        {
+          keywordQueryService: options.keywordQueryService,
+          semanticQueryService: options.semanticQueryService,
+        },
+        backend.available,
+      ),
+    );
 }

--- a/packages/backend/src/client/client.test.ts
+++ b/packages/backend/src/client/client.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
-import type { QueryService } from "@lorelum/engine";
+import { SemanticIndexNotReadyError } from "@lorelum/engine";
+import type {
+  QueryRequest,
+  QueryService,
+  SemanticQueryService,
+  StorageRoot,
+} from "@lorelum/engine";
 
 import { createBackendApp } from "../app";
 import { createEmbeddingService, type EmbeddingService } from "../modules/embedding/service";
@@ -27,23 +33,38 @@ afterEach(() => {
 });
 
 function runningApp(
-  queryService?: QueryService,
+  keywordQueryService?: QueryService,
   backendIdentity: InstanceIdentity = identity,
   embedding?: EmbeddingService,
   indexOperations?: IndexOperationService,
+  semanticQueryService?: SemanticQueryService,
 ): {
   readonly app: ReturnType<typeof createBackendApp>;
   readonly url: string;
 } {
+  const keywordService: QueryService = keywordQueryService ?? {
+    async query() {
+      return { mode: "keyword", results: [] } as const;
+    },
+  };
+  const semantic =
+    semanticQueryService ??
+    ({
+      async query() {
+        return {
+          mode: "semantic",
+          profileId: "a".repeat(64),
+          coverage: "complete",
+          results: [],
+        } as const;
+      },
+    } satisfies SemanticQueryService);
   const app = createBackendApp({
     backend: createBackendService({ identity: backendIdentity, secret, onStop: () => undefined }),
     ...(embedding === undefined ? {} : { embedding }),
     ...(indexOperations === undefined ? {} : { indexOperations }),
-    queryService: queryService ?? {
-      async query() {
-        return { mode: "keyword", results: [] } as const;
-      },
-    },
+    keywordQueryService: keywordService,
+    semanticQueryService: semantic,
   });
   apps.push(app);
   app.listen({ hostname: "127.0.0.1", port: 0, maxRequestBodySize: 65_536 });
@@ -68,7 +89,7 @@ describe("createBackendClient", () => {
     });
 
     await expect(
-      client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "search" }),
+      client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "search", mode: "keyword" }),
     ).resolves.toEqual({
       mode: "keyword",
       results: [],
@@ -88,7 +109,7 @@ describe("createBackendClient", () => {
     });
 
     await expect(
-      client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "search" }),
+      client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "search", mode: "keyword" }),
     ).rejects.toEqual(expect.objectContaining({ code: "backend.incompatible" }));
   });
 
@@ -106,7 +127,7 @@ describe("createBackendClient", () => {
     });
 
     await expect(
-      client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "search" }),
+      client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "search", mode: "keyword" }),
     ).rejects.toBeInstanceOf(BackendRemoteError);
   });
 
@@ -323,4 +344,53 @@ test("rejects a mismatched protocol before sending control or model requests", a
   await expect(client.status()).rejects.toMatchObject({ code: "backend.incompatible" });
   await expect(client.stop()).rejects.toMatchObject({ code: "backend.incompatible" });
   await expect(client.loadModel()).rejects.toMatchObject({ code: "backend.incompatible" });
+});
+
+test("round-trips semantic query metadata", async () => {
+  const calls: unknown[] = [];
+  const { url } = runningApp(undefined, identity, undefined, undefined, {
+    async query(_root: StorageRoot, request: QueryRequest) {
+      calls.push(request);
+      return {
+        mode: "semantic",
+        profileId: "b".repeat(64),
+        coverage: "complete" as const,
+        results: [],
+      };
+    },
+  });
+  const client = createBackendClient({
+    identity,
+    secret,
+    buildIdentity: identity.buildIdentity,
+    baseUrl: url,
+  });
+
+  await expect(
+    client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "meaning" }),
+  ).resolves.toEqual({
+    mode: "semantic",
+    profileId: "b".repeat(64),
+    coverage: "complete",
+    results: [],
+  });
+  expect(calls).toEqual([{ text: "meaning" }]);
+});
+
+test("preserves semantic index errors through the client boundary", async () => {
+  const { url } = runningApp(undefined, identity, undefined, undefined, {
+    async query() {
+      throw new SemanticIndexNotReadyError();
+    },
+  });
+  const client = createBackendClient({
+    identity,
+    secret,
+    buildIdentity: identity.buildIdentity,
+    baseUrl: url,
+  });
+
+  await expect(
+    client.query({ rootPath: "/tmp/lorelum-client-test" }, { text: "meaning" }),
+  ).rejects.toMatchObject({ code: "semantic.index-not-ready" });
 });

--- a/packages/backend/src/client/client.ts
+++ b/packages/backend/src/client/client.ts
@@ -18,7 +18,12 @@ import {
 } from "../protocol/errors";
 import { EmbeddingError, embeddingErrorCodes } from "../modules/embedding/errors";
 import { constantTimeEqual, identityProof, type InstanceIdentity } from "../protocol/identity";
-import { queryRequestSchema, queryResultSchema } from "../modules/query/model";
+import {
+  queryRequestSchema,
+  queryResultSchema,
+  type BackendQueryResult,
+  type QueryMode,
+} from "../modules/query/model";
 import {
   identitySchema,
   statusSchema,
@@ -42,7 +47,9 @@ import {
 import { ENCODING_ID } from "../modules/embedding/model";
 import type { EmbeddingResult } from "../modules/embedding/model";
 import { DEFAULT_BACKEND_SETTINGS } from "../config/model";
-import type { QueryRequest, QueryResult, StorageRoot } from "@lorelum/engine";
+import type { QueryRequest, StorageRoot } from "@lorelum/engine";
+
+export type BackendQueryRequest = QueryRequest & { readonly mode?: QueryMode };
 
 export interface CreateBackendClientOptions {
   readonly identity: InstanceIdentity;
@@ -64,7 +71,7 @@ export interface BackendClient {
   statusModel(): Promise<ModelStatus>;
   unloadModel(): Promise<ModelStatus>;
   embed(kind: "query" | "document", inputs: readonly string[]): Promise<EmbeddingResult>;
-  query(root: StorageRoot, request: QueryRequest): Promise<QueryResult>;
+  query(root: StorageRoot, request: BackendQueryRequest): Promise<BackendQueryResult>;
   indexStatus(root: StorageRoot): Promise<IndexStatus>;
   buildIndex(root: StorageRoot): Promise<IndexOperation>;
   rebuildIndex(root: StorageRoot): Promise<IndexOperation>;

--- a/packages/backend/src/client/index.ts
+++ b/packages/backend/src/client/index.ts
@@ -1,1 +1,6 @@
-export { createBackendClient, type BackendClient, type CreateBackendClientOptions } from "./client";
+export {
+  createBackendClient,
+  type BackendClient,
+  type BackendQueryRequest,
+  type CreateBackendClientOptions,
+} from "./client";

--- a/packages/backend/src/modules/embedding/controller.test.ts
+++ b/packages/backend/src/modules/embedding/controller.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { createBackendApp } from "../../app";
+import type { QueryService, SemanticQueryService } from "@lorelum/engine";
 import { DEFAULT_BACKEND_SETTINGS } from "../../config/model";
 import { createBackendService } from "../backend/service";
 import { createEmbeddingService } from "./service";
@@ -18,14 +19,21 @@ function fixture() {
     onStop() {},
     modelState: () => embedding.status().state,
   });
+  const keywordQueryService: QueryService = {
+    async query() {
+      return { mode: "keyword", results: [] };
+    },
+  };
+  const semanticQueryService: SemanticQueryService = {
+    async query() {
+      return { mode: "semantic", profileId: "a".repeat(64), coverage: "complete", results: [] };
+    },
+  };
   const app = createBackendApp({
     backend,
     embedding,
-    queryService: {
-      async query() {
-        return { mode: "keyword", results: [] };
-      },
-    },
+    keywordQueryService,
+    semanticQueryService,
   });
   function request(path: string, method = "GET", body?: unknown, authorized = true) {
     return app.handle(

--- a/packages/backend/src/modules/index/controller.test.ts
+++ b/packages/backend/src/modules/index/controller.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import type { QueryService } from "@lorelum/engine";
+import type { QueryService, SemanticQueryService } from "@lorelum/engine";
 
 import { createBackendApp } from "../../app";
 import { createBackendService } from "../backend/service";
@@ -25,14 +25,20 @@ function request(path: string, init: RequestInit = {}): Request {
 }
 
 function app(indexOperations: IndexOperationService) {
-  const queryService: QueryService = {
+  const keywordQueryService: QueryService = {
     async query() {
       return { mode: "keyword", results: [] };
     },
   };
+  const semanticQueryService: SemanticQueryService = {
+    async query() {
+      return { mode: "semantic", profileId, coverage: "complete", results: [] };
+    },
+  };
   return createBackendApp({
     backend: createBackendService({ identity, secret, onStop: () => undefined }),
-    queryService,
+    keywordQueryService,
+    semanticQueryService,
     indexOperations,
   });
 }

--- a/packages/backend/src/modules/index/embedding-adapter.ts
+++ b/packages/backend/src/modules/index/embedding-adapter.ts
@@ -9,3 +9,11 @@ export function createEmbeddingAdapter(service: EmbeddingService): EmbeddingPort
     embed: (inputs: readonly string[]) => service.embed("document", inputs),
   });
 }
+
+/** Adapts the same daemon-lifetime model to semantic query inputs. */
+export function createQueryEmbeddingAdapter(service: EmbeddingService): EmbeddingPort {
+  return Object.freeze({
+    maxBatchSize: 1,
+    embed: (inputs: readonly string[]) => service.embed("query", inputs),
+  });
+}

--- a/packages/backend/src/modules/query/controller.test.ts
+++ b/packages/backend/src/modules/query/controller.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "bun:test";
+import { InvalidQueryRequestError, SemanticIndexNotReadyError } from "@lorelum/engine";
+
+import { createBackendApp } from "../../app";
+import { createBackendService } from "../backend/service";
+import type { QueryService } from "@lorelum/engine";
+import type { SemanticQueryService } from "@lorelum/engine";
+import { PROTOCOL_VERSION } from "../../protocol/constants";
+
+const secret = "query-controller-test-secret";
+const identity = {
+  instanceId: "query-controller-test",
+  buildIdentity: "query-controller-build",
+  protocolVersion: PROTOCOL_VERSION,
+} as const;
+
+function request(body: unknown): Request {
+  return new Request("http://127.0.0.1/internal/v1/query", {
+    method: "POST",
+    headers: {
+      host: "127.0.0.1:26186",
+      authorization: `Bearer ${secret}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function app(keywordQueryService: QueryService, semanticQueryService: SemanticQueryService) {
+  return createBackendApp({
+    backend: createBackendService({ identity, secret, onStop: () => undefined }),
+    keywordQueryService,
+    semanticQueryService,
+  });
+}
+
+test("defaults query mode to semantic and preserves semantic result metadata", async () => {
+  const calls: string[] = [];
+  const instance = app(
+    {
+      async query() {
+        throw new Error("keyword facade must not be selected");
+      },
+    },
+    {
+      async query(root, query) {
+        calls.push(`${root.rootPath}:${query.text}`);
+        return {
+          mode: "semantic",
+          profileId: "a".repeat(64),
+          coverage: "partial",
+          results: [],
+        };
+      },
+    },
+  );
+
+  const response = await instance.handle(
+    request({ storageRoot: "/tmp/query-controller", query: { text: "deployment" } }),
+  );
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({
+    mode: "semantic",
+    profileId: "a".repeat(64),
+    coverage: "partial",
+    results: [],
+  });
+  expect(calls).toEqual(["/tmp/query-controller:deployment"]);
+});
+
+test("explicit keyword mode selects only the keyword facade", async () => {
+  const calls: string[] = [];
+  const instance = app(
+    {
+      async query(_root, query) {
+        calls.push(query.text);
+        return { mode: "keyword", results: [] };
+      },
+    },
+    {
+      async query() {
+        throw new Error("semantic facade must not be selected");
+      },
+    },
+  );
+
+  const response = await instance.handle(
+    request({
+      storageRoot: "/tmp/query-controller",
+      query: { text: "deployment", mode: "keyword" },
+    }),
+  );
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ mode: "keyword", results: [] });
+  expect(calls).toEqual(["deployment"]);
+});
+
+test("maps semantic index readiness failures to a typed remote error", async () => {
+  const instance = app(
+    {
+      async query() {
+        return { mode: "keyword", results: [] };
+      },
+    },
+    {
+      async query() {
+        throw new SemanticIndexNotReadyError();
+      },
+    },
+  );
+  const response = await instance.handle(
+    request({ storageRoot: "/tmp/query-controller", query: { text: "deployment" } }),
+  );
+  expect(response.status).toBe(503);
+  expect(await response.json()).toMatchObject({ error: { code: "semantic.index-not-ready" } });
+});
+
+test("maps invalid Engine input before exposing an implementation failure", async () => {
+  const instance = app(
+    {
+      async query() {
+        throw new InvalidQueryRequestError();
+      },
+    },
+    {
+      async query() {
+        return { mode: "semantic", profileId: "a".repeat(64), coverage: "complete", results: [] };
+      },
+    },
+  );
+  const response = await instance.handle(
+    request({
+      storageRoot: "/tmp/query-controller",
+      query: { text: "deployment", mode: "keyword" },
+    }),
+  );
+  expect(response.status).toBe(400);
+  expect(await response.json()).toMatchObject({ error: { code: "usage.invalid" } });
+});

--- a/packages/backend/src/modules/query/controller.ts
+++ b/packages/backend/src/modules/query/controller.ts
@@ -3,18 +3,31 @@ import {
   InvalidQueryRequestError,
   KeywordIndexError,
   KeywordIndexUnavailableError,
+  SemanticEmbeddingError,
+  SemanticIndexError,
+  SemanticIndexIncompatibleError,
+  SemanticIndexNotReadyError,
+  SemanticIndexQueryError,
   StoreBusyError,
   StoreRecoveryRequiredError,
-  type QueryService,
   type QueryResult,
+  type QueryService,
+  type SemanticQueryResult,
+  type SemanticQueryService,
 } from "@lorelum/engine";
 import { Elysia, status } from "elysia";
 import { reject, requireJson } from "../../plugins/local-auth";
 import { backendErrorBody, errorSchema } from "../../protocol/errors";
+import { EmbeddingError } from "../embedding/errors";
 import { queryRequestSchema, queryResultSchema, type BackendQueryResult } from "./model";
 
-/** QueryService already owns the use case; this controller only adapts transport. */
-export function queryController(service: QueryService, available: () => boolean) {
+export interface QueryControllerServices {
+  readonly keywordQueryService: QueryService;
+  readonly semanticQueryService: SemanticQueryService;
+}
+
+/** The controller selects the Engine use case; it does not implement retrieval rules. */
+export function queryController(services: QueryControllerServices, available: () => boolean) {
   return new Elysia({ normalize: false })
     .onBeforeHandle(({ request }) => {
       if (!available()) return reject(503, "backend.busy");
@@ -28,22 +41,16 @@ export function queryController(service: QueryService, available: () => boolean)
             text: body.query.text,
             ...(body.query.limit === undefined ? {} : { limit: body.query.limit }),
           };
-          return toResponse(await service.query({ rootPath: body.storageRoot }, query));
-        } catch (error) {
-          if (error instanceof InvalidQueryRequestError)
-            return status(400, domainError("usage.invalid", "The command invocation is invalid."));
-          if (error instanceof KeywordIndexUnavailableError)
-            return status(503, domainError("query.unavailable", "Keyword query is unavailable."));
-          if (error instanceof KeywordIndexError)
-            return status(500, domainError("query.failed", "Keyword query failed."));
-          if (error instanceof StoreBusyError)
-            return status(503, domainError("store.busy", "The local Pack store is busy."));
-          if (error instanceof StoreRecoveryRequiredError)
-            return status(
-              503,
-              domainError("store.recovery-required", "The local Pack store requires recovery."),
+          if ((body.query.mode ?? "semantic") === "keyword") {
+            return toResponse(
+              await services.keywordQueryService.query({ rootPath: body.storageRoot }, query),
             );
-          return status(500, backendErrorBody("backend.failed"));
+          }
+          return toResponse(
+            await services.semanticQueryService.query({ rootPath: body.storageRoot }, query),
+          );
+        } catch (error) {
+          return queryFailure(error);
         }
       },
       {
@@ -52,20 +59,57 @@ export function queryController(service: QueryService, available: () => boolean)
       },
     );
 }
+
+function queryFailure(error: unknown) {
+  if (error instanceof InvalidQueryRequestError)
+    return status(400, domainError("usage.invalid", "The command invocation is invalid."));
+  if (error instanceof KeywordIndexUnavailableError)
+    return status(503, domainError("query.unavailable", "Keyword query is unavailable."));
+  if (error instanceof KeywordIndexError)
+    return status(500, domainError("query.failed", "Keyword query failed."));
+  if (error instanceof SemanticIndexNotReadyError)
+    return status(503, domainError("semantic.index-not-ready", "Build the semantic index first."));
+  if (error instanceof SemanticIndexIncompatibleError)
+    return status(
+      503,
+      domainError("semantic.index-incompatible", "The semantic index is incompatible."),
+    );
+  if (error instanceof SemanticEmbeddingError)
+    return status(
+      503,
+      domainError("semantic.embedding-failed", "Semantic query embedding failed."),
+    );
+  if (error instanceof SemanticIndexQueryError || error instanceof SemanticIndexError)
+    return status(
+      500,
+      domainError("semantic.index-failed", "The semantic index could not answer the query."),
+    );
+  if (error instanceof EmbeddingError)
+    return status(503, { error: { code: error.code, message: error.message } });
+  if (error instanceof StoreBusyError)
+    return status(503, domainError("store.busy", "The local Pack store is busy."));
+  if (error instanceof StoreRecoveryRequiredError)
+    return status(
+      503,
+      domainError("store.recovery-required", "The local Pack store requires recovery."),
+    );
+  return status(500, backendErrorBody("backend.failed"));
+}
+
 function domainError(code: string, message: string) {
   return { error: { code, message } };
 }
-function toResponse(result: QueryResult): BackendQueryResult {
-  return {
-    mode: result.mode,
-    results: result.results.map((hit) => ({
-      practiceId: hit.practiceId,
-      title: hit.title,
-      stage: hit.stage,
-      techStack: [...hit.techStack],
-      appliesWhen: hit.appliesWhen,
-      severity: hit.severity,
-      contentDigest: hit.contentDigest,
-    })),
-  };
+
+function toResponse(result: QueryResult | SemanticQueryResult): BackendQueryResult {
+  const results = result.results.map((hit) => ({
+    practiceId: hit.practiceId,
+    title: hit.title,
+    stage: hit.stage,
+    techStack: [...hit.techStack],
+    appliesWhen: hit.appliesWhen,
+    severity: hit.severity,
+    contentDigest: hit.contentDigest,
+  }));
+  if (result.mode === "keyword") return { mode: "keyword", results };
+  return { mode: "semantic", profileId: result.profileId, coverage: result.coverage, results };
 }

--- a/packages/backend/src/modules/query/model.ts
+++ b/packages/backend/src/modules/query/model.ts
@@ -1,14 +1,14 @@
 import { z } from "zod";
 
-/**
- * Wire contract for the Engine keyword-query facade.  Query text and limit
- * remain intentionally broad here: QueryService owns their domain validation.
- */
+/** Wire contract for Backend query dispatch; Engine owns text and limit validation. */
+export const queryModeSchema = z.enum(["semantic", "keyword"]);
+export type QueryMode = z.infer<typeof queryModeSchema>;
 export const queryRequestSchema = z.strictObject({
   storageRoot: z.string().min(1).regex(/^\//),
   query: z.strictObject({
     text: z.string(),
     limit: z.int().optional(),
+    mode: queryModeSchema.optional(),
   }),
 });
 export type BackendQueryRequest = z.infer<typeof queryRequestSchema>;
@@ -23,8 +23,18 @@ export const queryHitSchema = z.strictObject({
   contentDigest: z.string(),
 });
 
-export const queryResultSchema = z.strictObject({
+export const keywordQueryResultSchema = z.strictObject({
   mode: z.literal("keyword"),
   results: z.array(queryHitSchema),
 });
+export const semanticQueryResultSchema = z.strictObject({
+  mode: z.literal("semantic"),
+  profileId: z.string().regex(/^[a-f0-9]{64}$/),
+  coverage: z.enum(["complete", "partial"]),
+  results: z.array(queryHitSchema),
+});
+export const queryResultSchema = z.discriminatedUnion("mode", [
+  keywordQueryResultSchema,
+  semanticQueryResultSchema,
+]);
 export type BackendQueryResult = z.infer<typeof queryResultSchema>;

--- a/packages/backend/src/protocol/errors.ts
+++ b/packages/backend/src/protocol/errors.ts
@@ -41,6 +41,10 @@ export const backendRemoteErrorCodes = [
   "usage.invalid",
   "query.unavailable",
   "query.failed",
+  "semantic.index-not-ready",
+  "semantic.index-incompatible",
+  "semantic.index-failed",
+  "semantic.embedding-failed",
   "store.busy",
   "store.recovery-required",
 ] as const;

--- a/packages/backend/src/runtime/daemon.ts
+++ b/packages/backend/src/runtime/daemon.ts
@@ -6,13 +6,17 @@ import {
   createEmbeddingProfile,
   createLocalStore,
   createQueryService,
+  createSemanticQueryService,
   createSemanticIndexService,
 } from "@lorelum/engine";
 import { BACKEND_HOST, MAX_BODY_BYTES } from "../protocol/constants";
 import { BackendError } from "../protocol/errors";
 import { createBackendApp } from "../app";
 import { createBackendService } from "../modules/backend/service";
-import { createEmbeddingAdapter } from "../modules/index/embedding-adapter";
+import {
+  createEmbeddingAdapter,
+  createQueryEmbeddingAdapter,
+} from "../modules/index/embedding-adapter";
 import { createIndexOperationService } from "../modules/index/operation-service";
 import { isSameProcess } from "./process-identity";
 import { readRecord, removeRecord, writeRecord } from "./runtime-state";
@@ -71,20 +75,27 @@ export async function runBackendDaemon(options: { readonly buildIdentity: string
   });
   const store = createLocalStore();
   const model = embedding.status();
+  const profile = createEmbeddingProfile({
+    encodingId: model.encodingId,
+    dimensions: model.dimensions,
+  });
   const semanticIndex = createSemanticIndexService({
     store,
-    profile: createEmbeddingProfile({
-      encodingId: model.encodingId,
-      dimensions: model.dimensions,
-    }),
+    profile,
     embedding: createEmbeddingAdapter(embedding),
+  });
+  const semanticQuery = createSemanticQueryService({
+    store,
+    profile,
+    embedding: createQueryEmbeddingAdapter(embedding),
   });
   const indexOperations = createIndexOperationService(semanticIndex);
   const app = createBackendApp({
     backend,
     embedding,
     port,
-    queryService: createQueryService({ store }),
+    keywordQueryService: createQueryService({ store }),
+    semanticQueryService: semanticQuery,
     indexOperations,
   });
   const signalHandler = () => {

--- a/packages/cli/integration/support/commands.ts
+++ b/packages/cli/integration/support/commands.ts
@@ -30,8 +30,9 @@ export async function runQuery(
   text: string,
   storageRoot: string,
   topK?: number,
+  mode: "keyword" | "semantic" = "keyword",
 ): Promise<ProcessResult> {
-  const args = [binaryPath, "query", text, "--store-root", storageRoot];
+  const args = [binaryPath, "query", text, "--mode", mode, "--store-root", storageRoot];
   if (topK !== undefined) args.push("--top-k", String(topK));
   return runProcess(args);
 }

--- a/packages/cli/src/query/query-command.test.ts
+++ b/packages/cli/src/query/query-command.test.ts
@@ -9,6 +9,7 @@ import {
   StoreRecoveryRequiredError,
   type QueryResult,
 } from "@lorelum/engine";
+import type { BackendClient } from "@lorelum/backend/client";
 
 import { run } from "../main.js";
 import {
@@ -35,7 +36,19 @@ const queryResult: QueryResult = {
   ],
 };
 
-async function invoke(args: readonly string[], queryService: QueryCommandServices["queryService"]) {
+async function invoke(
+  args: readonly string[],
+  queryService: QueryCommandServices["queryService"],
+  createClient: QueryCommandServices["createClient"] = async () =>
+    ({
+      query: async () => ({
+        mode: "semantic",
+        profileId: "p".repeat(64),
+        coverage: "complete",
+        results: [],
+      }),
+    }) as Pick<BackendClient, "query">,
+) {
   const stdout = {
     value: "",
     write(message: string) {
@@ -50,6 +63,7 @@ async function invoke(args: readonly string[], queryService: QueryCommandService
   };
   const definition = createQueryCommand({
     queryService,
+    createClient,
     storageRoot: { rootPath: "unused-default" },
   });
   const exitCode = await run([...args], {
@@ -65,10 +79,10 @@ async function invoke(args: readonly string[], queryService: QueryCommandService
   return { exitCode, response, definition };
 }
 
-test("passes the exact text, parsed top-k, and selected Store root to QueryService", async () => {
+test("passes the exact text, parsed top-k, and selected Store root to keyword QueryService", async () => {
   let request: unknown;
   let rootPath = "";
-  const result = await invoke(["query", "React auth", "--top-k", "3"], {
+  const result = await invoke(["query", "React auth", "--mode", "keyword", "--top-k", "3"], {
     async query(root, received) {
       rootPath = root.rootPath;
       request = received;
@@ -85,22 +99,78 @@ test("passes the exact text, parsed top-k, and selected Store root to QueryServi
 test("resolves an explicit Store root and omits the optional limit by default", async () => {
   let request: unknown;
   let rootPath = "";
-  const result = await invoke(["--store-root", "query-store", "query", "请求"], {
-    async query(root, received) {
-      rootPath = root.rootPath;
-      request = received;
-      return { mode: "keyword", results: [] };
+  const result = await invoke(
+    ["--store-root", "query-store", "query", "请求", "--mode", "keyword"],
+    {
+      async query(root, received) {
+        rootPath = root.rootPath;
+        request = received;
+        return { mode: "keyword", results: [] };
+      },
     },
-  });
+  );
   expect(rootPath).toMatch(/query-store$/);
   expect(request).toEqual({ text: "请求" });
   expect(result.exitCode).toBe(0);
 });
 
+test("uses semantic Backend query by default and preserves semantic metadata", async () => {
+  let calls = 0;
+  let received: unknown;
+  const semantic = {
+    mode: "semantic" as const,
+    profileId: "p".repeat(64),
+    coverage: "partial" as const,
+    results: [],
+  };
+  const result = await invoke(
+    ["query", "How do I verify a release?", "--top-k", "7"],
+    {
+      async query() {
+        throw new Error("keyword path should not run");
+      },
+    },
+    async () =>
+      ({
+        query: async (root, request) => {
+          calls++;
+          received = { root: root.rootPath, request };
+          return semantic;
+        },
+      }) as Pick<BackendClient, "query">,
+  );
+  expect(calls).toBe(1);
+  expect(received).toEqual({
+    root: "unused-default",
+    request: { text: "How do I verify a release?", limit: 7, mode: "semantic" },
+  });
+  expect(result.response.data).toEqual(semantic);
+  expect(validateJsonSchema(result.response.data, result.definition.resultSchema)).toEqual([]);
+});
+
+test("rejects an invalid mode before creating the Backend client", async () => {
+  let created = false;
+  const result = await invoke(
+    ["query", "text", "--mode", "hybrid"],
+    {
+      async query() {
+        return queryResult;
+      },
+    },
+    async () => {
+      created = true;
+      throw new Error("must not connect");
+    },
+  );
+  expect(created).toBe(false);
+  expect(result.exitCode).toBe(2);
+  expect(result.response.error.code).toBe("usage.invalid");
+});
+
 test("delegates query-domain validation to Engine before Store I/O", async () => {
   let reads = 0;
   const result = await invoke(
-    ["query", "   "],
+    ["query", "   ", "--mode", "keyword"],
     createQueryService({
       store: {
         async readSnapshotIdentity() {
@@ -141,7 +211,7 @@ test.each(["1.5", "+2", "2x", ""])(
   'rejects non-decimal --top-k "%s" before QueryService',
   async (topK) => {
     let calls = 0;
-    const result = await invoke(["query", "text", "--top-k", topK], {
+    const result = await invoke(["query", "text", "--mode", "keyword", "--top-k", topK], {
       async query() {
         calls++;
         return queryResult;
@@ -165,7 +235,7 @@ test("maps Engine query validation and retrieval failures to public CLI codes", 
     [new StoreRecoveryRequiredError("internal-path"), "store.recovery-required"],
   ] as const) {
     // eslint-disable-next-line no-await-in-loop -- each case must exercise its own mapped error
-    const result = await invoke(["query", "text"], {
+    const result = await invoke(["query", "text", "--mode", "keyword"], {
       async query() {
         throw error;
       },
@@ -177,7 +247,7 @@ test("maps Engine query validation and retrieval failures to public CLI codes", 
 });
 
 test("maps undeclared query failures without exposing details", async () => {
-  const result = await invoke(["query", "text"], {
+  const result = await invoke(["query", "text", "--mode", "keyword"], {
     async query() {
       throw new CliError("undeclared.error", "internal-path");
     },
@@ -194,6 +264,15 @@ test("publishes query arguments, schema, error allowlist, and exit codes through
         return { mode: "keyword", results: [] };
       },
     },
+    createClient: async () =>
+      ({
+        query: async () => ({
+          mode: "semantic",
+          profileId: "p".repeat(64),
+          coverage: "complete",
+          results: [],
+        }),
+      }) as Pick<BackendClient, "query">,
     storageRoot: { rootPath: "unused-default" },
   });
   const description = describeCommand("query", [definition]);
@@ -210,4 +289,17 @@ test("publishes query arguments, schema, error allowlist, and exit codes through
       (option) => option.name === "--top-k <n>",
     ),
   ).toBe(true);
+  expect(
+    (
+      description as {
+        options: readonly { name: string; defaultValue?: string; values?: string[] }[];
+      }
+    ).options,
+  ).toContainEqual(
+    expect.objectContaining({
+      name: "--mode <mode>",
+      defaultValue: "semantic",
+      values: ["semantic", "keyword"],
+    }),
+  );
 });

--- a/packages/cli/src/query/query-command.ts
+++ b/packages/cli/src/query/query-command.ts
@@ -1,12 +1,23 @@
 import {
+  BackendError,
+  BackendRemoteError,
+  backendErrorCodes,
+  backendRemoteErrorCodes,
+  embeddingErrorCodes,
+  EmbeddingError,
+} from "@lorelum/backend/protocol";
+import type { BackendClient } from "@lorelum/backend/client";
+import {
   InvalidQueryRequestError,
   KeywordIndexError,
   KeywordIndexUnavailableError,
+  parseQueryRequest,
   StoreBusyError,
   StoreRecoveryRequiredError,
   type QueryHit,
   type QueryResult,
   type QueryService,
+  type SemanticQueryResult,
   type StorageRoot,
 } from "@lorelum/engine";
 
@@ -23,7 +34,27 @@ import { queryResultSchema } from "./result-schema.js";
 
 export interface QueryCommandServices {
   readonly queryService: QueryService;
+  readonly createClient: () => Promise<Pick<BackendClient, "query">>;
   readonly storageRoot: StorageRoot;
+}
+
+const queryModes = ["semantic", "keyword"] as const;
+type QueryMode = (typeof queryModes)[number];
+const queryErrorCodes = Object.freeze([
+  ...new Set([
+    ...frameworkErrorCodes,
+    ...backendErrorCodes,
+    ...embeddingErrorCodes,
+    ...backendRemoteErrorCodes,
+  ]),
+]);
+
+function parseMode(value: unknown): QueryMode {
+  if (value === undefined) return "semantic";
+  if (typeof value !== "string" || !queryModes.includes(value as QueryMode)) {
+    throw invalidInvocationError();
+  }
+  return value as QueryMode;
 }
 
 function parseTopK(value: unknown): number | undefined {
@@ -32,9 +63,12 @@ function parseTopK(value: unknown): number | undefined {
   return Number(value);
 }
 
-function toQueryResult(result: QueryResult): JsonValue {
+function toQueryResult(result: QueryResult | SemanticQueryResult): JsonValue {
   return {
     mode: result.mode,
+    ...(result.mode === "semantic"
+      ? { profileId: result.profileId, coverage: result.coverage }
+      : {}),
     results: result.results.map((hit: QueryHit) => ({
       practiceId: hit.practiceId,
       title: hit.title,
@@ -50,6 +84,12 @@ function toQueryResult(result: QueryResult): JsonValue {
 function throwVisibleQueryError(error: unknown): never {
   if (error instanceof CliError) throw error;
   if (error instanceof InvalidQueryRequestError) throw invalidInvocationError();
+  if (error instanceof BackendError || error instanceof EmbeddingError) {
+    throw new CliError(error.code, error.message);
+  }
+  if (error instanceof BackendRemoteError) {
+    throw new CliError(error.code, queryRemoteErrorMessage(error.code));
+  }
   if (error instanceof KeywordIndexUnavailableError) {
     throw new CliError(cliErrorCodes.queryUnavailable, "Keyword query is unavailable.");
   }
@@ -68,12 +108,43 @@ function throwVisibleQueryError(error: unknown): never {
   throw error;
 }
 
+function queryRemoteErrorMessage(code: (typeof backendRemoteErrorCodes)[number]): string {
+  switch (code) {
+    case "usage.invalid":
+      return "The command invocation is invalid.";
+    case "query.unavailable":
+      return "Keyword query is unavailable.";
+    case "query.failed":
+      return "Keyword query failed.";
+    case "semantic.index-not-ready":
+      return "Build the semantic index before running a semantic query.";
+    case "semantic.index-incompatible":
+      return "The semantic index is incompatible; build or rebuild it.";
+    case "semantic.index-failed":
+      return "The semantic index could not answer the query.";
+    case "semantic.embedding-failed":
+      return "Semantic query embedding failed.";
+    case "store.busy":
+      return "The local Pack store is busy.";
+    case "store.recovery-required":
+      return "The local Pack store requires recovery.";
+  }
+}
+
 export function createQueryCommand(services: QueryCommandServices): CommandDefinition {
   return {
     name: "query",
-    summary: "Find installed Practices by keyword relevance.",
+    summary: "Find installed Practices by semantic or keyword relevance.",
     positionals: [{ name: "text", required: true }],
     options: [
+      {
+        longFlag: "--mode",
+        description: "Choose semantic relevance (default) or the offline keyword index.",
+        value: { name: "mode", required: true },
+        optionRequired: false,
+        defaultValue: "semantic",
+        values: queryModes,
+      },
       {
         longFlag: "--top-k",
         description: "Return at most this many matching Practices.",
@@ -82,25 +153,25 @@ export function createQueryCommand(services: QueryCommandServices): CommandDefin
       },
     ],
     resultSchema: queryResultSchema,
-    errorCodes: [
-      ...frameworkErrorCodes,
-      cliErrorCodes.queryUnavailable,
-      cliErrorCodes.queryFailed,
-      cliErrorCodes.storeBusy,
-      cliErrorCodes.storeRecoveryRequired,
-    ],
+    errorCodes: queryErrorCodes,
     exitCodes: [0, 2],
     async handler(invocation) {
       try {
         const text = invocation.positionals[0];
         if (text === undefined) throw invalidInvocationError();
+        const mode = parseMode(invocation.options.mode);
         const limit = parseTopK(invocation.options.topK);
+        // Validate domain input before resolving or connecting to the Backend.
+        parseQueryRequest(limit === undefined ? { text } : { text, limit });
         const root = resolveInvocationStorageRoot(
           invocation.options.storeRoot,
           services.storageRoot,
         );
         const request = limit === undefined ? { text } : { text, limit };
-        const result = await services.queryService.query(root, request);
+        const result =
+          mode === "keyword"
+            ? await services.queryService.query(root, request)
+            : await (await services.createClient()).query(root, { ...request, mode });
         return { data: toQueryResult(result) };
       } catch (error) {
         throwVisibleQueryError(error);

--- a/packages/cli/src/query/result-schema.ts
+++ b/packages/cli/src/query/result-schema.ts
@@ -5,36 +5,52 @@ import type { JsonSchema } from "../output/protocol.js";
 const stringSchema: JsonSchema = { type: "string" };
 const severitySchema: JsonSchema = { enum: SeverityEnum.options };
 
-export const queryResultSchema: JsonSchema = {
+const queryHitSchema: JsonSchema = {
   type: "object",
   additionalProperties: false,
-  required: ["mode", "results"],
+  required: [
+    "practiceId",
+    "title",
+    "stage",
+    "techStack",
+    "appliesWhen",
+    "severity",
+    "contentDigest",
+  ],
   properties: {
-    mode: { const: "keyword" },
-    results: {
-      type: "array",
-      items: {
-        type: "object",
-        additionalProperties: false,
-        required: [
-          "practiceId",
-          "title",
-          "stage",
-          "techStack",
-          "appliesWhen",
-          "severity",
-          "contentDigest",
-        ],
-        properties: {
-          practiceId: stringSchema,
-          title: stringSchema,
-          stage: stringSchema,
-          techStack: { type: "array", items: stringSchema },
-          appliesWhen: stringSchema,
-          severity: severitySchema,
-          contentDigest: stringSchema,
-        },
+    practiceId: stringSchema,
+    title: stringSchema,
+    stage: stringSchema,
+    techStack: { type: "array", items: stringSchema },
+    appliesWhen: stringSchema,
+    severity: severitySchema,
+    contentDigest: stringSchema,
+  },
+};
+
+const resultsSchema: JsonSchema = { type: "array", items: queryHitSchema };
+
+export const queryResultSchema: JsonSchema = {
+  oneOf: [
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["mode", "results"],
+      properties: {
+        mode: { const: "keyword" },
+        results: resultsSchema,
       },
     },
-  },
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["mode", "profileId", "coverage", "results"],
+      properties: {
+        mode: { const: "semantic" },
+        profileId: stringSchema,
+        coverage: { enum: ["complete", "partial"] },
+        results: resultsSchema,
+      },
+    },
+  ],
 };

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -254,7 +254,11 @@ export const commandRegistry = snapshotCommandDefinitions([
   discoveryCommandDefinition,
   createInstallCommand({ store: sharedStore, storageRoot: sharedStorageRoot }),
   createGetCommand({ store: sharedStore, storageRoot: sharedStorageRoot }),
-  createQueryCommand({ queryService: sharedQueryService, storageRoot: sharedStorageRoot }),
+  createQueryCommand({
+    queryService: sharedQueryService,
+    createClient: createProcessBackendClient,
+    storageRoot: sharedStorageRoot,
+  }),
   createListCommand({ list: sharedListService, storageRoot: sharedStorageRoot }),
   ...createBackendCommands({ createSupervisor: createProcessBackendSupervisor }),
   ...createModelCommands({ createClient: createProcessBackendClient }),

--- a/packages/engine/src/query/index.ts
+++ b/packages/engine/src/query/index.ts
@@ -4,5 +4,6 @@ export {
   KeywordIndexError,
   KeywordIndexUnavailableError,
 } from "./errors";
+export { parseQueryRequest } from "./request";
 export type { QueryRequest, QueryHit, QueryResult, QueryService, QueryDependencies } from "./types";
 export * from "./semantic";

--- a/packages/engine/src/query/query-service.ts
+++ b/packages/engine/src/query/query-service.ts
@@ -15,7 +15,8 @@ import {
 } from "./keyword/persistent-keyword-index";
 import { projectKeywordPractice } from "./keyword/projection";
 import { parseQueryRequest } from "./request";
-import type { QueryDependencies, QueryHit, QueryResult, QueryService } from "./types";
+import { assembleQueryHits } from "./result";
+import type { QueryDependencies, QueryResult, QueryService } from "./types";
 
 const MAX_QUERY_RETRIES = 3;
 
@@ -148,25 +149,10 @@ function assembleQueryResult(
   practices: readonly EffectivePractice[],
   candidates: readonly KeywordCandidate[],
 ): QueryResult {
-  const byId = new Map(practices.map((practice) => [practice.practiceId, practice]));
-  const results = candidates.map((candidate): QueryHit => {
-    const effective = byId.get(candidate.practiceId);
-    if (effective === undefined || effective.contentDigest !== candidate.contentDigest) {
-      throw new KeywordIndexError("Keyword candidate differs from its query snapshot");
-    }
-    const { practice } = effective;
-    if (practice.severity === undefined) {
-      throw new KeywordIndexError("Query snapshot is not canonical");
-    }
-    return Object.freeze({
-      practiceId: effective.practiceId,
-      title: practice.title,
-      stage: practice.stage,
-      techStack: Object.freeze([...practice.tech_stack]),
-      appliesWhen: practice.applies_when,
-      severity: practice.severity,
-      contentDigest: effective.contentDigest,
-    });
-  });
-  return Object.freeze({ mode: "keyword", results: Object.freeze(results) });
+  const results = assembleQueryHits(
+    practices,
+    candidates,
+    (message) => new KeywordIndexError(message),
+  );
+  return Object.freeze({ mode: "keyword", results });
 }

--- a/packages/engine/src/query/result.ts
+++ b/packages/engine/src/query/result.ts
@@ -1,0 +1,42 @@
+import type { EffectivePractice } from "../local-store";
+import type { QueryHit } from "./types";
+
+/** Candidate identity shared by keyword and semantic result assembly. */
+export interface QueryCandidateIdentity {
+  readonly practiceId: string;
+  readonly contentDigest: string;
+}
+
+/**
+ * Read canonical Practice rows into the public query summary shape.
+ *
+ * The caller supplies the domain-specific error constructor so keyword and
+ * semantic queries preserve their existing typed failure boundaries.
+ */
+export function assembleQueryHits(
+  practices: readonly EffectivePractice[],
+  candidates: readonly QueryCandidateIdentity[],
+  createError: (message: string) => Error,
+): readonly QueryHit[] {
+  const byId = new Map(practices.map((practice) => [practice.practiceId, practice]));
+  const results = candidates.map((candidate): QueryHit => {
+    const effective = byId.get(candidate.practiceId);
+    if (effective === undefined || effective.contentDigest !== candidate.contentDigest) {
+      throw createError("Query candidate differs from its query snapshot");
+    }
+    const { practice } = effective;
+    if (practice.severity === undefined) {
+      throw createError("Query snapshot is not canonical");
+    }
+    return Object.freeze({
+      practiceId: effective.practiceId,
+      title: practice.title,
+      stage: practice.stage,
+      techStack: Object.freeze([...practice.tech_stack]),
+      appliesWhen: practice.applies_when,
+      severity: practice.severity,
+      contentDigest: effective.contentDigest,
+    });
+  });
+  return Object.freeze(results);
+}

--- a/packages/engine/src/query/semantic/errors.ts
+++ b/packages/engine/src/query/semantic/errors.ts
@@ -24,3 +24,27 @@ export class SemanticEmbeddingError extends SemanticIndexError {
     this.name = "SemanticEmbeddingError";
   }
 }
+
+/** The active semantic index is absent or cannot safely answer this query yet. */
+export class SemanticIndexNotReadyError extends SemanticIndexError {
+  constructor(message = "Semantic index is not ready", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SemanticIndexNotReadyError";
+  }
+}
+
+/** The active semantic index belongs to another Store or Profile contract. */
+export class SemanticIndexIncompatibleError extends SemanticIndexError {
+  constructor(message = "Semantic index is incompatible", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SemanticIndexIncompatibleError";
+  }
+}
+
+/** The active semantic index could not be read or its candidates failed validation. */
+export class SemanticIndexQueryError extends SemanticIndexError {
+  constructor(message = "Semantic index query failed", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SemanticIndexQueryError";
+  }
+}

--- a/packages/engine/src/query/semantic/index.ts
+++ b/packages/engine/src/query/semantic/index.ts
@@ -1,13 +1,22 @@
 export { createEmbeddingProfile } from "./profile";
 export {
   SemanticEmbeddingError,
+  SemanticIndexIncompatibleError,
   SemanticIndexError,
+  SemanticIndexNotReadyError,
+  SemanticIndexQueryError,
   SemanticIndexSnapshotChangedError,
 } from "./errors";
 export { createSemanticIndexService } from "./index/service";
+export { createSemanticQueryService } from "./query-service";
 export { SEMANTIC_INDEX_VERSION } from "./index/metadata";
 export type { EmbeddingBatch, EmbeddingPort, EncodingContract } from "./encoding";
 export type { EmbeddingProfile } from "./profile";
+export type {
+  SemanticQueryDependencies,
+  SemanticQueryResult,
+  SemanticQueryService,
+} from "./query-service";
 export type {
   SemanticIndexBuildResult,
   SemanticIndexDependencies,

--- a/packages/engine/src/query/semantic/index/paths.ts
+++ b/packages/engine/src/query/semantic/index/paths.ts
@@ -1,0 +1,22 @@
+import { join } from "node:path";
+
+import { SEMANTIC_INDEX_VERSION } from "./metadata";
+
+const INDEX_FILE_NAME = "active.sqlite";
+const WRITER_DIRECTORY = "writer";
+
+export interface SemanticIndexPaths {
+  readonly directory: string;
+  readonly active: string;
+  readonly writer: string;
+}
+
+/** Derive all Store-local paths for one fixed semantic Profile. */
+export function semanticIndexPaths(rootPath: string, profileId: string): SemanticIndexPaths {
+  const directory = join(rootPath, "indexes", "semantic", `v${SEMANTIC_INDEX_VERSION}`, profileId);
+  return Object.freeze({
+    directory,
+    active: join(directory, INDEX_FILE_NAME),
+    writer: join(directory, WRITER_DIRECTORY),
+  });
+}

--- a/packages/engine/src/query/semantic/index/reader.ts
+++ b/packages/engine/src/query/semantic/index/reader.ts
@@ -1,0 +1,167 @@
+import { access } from "node:fs/promises";
+import { Database } from "bun:sqlite";
+
+import { SemanticIndexError } from "../errors";
+import {
+  SemanticIndexIncompatibleError,
+  SemanticIndexNotReadyError,
+  SemanticIndexQueryError,
+} from "../errors";
+import type { EmbeddingProfile } from "../profile";
+import { isCompatibleMetadata, type SemanticIndexMetadata } from "./metadata";
+import {
+  readSemanticIndexMetadata,
+  readSemanticIndexVector,
+  verifySemanticIndexIntegrity,
+} from "./database";
+import { semanticIndexPaths } from "./paths";
+
+export interface SemanticCandidate {
+  readonly practiceId: string;
+  readonly contentDigest: string;
+  /** Internal score used only for deterministic ordering. */
+  readonly similarity: number;
+}
+
+export interface SemanticIndexReader {
+  readonly metadata: SemanticIndexMetadata;
+  /** Whether at least one vector remains eligible after the supplied exclusions. */
+  hasEligibleVectors(excludedPracticeIds: ReadonlySet<string>): boolean;
+  search(
+    queryVector: Float32Array,
+    excludedPracticeIds: ReadonlySet<string>,
+    limit: number,
+  ): readonly SemanticCandidate[];
+  close(): void;
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function cosine(left: Float32Array, right: Float32Array): number {
+  if (left.length !== right.length) {
+    throw new SemanticIndexQueryError("Semantic query vector dimensions are invalid");
+  }
+  let score = 0;
+  for (let index = 0; index < left.length; index += 1) score += left[index]! * right[index]!;
+  if (!Number.isFinite(score)) {
+    throw new SemanticIndexQueryError("Semantic similarity is not finite");
+  }
+  return score;
+}
+
+function readPracticeIds(database: Database): readonly string[] {
+  try {
+    const rows = database.query("SELECT practice_id FROM semantic_vectors").all() as unknown[];
+    return Object.freeze(
+      rows.map((row) => {
+        if (
+          typeof row !== "object" ||
+          row === null ||
+          !("practice_id" in row) ||
+          typeof row.practice_id !== "string"
+        ) {
+          throw new SemanticIndexQueryError("Semantic index Practice ID is invalid");
+        }
+        return row.practice_id;
+      }),
+    );
+  } catch (error) {
+    if (error instanceof SemanticIndexQueryError) throw error;
+    throw new SemanticIndexQueryError("Cannot read semantic index Practice IDs", { cause: error });
+  }
+}
+
+function readCandidateRows(
+  database: Database,
+  metadata: SemanticIndexMetadata,
+  queryVector: Float32Array,
+  excludedPracticeIds: ReadonlySet<string>,
+): SemanticCandidate[] {
+  const candidates: SemanticCandidate[] = [];
+  for (const practiceId of readPracticeIds(database)) {
+    if (excludedPracticeIds.has(practiceId)) continue;
+    const row = readSemanticIndexVector(database, practiceId, metadata.dimensions);
+    if (row === undefined) {
+      throw new SemanticIndexQueryError("Semantic index vector row disappeared during query");
+    }
+    candidates.push({
+      practiceId,
+      contentDigest: row.contentDigest,
+      similarity: cosine(queryVector, row.vector),
+    });
+  }
+  candidates.sort((left, right) => {
+    const scoreOrder = right.similarity - left.similarity;
+    return scoreOrder === 0 ? compareCodeUnits(left.practiceId, right.practiceId) : scoreOrder;
+  });
+  return candidates;
+}
+
+/** Open one read-only SQLite connection for metadata and all candidate reads. */
+export async function openSemanticIndexReader(
+  rootPath: string,
+  profile: EmbeddingProfile,
+): Promise<SemanticIndexReader> {
+  const path = semanticIndexPaths(rootPath, profile.profileId).active;
+  try {
+    await access(path);
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      throw new SemanticIndexNotReadyError("Semantic index has not been built");
+    }
+    throw new SemanticIndexQueryError("Cannot access semantic SQLite index", { cause: error });
+  }
+
+  let database: Database | undefined;
+  try {
+    database = new Database(path, { readonly: true });
+    verifySemanticIndexIntegrity(database);
+    const metadata = readSemanticIndexMetadata(database);
+    if (!isCompatibleMetadata(metadata, profile, metadata.rootBinding)) {
+      throw new SemanticIndexIncompatibleError("Semantic index does not match the active Profile");
+    }
+    const connection = database;
+    return Object.freeze({
+      metadata,
+      hasEligibleVectors(excludedPracticeIds: ReadonlySet<string>) {
+        return readPracticeIds(connection).some(
+          (practiceId) => !excludedPracticeIds.has(practiceId),
+        );
+      },
+      search(queryVector, excludedPracticeIds, limit) {
+        if (queryVector.length !== metadata.dimensions) {
+          throw new SemanticIndexQueryError("Semantic query vector dimensions are invalid");
+        }
+        const candidates = readCandidateRows(
+          connection,
+          metadata,
+          queryVector,
+          excludedPracticeIds,
+        );
+        return Object.freeze(candidates.slice(0, limit));
+      },
+      close() {
+        connection.close();
+      },
+    } satisfies SemanticIndexReader);
+  } catch (error) {
+    try {
+      database?.close();
+    } catch {
+      // Preserve the original index failure.
+    }
+    if (
+      error instanceof SemanticIndexNotReadyError ||
+      error instanceof SemanticIndexIncompatibleError ||
+      error instanceof SemanticIndexQueryError
+    ) {
+      throw error;
+    }
+    if (error instanceof SemanticIndexError) {
+      throw new SemanticIndexQueryError(error.message, { cause: error });
+    }
+    throw new SemanticIndexQueryError("Cannot open semantic SQLite index", { cause: error });
+  }
+}

--- a/packages/engine/src/query/semantic/index/service.ts
+++ b/packages/engine/src/query/semantic/index/service.ts
@@ -37,9 +37,7 @@ import {
   verifySemanticIndexIntegrity,
 } from "./database";
 import { planIncrementalSemanticIndex } from "./incremental";
-
-const INDEX_FILE_NAME = "active.sqlite";
-const WRITER_DIRECTORY = "writer";
+import { semanticIndexPaths, type SemanticIndexPaths } from "./paths";
 
 export interface SemanticIndexBuildResult {
   readonly status: SemanticIndexStatus;
@@ -62,21 +60,6 @@ export interface SemanticIndexDependencies {
   >;
   readonly profile: EmbeddingProfile;
   readonly embedding: EmbeddingPort;
-}
-
-interface IndexPaths {
-  readonly directory: string;
-  readonly active: string;
-  readonly writer: string;
-}
-
-function paths(rootPath: string, profileId: string): IndexPaths {
-  const directory = join(rootPath, "indexes", "semantic", "v1", profileId);
-  return Object.freeze({
-    directory,
-    active: join(directory, INDEX_FILE_NAME),
-    writer: join(directory, WRITER_DIRECTORY),
-  });
 }
 
 async function activeMetadata(path: string): Promise<SemanticIndexMetadata | undefined> {
@@ -132,7 +115,9 @@ export function createSemanticIndexService(
   const status = async (root: StorageRoot): Promise<SemanticIndexStatus> => {
     const identity = await store.readSnapshotIdentity(root);
     try {
-      const metadata = await activeMetadata(paths(root.rootPath, profile.profileId).active);
+      const metadata = await activeMetadata(
+        semanticIndexPaths(root.rootPath, profile.profileId).active,
+      );
       if (metadata === undefined) return statusFor("missing", profile);
       return statusFor(stateForMetadata(metadata, identity, profile), profile, metadata);
     } catch (error) {
@@ -143,7 +128,7 @@ export function createSemanticIndexService(
 
   const publish = async (
     root: StorageRoot,
-    indexPaths: IndexPaths,
+    indexPaths: SemanticIndexPaths,
     staging: string,
     identity: StoreSnapshotIdentity,
     metadata: SemanticIndexMetadata,
@@ -156,7 +141,7 @@ export function createSemanticIndexService(
 
   const fullBuild = async (
     root: StorageRoot,
-    indexPaths: IndexPaths,
+    indexPaths: SemanticIndexPaths,
   ): Promise<SemanticIndexBuildResult> => {
     const snapshot = await store.readEffectivePracticeSnapshot(root);
     const documents = Object.freeze(snapshot.practices.map(projectSemanticPractice));
@@ -197,7 +182,7 @@ export function createSemanticIndexService(
 
   const incrementalBuild = async (
     root: StorageRoot,
-    indexPaths: IndexPaths,
+    indexPaths: SemanticIndexPaths,
     existing: SemanticIndexMetadata,
   ): Promise<SemanticIndexBuildResult | undefined> => {
     const changes = await store.readEffectivePracticeChanges(root, existing.effectiveRevision);
@@ -276,7 +261,7 @@ export function createSemanticIndexService(
   };
 
   const build = async (root: StorageRoot, force: boolean): Promise<SemanticIndexBuildResult> => {
-    const indexPaths = paths(root.rootPath, profile.profileId);
+    const indexPaths = semanticIndexPaths(root.rootPath, profile.profileId);
     await mkdir(indexPaths.writer, { recursive: true });
     const lock = await acquireMutationLock(indexPaths.writer);
     try {

--- a/packages/engine/src/query/semantic/query-service.test.ts
+++ b/packages/engine/src/query/semantic/query-service.test.ts
@@ -1,0 +1,312 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  StoreBusyError,
+  StoreSnapshotChangedError,
+  type EffectivePractice,
+  type StorageRoot,
+  type StoreSnapshotIdentity,
+} from "../../local-store";
+import { canonicalizePractice, type RevisionDelta } from "../../local-store/model";
+import type { EmbeddingPort } from "./encoding";
+import { SemanticIndexNotReadyError, SemanticIndexQueryError } from "./errors";
+import { createSemanticIndexService } from "./index/service";
+import { createEmbeddingProfile } from "./profile";
+import { createSemanticQueryService } from "./query-service";
+
+const encodingId = "a".repeat(64);
+
+function identity(rootPath: string, revision = 1): StoreSnapshotIdentity {
+  return Object.freeze({
+    rootBinding: `test:${rootPath}`,
+    generation: revision,
+    effectiveRevision: revision,
+    manifestDigest: `${revision}`.padStart(64, "0"),
+  });
+}
+
+function practice(id: string, body = id): EffectivePractice {
+  const canonical = canonicalizePractice({
+    id,
+    title: id,
+    stage: "implementation",
+    tech_stack: ["typescript"],
+    applies_when: body,
+    body,
+    severity: "warn",
+  });
+  return { practiceId: id, ...canonical, sources: [] };
+}
+
+function vectorFor(text: string): readonly number[] {
+  if (text.includes("platform.beta")) return [0, 1];
+  if (text.includes("beta query")) return [0, 1];
+  return [1, 0];
+}
+
+function port(): EmbeddingPort & { readonly calls: readonly string[][] } {
+  const calls: string[][] = [];
+  return {
+    maxBatchSize: 8,
+    calls,
+    async embed(inputs) {
+      calls.push([...inputs]);
+      return { encodingId, vectors: inputs.map(vectorFor) };
+    },
+  };
+}
+
+async function withRoot(run: (rootPath: string) => Promise<void>): Promise<void> {
+  const rootPath = await mkdtemp(join(tmpdir(), "lorelum-semantic-query-"));
+  try {
+    await run(rootPath);
+  } finally {
+    await rm(rootPath, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  }
+}
+
+type FakeStore = {
+  current: StoreSnapshotIdentity;
+  practices: readonly EffectivePractice[];
+  changes:
+    | {
+        readonly identity: StoreSnapshotIdentity;
+        readonly deltas: readonly { readonly revision: number; readonly delta: RevisionDelta }[];
+        readonly currentPractices: readonly EffectivePractice[];
+      }
+    | undefined;
+  readSnapshotIdentity(root: StorageRoot): Promise<StoreSnapshotIdentity>;
+  readEffectivePracticeChanges(
+    root: StorageRoot,
+    afterEffectiveRevision: number,
+  ): Promise<FakeStore["changes"]>;
+  readEffectivePracticesAtSnapshot(
+    root: StorageRoot,
+    expected: StoreSnapshotIdentity,
+    ids: readonly string[],
+  ): Promise<readonly EffectivePractice[]>;
+};
+
+function createStore(rootPath: string, initial: readonly EffectivePractice[]): FakeStore {
+  let store: FakeStore;
+  store = {
+    current: identity(rootPath),
+    practices: initial,
+    changes: undefined,
+    async readSnapshotIdentity(_root: StorageRoot): Promise<StoreSnapshotIdentity> {
+      return store.current;
+    },
+    async readEffectivePracticeChanges(
+      _root: StorageRoot,
+      _afterEffectiveRevision: number,
+    ): Promise<FakeStore["changes"]> {
+      return store.changes;
+    },
+    async readEffectivePracticesAtSnapshot(
+      _root: StorageRoot,
+      expected: StoreSnapshotIdentity,
+      ids: readonly string[],
+    ): Promise<readonly EffectivePractice[]> {
+      if (!sameIdentity(store.current, expected)) throw new StoreSnapshotChangedError();
+      const wanted = new Set(ids);
+      return store.practices.filter((item: EffectivePractice) => wanted.has(item.practiceId));
+    },
+  };
+  return store;
+}
+
+function sameIdentity(left: StoreSnapshotIdentity, right: StoreSnapshotIdentity): boolean {
+  return (
+    left.rootBinding === right.rootBinding &&
+    left.generation === right.generation &&
+    left.effectiveRevision === right.effectiveRevision &&
+    left.manifestDigest === right.manifestDigest
+  );
+}
+
+async function build(
+  rootPath: string,
+  store: FakeStore,
+  profile: ReturnType<typeof createEmbeddingProfile>,
+  embedding: EmbeddingPort,
+): Promise<void> {
+  const index = createSemanticIndexService({
+    store: {
+      readSnapshotIdentity: store.readSnapshotIdentity,
+      readEffectivePracticeSnapshot: async () => ({
+        identity: store.current,
+        practices: store.practices,
+      }),
+      async readEffectivePracticeChanges(root, afterEffectiveRevision) {
+        const changes = await store.readEffectivePracticeChanges(root, afterEffectiveRevision);
+        return changes === undefined
+          ? undefined
+          : { ...changes, currentPractices: store.practices };
+      },
+      async withSnapshotFence(_root, expected, publish) {
+        if (!sameIdentity(store.current, expected)) throw new StoreSnapshotChangedError();
+        return publish();
+      },
+    },
+    profile,
+    embedding,
+  });
+  await index.build({ rootPath });
+}
+
+function semantic(
+  store: FakeStore,
+  profile: ReturnType<typeof createEmbeddingProfile>,
+  embedding: EmbeddingPort,
+) {
+  return createSemanticQueryService({ store, profile, embedding });
+}
+
+test("returns complete semantic results with deterministic score and ID ordering", async () => {
+  await withRoot(async (rootPath) => {
+    const store = createStore(rootPath, [
+      practice("platform.beta"),
+      practice("platform.alpha"),
+      practice("platform.alpha2"),
+    ]);
+    const embedding = port();
+    const profile = createEmbeddingProfile({ encodingId, dimensions: 2 });
+    await build(rootPath, store, profile, embedding);
+
+    const result = await semantic(store, profile, embedding).query(
+      { rootPath },
+      { text: "alpha", limit: 3 },
+    );
+    expect(result.mode).toBe("semantic");
+    expect(result.coverage).toBe("complete");
+    expect(result.results.map((hit) => hit.practiceId)).toEqual([
+      "platform.alpha",
+      "platform.alpha2",
+      "platform.beta",
+    ]);
+    expect(embedding.calls).toHaveLength(2);
+  });
+});
+
+test("empty index does not call the embedding port", async () => {
+  await withRoot(async (rootPath) => {
+    const store = createStore(rootPath, []);
+    const embedding = port();
+    const profile = createEmbeddingProfile({ encodingId, dimensions: 2 });
+    await build(rootPath, store, profile, embedding);
+    const result = await semantic(store, profile, embedding).query(
+      { rootPath },
+      { text: "anything" },
+    );
+    expect(result).toMatchObject({ mode: "semantic", coverage: "complete", results: [] });
+    expect(embedding.calls).toEqual([]);
+  });
+});
+
+test("partial coverage excludes all Practice IDs touched by retained deltas", async () => {
+  await withRoot(async (rootPath) => {
+    const original = practice("platform.original");
+    const retained = practice("platform.retained");
+    const store = createStore(rootPath, [original, retained]);
+    const embedding = port();
+    const profile = createEmbeddingProfile({ encodingId, dimensions: 2 });
+    await build(rootPath, store, profile, embedding);
+    const next = identity(rootPath, 2);
+    store.current = next;
+    store.practices = [practice("platform.original", "changed"), retained];
+    store.changes = {
+      identity: next,
+      deltas: [
+        {
+          revision: 2,
+          delta: {
+            added: ["platform.original"],
+            changed: ["platform.original"],
+            invalidated: ["platform.removed"],
+          },
+        },
+      ],
+      currentPractices: [practice("platform.original", "changed")],
+    };
+
+    const result = await semantic(store, profile, embedding).query(
+      { rootPath },
+      { text: "beta query" },
+    );
+    expect(result.coverage).toBe("partial");
+    expect(result.results.map((hit) => hit.practiceId)).toEqual(["platform.retained"]);
+    expect(embedding.calls).toHaveLength(2);
+  });
+});
+
+test("partial query with every vector excluded returns empty without embedding", async () => {
+  await withRoot(async (rootPath) => {
+    const store = createStore(rootPath, [practice("platform.only")]);
+    const embedding = port();
+    const profile = createEmbeddingProfile({ encodingId, dimensions: 2 });
+    await build(rootPath, store, profile, embedding);
+    const next = identity(rootPath, 2);
+    store.current = next;
+    store.changes = {
+      identity: next,
+      deltas: [{ revision: 2, delta: { added: [], changed: ["platform.only"], invalidated: [] } }],
+      currentPractices: [],
+    };
+    const result = await semantic(store, profile, embedding).query(
+      { rootPath },
+      { text: "anything" },
+    );
+    expect(result).toMatchObject({ coverage: "partial", results: [] });
+    expect(embedding.calls).toHaveLength(1);
+  });
+});
+
+test("history gaps are explicit and never silently fall back to keyword", async () => {
+  await withRoot(async (rootPath) => {
+    const store = createStore(rootPath, [practice("platform.only")]);
+    const embedding = port();
+    const profile = createEmbeddingProfile({ encodingId, dimensions: 2 });
+    await build(rootPath, store, profile, embedding);
+    store.current = identity(rootPath, 3);
+    store.changes = undefined;
+    await expect(
+      semantic(store, profile, embedding).query({ rootPath }, { text: "anything" }),
+    ).rejects.toBeInstanceOf(SemanticIndexNotReadyError);
+  });
+});
+
+test("candidate digest mismatch is a typed query failure", async () => {
+  await withRoot(async (rootPath) => {
+    const original = practice("platform.only");
+    const store = createStore(rootPath, [original]);
+    const embedding = port();
+    const profile = createEmbeddingProfile({ encodingId, dimensions: 2 });
+    await build(rootPath, store, profile, embedding);
+    const invalid = { ...original, contentDigest: "f".repeat(64) };
+    store.practices = [invalid];
+    await expect(
+      semantic(store, profile, embedding).query({ rootPath }, { text: "anything" }),
+    ).rejects.toBeInstanceOf(SemanticIndexQueryError);
+  });
+});
+
+test("Store changes during candidate read are retried three times", async () => {
+  await withRoot(async (rootPath) => {
+    const store = createStore(rootPath, [practice("platform.only")]);
+    const embedding = port();
+    const profile = createEmbeddingProfile({ encodingId, dimensions: 2 });
+    await build(rootPath, store, profile, embedding);
+    let reads = 0;
+    store.readEffectivePracticesAtSnapshot = async () => {
+      reads += 1;
+      throw new StoreSnapshotChangedError();
+    };
+    await expect(
+      semantic(store, profile, embedding).query({ rootPath }, { text: "anything" }),
+    ).rejects.toBeInstanceOf(StoreBusyError);
+    expect(reads).toBe(3);
+  });
+});

--- a/packages/engine/src/query/semantic/query-service.ts
+++ b/packages/engine/src/query/semantic/query-service.ts
@@ -1,0 +1,207 @@
+import {
+  StoreBusyError,
+  StoreSnapshotChangedError,
+  type EffectivePractice,
+  type StorageRoot,
+  type StoreSnapshotIdentity,
+} from "../../local-store";
+import { revisionDeltaPracticeIds, type RevisionDelta } from "../../local-store/model";
+import { parseQueryRequest } from "../request";
+import { assembleQueryHits } from "../result";
+import type { QueryHit, QueryRequest } from "../types";
+import { validateEmbeddingBatch, type EmbeddingPort } from "./encoding";
+import {
+  SemanticIndexIncompatibleError,
+  SemanticIndexNotReadyError,
+  SemanticIndexQueryError,
+} from "./errors";
+import { openSemanticIndexReader, type SemanticCandidate } from "./index/reader";
+import type { EmbeddingProfile } from "./profile";
+
+const MAX_QUERY_RETRIES = 3;
+
+export interface SemanticQueryResult {
+  readonly mode: "semantic";
+  readonly profileId: string;
+  readonly coverage: "complete" | "partial";
+  readonly results: readonly QueryHit[];
+}
+
+export interface SemanticQueryService {
+  query(root: StorageRoot, request: QueryRequest): Promise<SemanticQueryResult>;
+}
+
+export interface SemanticQueryDependencies {
+  readonly store: {
+    readSnapshotIdentity(root: StorageRoot): Promise<StoreSnapshotIdentity>;
+    readEffectivePracticeChanges(
+      root: StorageRoot,
+      afterEffectiveRevision: number,
+    ): Promise<
+      | {
+          readonly identity: StoreSnapshotIdentity;
+          readonly deltas: readonly { readonly revision: number; readonly delta: RevisionDelta }[];
+        }
+      | undefined
+    >;
+    readEffectivePracticesAtSnapshot(
+      root: StorageRoot,
+      expected: StoreSnapshotIdentity,
+      ids: readonly string[],
+    ): Promise<readonly EffectivePractice[]>;
+  };
+  readonly profile: EmbeddingProfile;
+  readonly embedding: EmbeddingPort;
+}
+
+interface QueryCoverage {
+  readonly identity: StoreSnapshotIdentity;
+  readonly excludedPracticeIds: ReadonlySet<string>;
+  readonly coverage: "complete" | "partial";
+}
+
+function sameIdentity(left: StoreSnapshotIdentity, right: StoreSnapshotIdentity): boolean {
+  return (
+    left.rootBinding === right.rootBinding &&
+    left.generation === right.generation &&
+    left.effectiveRevision === right.effectiveRevision &&
+    left.manifestDigest === right.manifestDigest
+  );
+}
+
+async function prepareCoverage(
+  store: SemanticQueryDependencies["store"],
+  root: StorageRoot,
+  metadata: {
+    readonly rootBinding: string;
+    readonly generation: number;
+    readonly effectiveRevision: number;
+    readonly manifestDigest: string;
+  },
+  current: StoreSnapshotIdentity,
+): Promise<QueryCoverage> {
+  if (metadata.rootBinding !== current.rootBinding) {
+    throw new SemanticIndexIncompatibleError("Semantic index belongs to another Store");
+  }
+  if (sameIdentity(metadata, current)) {
+    return Object.freeze({
+      identity: current,
+      excludedPracticeIds: new Set<string>(),
+      coverage: "complete",
+    });
+  }
+  if (
+    metadata.effectiveRevision > current.effectiveRevision ||
+    metadata.generation > current.generation
+  ) {
+    throw new SemanticIndexNotReadyError("Semantic index is ahead of the LocalStore");
+  }
+
+  const changes = await store.readEffectivePracticeChanges(root, metadata.effectiveRevision);
+  if (changes === undefined) {
+    throw new SemanticIndexNotReadyError(
+      "Semantic index history is unavailable; run index build before querying",
+    );
+  }
+  if (changes.identity.rootBinding !== metadata.rootBinding) {
+    throw new SemanticIndexIncompatibleError("Semantic index history belongs to another Store");
+  }
+  if (changes.identity.effectiveRevision < metadata.effectiveRevision) {
+    throw new SemanticIndexNotReadyError("Semantic index history moved backwards");
+  }
+  if (changes.identity.effectiveRevision < current.effectiveRevision) {
+    // The Store changed while the delta snapshot was being read. Let the
+    // bounded outer retry reopen both the index and Store view.
+    throw new StoreSnapshotChangedError();
+  }
+  let expectedRevision = metadata.effectiveRevision + 1;
+  for (const change of changes.deltas) {
+    if (change.revision !== expectedRevision) {
+      throw new SemanticIndexNotReadyError(
+        "Semantic index history is not contiguous; run index build before querying",
+      );
+    }
+    expectedRevision += 1;
+  }
+  if (expectedRevision !== changes.identity.effectiveRevision + 1) {
+    throw new SemanticIndexNotReadyError(
+      "Semantic index history is incomplete; run index build before querying",
+    );
+  }
+  return Object.freeze({
+    identity: changes.identity,
+    excludedPracticeIds: new Set(
+      revisionDeltaPracticeIds(
+        changes.deltas.map((change) => change.delta),
+        true,
+      ),
+    ),
+    coverage: "partial",
+  });
+}
+
+function semanticCandidateIds(candidates: readonly SemanticCandidate[]): readonly string[] {
+  return candidates.map((candidate) => candidate.practiceId);
+}
+
+export function createSemanticQueryService(
+  dependencies: SemanticQueryDependencies,
+): SemanticQueryService {
+  const { store, profile, embedding } = dependencies;
+
+  return Object.freeze({
+    async query(root: StorageRoot, request: QueryRequest): Promise<SemanticQueryResult> {
+      const input = parseQueryRequest(request);
+      for (let attempt = 0; attempt < MAX_QUERY_RETRIES; attempt += 1) {
+        let reader: Awaited<ReturnType<typeof openSemanticIndexReader>> | undefined;
+        try {
+          // eslint-disable-next-line no-await-in-loop -- each retry reopens the active snapshot.
+          reader = await openSemanticIndexReader(root.rootPath, profile);
+          // eslint-disable-next-line no-await-in-loop -- coverage is bound to this retry's Store view.
+          const current = await store.readSnapshotIdentity(root);
+          // eslint-disable-next-line no-await-in-loop -- delta history is part of the same retry.
+          const coverage = await prepareCoverage(store, root, reader.metadata, current);
+
+          let candidates: readonly SemanticCandidate[] = Object.freeze([]);
+          if (reader.hasEligibleVectors(coverage.excludedPracticeIds)) {
+            // eslint-disable-next-line no-await-in-loop -- the model admits one request at a time.
+            const batch = await embedding.embed([input.text]);
+            const [queryVector] = validateEmbeddingBatch(profile, [input.text], batch);
+            if (queryVector === undefined) {
+              throw new SemanticIndexQueryError("Embedding result did not contain a query vector");
+            }
+            candidates = reader.search(queryVector, coverage.excludedPracticeIds, input.limit);
+          }
+
+          const ids = semanticCandidateIds(candidates);
+          // eslint-disable-next-line no-await-in-loop -- final read validates this retry's snapshot.
+          const practices = await store.readEffectivePracticesAtSnapshot(
+            root,
+            coverage.identity,
+            ids,
+          );
+          const results = assembleQueryHits(
+            practices,
+            candidates,
+            (message) => new SemanticIndexQueryError(message),
+          );
+          return Object.freeze({
+            mode: "semantic",
+            profileId: profile.profileId,
+            coverage: coverage.coverage,
+            results,
+          });
+        } catch (error) {
+          if (error instanceof StoreSnapshotChangedError) {
+            if (attempt + 1 < MAX_QUERY_RETRIES) continue;
+            throw new StoreBusyError("LocalStore changed repeatedly during semantic query");
+          }
+          throw error;
+        } finally {
+          reader?.close();
+        }
+      }
+      throw new StoreBusyError("LocalStore changed repeatedly during semantic query");
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Makes local semantic retrieval the default for `lore query`. The selected Store is queried through the authenticated Backend using the already loaded local model and its active semantic index. `lore query --mode keyword` remains the explicit zero-configuration, offline path.

The Engine owns semantic candidate ranking, Store snapshot validation, and the `complete`/`partial` coverage contract. The Backend only dispatches the two Engine use cases, while the CLI chooses the route and renders the existing JSON envelope.

## Linked issue

Closes #121

## Type of change

- [ ] 🐛 Bug fix (non-breaking)
- [ ] ✨ New feature (non-breaking)
- [x] 💥 Breaking change (fix or feature that would cause existing behavior to change)
- [ ] 📚 Docs only
- [ ] 🔧 Refactor / chore

## How was this tested?

- `bun test --timeout 30000`: 698 passed, 0 failed.
- `bun run typecheck`, `bun run lint`, `bun run fmt:check`, and `git diff --check`: passed.
- Real source-level flow: built the native candidate, started the Backend, loaded the model, installed `agentic-coding 0.3.0` and `pack-creator 0.1.0` into an isolated Store, then built an index with 50 vectors. The default semantic query returned the expected delegation-context Practice; `lore get` returned its canonical content; `--mode keyword` still returned keyword results. The test Backend was stopped and the temporary Store was moved to Trash.
- Engine tests cover complete and partial coverage, retained-history gaps, candidate digest validation, and Store-change retries. Backend and CLI tests cover default dispatch, explicit keyword routing, typed error propagation, and result schemas.

## Checklist

- [x] Linked the issue this closes (`Closes #121`)
- [x] If this changes product behavior (Practice format, retrieval, CLI surface), the design was discussed in the issue / Discussions first
- [x] Added/updated tests for the change
- [x] Lint, type-check, and tests all pass locally
- [x] Updated relevant documentation
- [x] No secrets, credentials, or private info in the diff

## AI assistance and review

- [x] This PR used AI assistance (Codex implemented the scoped change, ran validation, and prepared this PR.)
- [x] If AI-assisted: an AI code review covered the changed behavior and edge cases; material findings are resolved or documented below

An independent subtractive review and a final staged review checked Engine/Backend/CLI boundaries, Store snapshot safety, retained-history handling, error mapping, documentation scope, and sensitive-data exposure. The review removed obsolete query-service compatibility code, a duplicate result type, unused reader data and validation, duplicated index-path construction, and repeated design prose. No material finding remains unresolved.

## Notes for reviewers

Focus on the Engine semantic-query service: it must never return a vector for a Practice changed after the active index, and it must fail rather than silently choose keyword when Store history cannot prove safety. Also review the route boundary: only semantic requests use the Backend; `--mode keyword` continues to call Engine directly.